### PR TITLE
Add captions for RTD navigation and sub-table of contents

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -141,7 +141,7 @@ todo_include_todos = False
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -309,4 +309,3 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,14 +12,52 @@ and visualizations. By encoding a complete and reproducible record of a
 computation, the documents can be shared with others on GitHub, Dropbox, and
 the `Jupyter Notebook Viewer <https://github.com/jupyter/nbviewer>`__.
 
+
+The main documentation for Jupyter is organized into several sections:
+
+* :ref:`user-docs`
+* :ref:`jupyter-subprojects`
+* :ref:`about-docs`
+
+Information about development is also available:
+
+* :ref:`dev-docs`
+
+
+.. _user-docs:
+
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
+    :caption: User Documentation
 
     install
     running
-    subprojects
-    config
     migrating
-    system
-    data_science
 
+
+.. _jupyter-subprojects:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Jupyter Subprojects
+
+   subprojects
+   config
+
+
+.. _dev-docs:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Developer Documentation
+
+   system
+
+
+.. _about-docs:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: About Jupyter
+
+   data_science


### PR DESCRIPTION
As part of a larger effort to improve document navigation, this PR adds sub table of contents to the master Table of Contents index. The `:caption:` tags allow greyed titles to display in RTD.
![screen shot 2015-09-15 at 2 54 25 pm](https://cloud.githubusercontent.com/assets/2680980/9891235/d993986c-5bb9-11e5-9bdb-1eedac4b9dd5.png)
