### PR TITLE
Fixing upgrade instructions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -121,7 +121,8 @@ upgrade using::
 If the older version of the IPython Notebook was installed using `conda` or Anaconda,
 upgrade using::
 
-    conda update jupyter
+    conda update ipython
+    conda install jupyter
 
 
 The :ref:`Migrating from IPython <migrating>` document gives additional information


### PR DESCRIPTION
If a user has ipython installed with conda, they have to do both an upgrade of ipython and an install of jupyter for the upgrade.