### PR TITLE
Restore note that Jupyter requires 2.7/3.3

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,6 +5,13 @@
 Installation
 ============
 
+Jupyter requires Python 2.7 or ≥ 3.3.
+
+.. note::
+
+    If you need to use Python 2.6 or 3.2, you can find IPython 1.2
+    `here <http://archive.ipython.org/release/>`__.
+
 This document will get you up and running with the the Jupyter Notebook.
 
 These installation instructions explain how to install the Jupyter Notebook and


### PR DESCRIPTION
and link to IPython 1.2