### PR TITLE
Add a welcome page to contributor section since Numfocus links land here.

### DIFF
--- a/docs/source/contrib_guide_welcome.rst
+++ b/docs/source/contrib_guide_welcome.rst
@@ -2,23 +2,27 @@
 Welcome
 =======
 
-Welcome. Whether you are a new, returning, or current contributor to Project
+Whether you are a new, returning, or current contributor to Project
 Jupyter's subprojects, such as Jupyter Notebook, or language kernels, like
-IPython, we welcome and appreciate your contributions.
+IPython, **we welcome you**.
 
-Project Jupyter is a quickly growing group of projects. Our project
-maintainers are balancing many requirements, needs, and resources. We ask
-contributors to take some time to become familiar with our contribution
-guides and spend some time learning about our project communication and
-workflow. The contribution guides here and project specific Contributor
-information are helpful in getting started. If questions arise, please ask us.
-`Community Resources <https://jupyter.org/community.html>`_ provides contact
-information.
+Project Jupyter has seen strong growth over the past several years, and it is
+wonderful to see the many ways people are using these projects. As a result of
+this rapid growth, our project maintainers are balancing many  requirements,
+needs, and resources. We ask contributors to take some time to become familiar
+with our contribution guides and spend some time learning about our project
+communication and workflow.
 
-By fostering a respectful, courteous participation, we believe that the 
-projects will thrive and continue to fulfill the evolving community needs. On
-a personal note, we ask you to be reflective on your communication with
-others as well as keeping discussions about the issues and not the individuals
+The contribution guides here and project specific Contributor information,
+which are found in the individual project repos, offer helpful tips and
+guidance. If you have a question, please ask us. `Community Resources
+<https://jupyter.org/community.html>`_ provides information on our commonly
+used communication methods.
+
+By fostering respectful, courteous participation within the projects, we
+believe that Project Jupyter will thrive and evolve to meet community needs.
+On a personal note, we ask you to be mindful in your communication with
+others as well as focusing discussions on the issues and not the individuals
 involved. 
 
 We are very pleased to have you as a contributor, and we hope you

--- a/docs/source/contrib_guide_welcome.rst
+++ b/docs/source/contrib_guide_welcome.rst
@@ -1,0 +1,26 @@
+=======
+Welcome
+=======
+
+Welcome. Whether you are a new, returning, or current contributor to Project
+Jupyter's subprojects, such as Jupyter Notebook, or language kernels, like
+IPython, we welcome and appreciate your contributions.
+
+Project Jupyter is a quickly growing group of projects. Our project
+maintainers are balancing many requirements, needs, and resources. We ask
+contributors to take some time to become familiar with our contribution
+guides and spend some time learning about our project communication and
+workflow. The contribution guides here and project specific Contributor
+information are helpful in getting started. If questions arise, please ask us.
+`Community Resources <https://jupyter.org/community.html>`_ provides contact
+information.
+
+By fostering a respectful, courteous participation, we believe that the 
+projects will thrive and continue to fulfill the evolving community needs. On
+a personal note, we ask you to be reflective on your communication with
+others as well as keeping discussions about the issues and not the individuals
+involved. 
+
+We are very pleased to have you as a contributor, and we hope you
+will find valuable your impact on the projects. Again, **thank you** for
+sharing your interests, ideas, and skills with us.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,6 +50,7 @@ newsletter.
     install
     running
     migrating
+    system
 
 
 .. _jupyter-subprojects:
@@ -68,7 +69,7 @@ newsletter.
    :maxdepth: 2
    :caption: Contributor Documentation
 
-   system
+   contrib_guide_welcome
    contrib_guide_code
    contrib_guide_bugs_enh
    contrib_guide_docs


### PR DESCRIPTION
Since [Numfocus](http://www.numfocus.org/open-source-projects.html) links to this section for contributing to Jupyter or IPython, I'm adding a Welcome section to the general contributor documentation.