### PR TITLE
remove `conda update ipython` from install instructions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -121,7 +121,6 @@ upgrade using::
 If the older version of the IPython Notebook was installed using `conda` or Anaconda,
 upgrade using::
 
-    conda update ipython
     conda install jupyter
 
 


### PR DESCRIPTION
`conda install jupyter` will upgrade ipython as a dependency

see discussion in #41