### PR TITLE
Add sidebar box to docs for What's New in Release

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,15 @@ Jupyter Documentation
 The Jupyter Notebook is a web application for interactive data science and
 scientific computing.
 
+.. sidebar:: What's New in Jupyter Notebook
+   :subtitle: `Beta Release 4.1.0b1 Changelog <https://jupyter-notebook.readthedocs.org/en/latest/changelog.html#id1>`_
+
+   - Cell toolbar selector moved to View menu
+   - Restart & Run All Cells added to Kernel menu
+   - Multiple-cell selection and actions including cut, copy, paste and execute
+   - Command palette added for executing Jupyter actions
+   - Find and replace added to Edit menu
+
 Using the Jupyter Notebook, you can author engaging
 documents that combine live-code with narrative text, equations, images, video,
 and visualizations. By encoding a complete and reproducible record of a


### PR DESCRIPTION
Adds a sidebar box to the index.rst page of docs. The box has a link to the current release changelog.

<img width="1091" alt="screen shot 2015-12-14 at 8 58 41 pm" src="https://cloud.githubusercontent.com/assets/2680980/11802437/843aa968-a2a5-11e5-9d02-91c4ad10fb4b.png">
