### PR TITLE
Added in note recommending Python 3 for building docs (fix for notebook #1118)

### DIFF
--- a/docs/source/contrib_guide_docs.rst
+++ b/docs/source/contrib_guide_docs.rst
@@ -38,7 +38,7 @@ notebook files end with ``.ipynb``.
    Jupyter ``.ipynb`` file, please clear the output cells. Save the file and
    test your change.
 
-Test documentation changes
+Test documentation changes\*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sphinx should be installed to test your documentation changes. For best results,
@@ -62,6 +62,8 @@ the ``docs`` directory:
   documentation are valid or if they are not longer current (i.e. cause a 500
   not found error).
 
+\* Note: We recommend using Python 3.4+ for building the documentation. If you are editing the documentation, you can use Python 2.7.9+ or the Github editor. 
+
 Create a pull request
 ~~~~~~~~~~~~~~~~~~~~~
 Once you are satisfied with your changes, submit a GitHub pull request, per 
@@ -75,6 +77,8 @@ Questions
 ---------
 Feel free to ask questions in the Google Group for Jupyter or on an open issue
 on GitHub.
+
+
 
 ========================
 Git and Github Resources


### PR DESCRIPTION
@willingc: I added in a note as you recommended yesterday in the notebook issue #1118. I guessed at an appropriate location for the note, but will move it if needed.

Thanks. 