### PR TITLE
Typos and flipped description.

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -16,10 +16,10 @@ Glossary of Jupyter Projects
         lightweight parallel computing in Python offering seamless notebook integration.
 
     `IPython <http://ipython.org>`__
-        the reference Jupyter kernel, providing a powerful environment for
         interactive computing in Python.
 
-    `IPython Kernel <http://ipython.readthedocs.org/en/master/>`__
+    `IPython Kernel <http://ipykernel.readthedocs.org/en/master/>`__
+        the reference Jupyter kernel, providing a powerful environment for
         interactive computing in Python.
 
     `ipywidgets <https://github.com/ipython/ipywidgets>`__

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ a wide range of programming languages.
 Kernels
 -------
 
-Kernels are `programming language specfic` processes that run independently
+Kernels are `programming language specific` processes that run independently
 and interact with the Jupyter Applications and their user interfaces.
 
 `IPython <http://ipython.org>`__ is the reference Jupyter kernel, providing a


### PR DESCRIPTION
link to ipykernel for kernel instead of IPython and we should create
these docs.