### PR TITLE
Change the name of the project to Jupyter Documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'Jupyter'
+project = 'Jupyter Documentation'
 copyright = '2015, Jupyter Team, https://jupyter.org'
 author = 'The Jupyter Team'
 


### PR DESCRIPTION
When we did user testing, a user got to the docs page and tried to click on the "Jupyter" home link at the top left of the page. The user thought it would take him back to the main jupyter.org site. This clarifies that the link doesn't go back to the home page.