### PR TITLE
Updated config for linkcheck and removed unused file

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -291,11 +291,11 @@ intersphinx_mapping = {
     'ipython': ('http://ipython.org/ipython-doc/dev/', None),
     'nbconvert': ('http://nbconvert.readthedocs.org/en/latest/', None),
     'nbformat': ('http://nbformat.readthedocs.org/en/latest/', None),
-    'ipywidgets': ('http://ipywidgets.readthedocs.org/en/latest/', None),
+#    'ipywidgets': ('http://ipywidgets.readthedocs.org/en/latest/', None),  TODO: Enable once ipywidgets is on RTD
     'traitlets': ('http://traitlets.readthedocs.org/en/latest/', None),
     'ipyparallel': ('http://ipyparallel.readthedocs.org/en/latest/', None),
     'notebook': ('http://jupyter-notebook.readthedocs.org/en/latest/', None),
-    'jupyter_client': ('http://jupyter-client.readthedocs.org/en/latest/', None),
+    'jupyterclient': ('http://jupyter-client.readthedocs.org/en/latest/', None),
     'qtconsole': ('http://jupyter.org/qtconsole/dev/', None),
     'jupytercore': ('http://jupyter-core.readthedocs.org/en/latest/', None),
 }

--- a/docs/source/scratch.rst
+++ b/docs/source/scratch.rst
@@ -1,8 +1,0 @@
-* R
-    - IRkernel (`Documentation <http://irkernel.github.io/>`__, `GitHub Repo <https://github.com/IRkernel/IRkernel>`__)
-    - IRdisplay (`GitHub Repo <https://github.com/IRkernel/IRdisplay>`__)
-    - repr (`GitHub Repo <https://github.com/IRkernel/repr>`__)
-* Julia
-     - IJulia Kernel (`GitHub Repo <https://github.com/JuliaLang/IJulia.jl>`__)
-     - Interactive Widgets (`GitHub Repo <https://github.com/JuliaLang/Interact.jl>`__)
-* Bash (`GitHub Repo <https://github.com/takluyver/bash_kernel>`__)


### PR DESCRIPTION
Update `conf.py` to correct intersphinx error when a non-alphanumeric character is used. This throws an error when running `make linkcheck` to check external doc links.

Comment out intersphinx mapping for `ipywidgets` until the project has docs on RTD. `make linkcheck` will error if there are no docs present or if the mapping link is set to GitHub repo. Since it will likely have docs soon, I have opted to comment out vs forgetting to put back in later.

Removed unused scratch.rst