### PR TITLE
update IPython doc link to ReadTheDocs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -288,7 +288,7 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 intersphinx_mapping = {
-    'ipython': ('http://ipython.org/ipython-doc/dev/', None),
+    'ipython': ('http://ipython.readthedocs.org/en/latest/', None),
     'nbconvert': ('http://nbconvert.readthedocs.org/en/latest/', None),
     'nbformat': ('http://nbformat.readthedocs.org/en/latest/', None),
 #    'ipywidgets': ('http://ipywidgets.readthedocs.org/en/latest/', None),  TODO: Enable once ipywidgets is on RTD


### PR DESCRIPTION
The link to the IPython docs is out of date.

I don't really know how intersphinx works, it's possible the links that use the ipython intersphinx destination need updating as well.