### PR TITLE
Migrate old ipython wiki pages for the dev guide

### DIFF
--- a/docs/source/development_guide/boot2docker.rst
+++ b/docs/source/development_guide/boot2docker.rst
@@ -1,0 +1,150 @@
+.. _boot2docker:
+
+Setup IPython development environment using boot2docker
+=======================================================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+The following are instructions on how to get an IPython development
+environment up and running without having to install anything on your
+host machine, other than
+```boot2docker`` <https://github.com/boot2docker/boot2docker>`__ and
+```docker`` <https://www.docker.com/>`__.
+
+Install ``boot2docker``
+-----------------------
+
+Install `boot2docker <https://github.com/boot2docker/boot2docker>`__.
+There are multiple ways to install, depending on your environment. See
+the `boot2docker
+docs <https://github.com/boot2docker/boot2docker>`__.
+
+Mac OS X
+~~~~~~~~
+
+On a Mac OS X host with `Homebrew <http://brew.sh>`__ installed:
+
+::
+
+    $ brew install boot2docker docker
+
+Initialize ``boot2docker`` VM
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    $ boot2docker init
+
+Start VM
+~~~~~~~~
+
+::
+
+    $ boot2docker up
+
+The ``boot2docker`` CLI communicates with the docker daemon on the
+``boot2docker`` VM. To do this, we must set some environment variables,
+e.g. ``DOCKER_HOST``,
+
+::
+
+    $ $(boot2docker shellinit)
+
+To view the IP address of the VM:
+
+::
+
+    $ boot2docker ip
+    192.168.59.103
+
+Install ``ipython`` from Development Branch
+-------------------------------------------
+
+::
+
+    $ git clone --recursive https://github.com/ipython/ipython.git
+
+Build Docker Image
+------------------
+
+Use the Dockerfile in the cloned ``ipython`` directory to build a Docker
+image.
+
+::
+
+    $ cd ipython
+    $ docker build --rm -t ipython .
+
+Run Docker Container
+--------------------
+
+Run a container using the new image. We mount the entire ``ipython``
+source tree on the host into the container at ``/srv/ipython`` to enable
+changes we make to the source on the host immediately reflected in the
+container.
+
+::
+
+    # change to the root of the git clone
+    $ cd ipython
+    $ docker run -it --rm -p 8888:8888 --workdir /srv/ipython --name ipython-dev -v `pwd`:/srv/ipython ipython /bin/bash
+
+To list the running container from another shell on the host:
+
+::
+
+    $ $(boot2docker shellinit)
+    $ docker ps
+    CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                    NAMES
+    f6065f206519        ipython             "/bin/bash"         1 minutes ago       Up 1 minutes        0.0.0.0:8888->8888/tcp   ipython-dev    
+
+Install IPython in Editable Mode
+--------------------------------
+
+Once in the container, you'll need to uninstall the ``ipython`` package
+and re-install in editable mode to enable your dev changes to be
+reflected in your environment.
+
+::
+
+    container $ pip uninstall ipython
+
+    # pip install ipython in editable mode 
+    container $ cd /srv
+    container $ ls
+    ipython
+    container $ pip install -e ipython
+
+Run Notebook Server
+-------------------
+
+::
+
+    container $ ipython notebook --no-browser --ip=*
+
+Visit Notebook Server
+---------------------
+
+On your host, run the following command to get the IP of the boot2docker
+VM if you forgot:
+
+::
+
+    # on host
+    $ boot2docker ip
+    192.168.59.103
+
+Then visit it in your browser:
+
+::
+
+    # browser
+    http://192.168.59.103:8888
+
+As a shortcut on a Mac, you can run the following in a terminal window
+(or make it a bash alias):
+
+::
+
+    $ open http://$(boot2docker ip 2>/dev/null):8888

--- a/docs/source/development_guide/closing_prs.rst
+++ b/docs/source/development_guide/closing_prs.rst
@@ -1,0 +1,61 @@
+.. _closing_prs:
+
+Policy on Closing Pull Requests
+===============================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+IPython has the following policy on closing pull requests. The goal of
+this policy is to keep our pull request queue small and allow us to
+focus on code that is being actively developed and has a strong chance
+of being merged in master soon.
+
+A pull request will be closed when:
+
+-  It has been reviewed, but has sat for a month or more waiting for the
+   submitter to commit more code to address the comments.
+-  The review process has uncovered larger design or technical issues
+   that extend beyond the details of the specific pull request.
+
+   -  In particular, we do not accept whole large "cleanup" changes
+      which do not address any specific bug. This includes trailing
+      whitespace, PEP8, etc. One of the reasons is that such massive
+      cleanup provide plenty of opportunities to introduce new and
+      subtle bugs.
+
+In general we will not close pull requests because of a lack of review.
+If a pull request has sat for a month or more without review, we need to
+kick ourselves and get to reviewing it.
+
+When a pull request is closed we will do the following:
+
+-  Post a github message to the pull request to confirm that everyone is
+   fine with closing the pull request. This message should cite this
+   policy.
+-  Open an issue to track the pull request. This issue should describe
+   what would be needed in order to reopen the pull request.
+-  Post a github message to the pull request encouraging the submitter
+   to continue with the work and detail what issues need to be addressed
+   in order for the pull request to be reopened.
+
+This policy was discussed in the following thread:
+
+http://mail.scipy.org/pipermail/ipython-dev/2012-August/010025.html
+
+Example Message:
+----------------
+
+.. code:: text
+
+    Hi,
+
+    This PR has been inactive for 1 month now, so we are going to close it and open an
+    issue to reference it. We try to keep our pull request queue small and focused on
+    active work.  We encourage you to reopen the pull request if and when you
+    continue to work on this. Please contact us if you have any questions.
+
+    Thanks for contributing.
+
+    see https://github.com/ipython/ipython/wiki/Dev%3A-Closing-pull-requests/ for 
+    our policies on closing pull request.

--- a/docs/source/development_guide/coding_style.rst
+++ b/docs/source/development_guide/coding_style.rst
@@ -1,0 +1,112 @@
+.. _coding_style:
+
+Coding Style
+============
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+This document describes our coding style. Coding style refers to the
+following:
+
+-  How source code is formatted (indentation, spacing, etc.)
+-  How things are named (variables, functions, classes, modules, etc.)
+
+General coding conventions
+--------------------------
+
+In general, we follow the standard Python style conventions as described
+in Python's `PEP 8 <http://www.python.org/dev/peps/pep-0008/>`__, the
+official Python Style Guide.
+
+Other general comments:
+
+-  In a large file, top level classes and functions should be separated
+   by 2 lines to make it easier to separate them visually.
+
+-  Use 4 spaces for indentation, **never** use hard tabs.
+
+-  Keep the ordering of methods the same in classes that have the same
+   methods. This is particularly true for classes that implement similar
+   interfaces and for interfaces that are similar.
+
+Naming conventions
+------------------
+
+For naming conventions, we also follow the guidelines of `PEP
+8 <http://www.python.org/dev/peps/pep-0008/>`__. Some of the existing
+code doesn't honor this perfectly, but for all new and refactored
+IPython code, we'll use:
+
+-  All ``lowercase`` module names. Long module names can have words
+   separated by underscores (``really_long_module_name.py``), but this
+   is not required. Try to use the convention of nearby files.
+
+-  ``CamelCase`` for class names.
+
+-  ``lowercase_with_underscores`` for methods, functions, variables and
+   attributes.
+
+-  Implementation-specific *private* methods will use
+   ``_single_underscore_prefix``. Names with a leading double underscore
+   will *only* be used in special cases, as they makes subclassing
+   difficult (such names are not easily seen by child classes).
+
+-  Occasionally some run-in lowercase names are used, but mostly for
+   very short names or where we are implementing methods very similar to
+   existing ones in a base class (like ``runlines()`` where
+   ``runsource()`` and ``runcode()`` had established precedent).
+
+-  The old IPython codebase has a big mix of classes and modules
+   prefixed with an explicit ``IP`` of ``ip``. This is not necessary and
+   all new code should not use this prefix. The only case where this
+   approach is justified is for classes or functions which are expected
+   to be imported into external namespaces and a very generic name (like
+   Shell) that is likely to clash with something else. However, if a
+   prefix seems absolutely necessary the more specific ``IPY`` or
+   ``ipy`` are preferred.
+
+-  All JavaScript code should follow these naming conventions as well.
+
+Attribute declarations for objects
+----------------------------------
+
+In general, objects should declare, in their *class*, all attributes the
+object is meant to hold throughout its life. While Python allows you to
+add an attribute to an instance at any point in time, this makes the
+code harder to read and requires methods to constantly use checks with
+hasattr() or try/except calls. By declaring all attributes of the object
+in the class header, there is a single place one can refer to for
+understanding the object's data interface, where comments can explain
+the role of each variable and when possible, sensible deafaults can be
+assigned.
+
+If an attribute is meant to contain a mutable object, it should be set
+to ``None`` in the class and its mutable value should be set in the
+object's constructor. Since class attributes are shared by all
+instances, failure to do this can lead to difficult to track bugs. But
+you should still set it in the class declaration so the interface
+specification is complete and documented in one place.
+
+A simple example:
+
+::
+
+    class Foo(object):
+        # X does..., sensible default given:
+        x = 1
+        # y does..., default will be set by constructor
+        y = None
+        # z starts as an empty list, must be set in constructor
+        z = None
+        
+        def __init__(self, y):
+            self.y = y
+            self.z = []
+
+New files
+---------
+
+When starting a new Python file for IPython, you can use the `following
+template <./template.py>`__ as a starting point that has a few common
+things pre-written for you.

--- a/docs/source/development_guide/documenting_ipython.rst
+++ b/docs/source/development_guide/documenting_ipython.rst
@@ -1,0 +1,177 @@
+.. _documenting_ipython:
+
+Documenting IPython
+===================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+When contributing code to IPython, you should strive for clarity and
+consistency, without falling prey to a style straitjacket. Basically,
+'document everything, try to be consistent, do what makes sense.'
+
+By and large we follow existing Python practices in major projects like
+Python itself or NumPy, this document provides some additional detail
+for IPython.
+
+Standalone documentation
+------------------------
+
+All standalone documentation should be written in plain text (``.txt``)
+files using reStructuredText [reStructuredText]\_ for markup and
+formatting. All such documentation should be placed in the directory
+docs/source of the IPython source tree. Or, when appropriate, a suitably
+named subdirectory should be used. The documentation in this location
+will serve as the main source for IPython documentation.
+
+The actual HTML and PDF docs are built using the Sphinx [Sphinx]\_
+documentation generation tool. Once you have Sphinx installed, you can
+build the html docs yourself by doing:
+
+.. code:: bash
+
+    $ cd ipython-mybranch/docs
+    $ make html
+
+Our usage of Sphinx follows that of matplotlib [Matplotlib]\_ closely.
+We are using a number of Sphinx tools and extensions written by the
+matplotlib team and will mostly follow their conventions, which are
+nicely spelled out in their documentation guide [MatplotlibDocGuide]\_.
+What follows is thus a abridged version of the matplotlib documentation
+guide, taken with permission from the matplotlib team.
+
+If you are reading this in a web browser, you can click on the "Show
+Source" link to see the original reStricturedText for the following
+examples.
+
+A bit of Python code:
+
+::
+
+    for i in range(10):
+        print i,
+    print "A big number:",2**34
+
+An interactive Python session:
+
+::
+
+    >>> from IPython.utils.path import get_ipython_dir
+    >>> get_ipython_dir()
+    '/home/fperez/.config/ipython'
+
+An IPython session:
+
+.. code:: ipython
+
+    In [7]: import IPython
+
+    In [8]: print "This IPython is version:",IPython.__version__
+    This IPython is version: 0.9.1
+
+    In [9]: 2+4
+    Out[9]: 6
+
+A bit of shell code:
+
+.. code:: bash
+
+    cd /tmp
+    echo "My home directory is: $HOME"
+    ls
+
+Docstring format
+----------------
+
+Good docstrings are very important. Unfortunately, Python itself only
+provides a rather loose standard for docstrings [PEP257]\_, and there is
+no universally accepted convention for all the different parts of a
+complete docstring. However, the NumPy project has established a very
+reasonable standard, and has developed some tools to support the smooth
+inclusion of such docstrings in Sphinx-generated manuals. Rather than
+inventing yet another pseudo-standard, IPython will be henceforth
+documented using the NumPy conventions; we carry copies of some of the
+NumPy support tools to remain self-contained, but share back upstream
+with NumPy any improvements or fixes we may make to the tools.
+
+The NumPy documentation guidelines [NumPyDocGuide]\_ contain detailed
+information on this standard, and for a quick overview, the NumPy
+example docstring [NumPyExampleDocstring]\_ is a useful read.
+
+For user-facing APIs, we try to be fairly strict about following the
+above standards (even though they mean more verbose and detailed
+docstrings). Wherever you can reasonably expect people to do
+introspection with:
+
+::
+
+    In [1]: some_function?
+
+the docstring should follow the NumPy style and be fairly detailed.
+
+For purely internal methods that are only likely to be read by others
+extending IPython itself we are a bit more relaxed, especially for
+small/short methods and functions whose intent is reasonably obvious. We
+still expect docstrings to be written, but they can be simpler. For very
+short functions with a single-line docstring you can use something like:
+
+::
+
+    def add(a, b):
+       """The sum of two numbers.
+       """
+       code
+
+and for longer multiline strings:
+
+::
+
+    def add(a, b):
+       """The sum of two numbers.
+
+       Here is the rest of the docs.
+       """
+       code
+
+Here are two additional PEPs of interest regarding documentation of
+code. While both of these were rejected, the ideas therein form much of
+the basis of docutils (the machinery to process reStructuredText):
+
+-  `Docstring Processing System
+   Framework <http://www.python.org/peps/pep-0256.html>`__
+-  `Docutils Design
+   Specification <http://www.python.org/peps/pep-0258.html>`__
+
+    **note**
+
+    In the past IPython used epydoc so currently many docstrings still
+    use epydoc conventions. We will update them as we go, but all new
+    code should be documented using the NumPy standard.
+
+Building and uploading
+----------------------
+
+The built docs are stored in a separate repository. Through some github
+magic, they're automatically exposed as a website. It works like this:
+
+-  You will need to have sphinx and latex installed. In Ubuntu, install
+   ``texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended``.
+   Install the latest version of sphinx from PyPI
+   (``pip install sphinx``).
+-  Ensure that the development version of IPython is the first in your
+   system path. You can either use a virtualenv, or modify your
+   PYTHONPATH.
+-  Switch into the docs directory, and run ``make gh-pages``. This will
+   build your updated docs as html and pdf, then automatically check out
+   the latest version of the docs repository, copy the built docs into
+   it, and commit your changes.
+-  Open the built docs in a web browser, and check that they're as
+   expected.
+-  (When building the docs for a new tagged release, you will have to
+   add its link to index.rst, then run ``python build_index.py`` to
+   update index.html. Commit the change.)
+-  Upload the docs with ``git push``. This only works if you have write
+   access to the docs repository.
+-  If you are building a version that is not the current dev branch, nor
+   a tagged release, then you must run gh-pages.py directly with
+   ``python gh-pages.py <version>``, and *not* with ``make gh-pages``.

--- a/docs/source/development_guide/github_workflow.rst
+++ b/docs/source/development_guide/github_workflow.rst
@@ -1,0 +1,152 @@
+.. _github_workflow:
+
+IPython on GitHub
+=================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+Notes on working with GitHub
+
+.. _github_workflow_milestones:
+
+Milestones
+----------
+
+-  100% of confirmed issues should have a milestone.
+-  An issue should never be closed without a milestone.
+-  All pull requests should have a milestone.
+-  All issues closed should be marked with the next release milestone,
+   next backport milestone, or **no action**.
+-  Open issues should only lack a milestone if:
+
+   -  more clarification is required (label: ``needs-info``)
+
+-  In general, there will be four milestones with open issues:
+
+   -  **next minor release**. This milestone contains issues that should
+      be backported for the next minor release. See
+      `below <#backporting>`__ for information on backporting.
+   -  **next major release**. This should be the default milestone of
+      all issues. As the release approaches, issues can be explicitly
+      bumped to next release + 1.
+   -  **next major release + 1**. Only issues that we are confident will
+      *not* be included in the next release go here. This milestone
+      should be mostly empty until relatively close to release.
+   -  **wishlist**. This is the milestone for issues that we have no
+      immediate plans to address.
+
+-  The remaining milestone is **no action** for open or closed issues
+   that require no action:
+
+   -  Not actually an issue (e.g. questions, discussion, etc.)
+   -  Duplicate of an existing Issue
+   -  Closed because we won't fix it
+   -  When an issue is closed with **no action**, it means that the
+      issue will not be fixed, or it was not an issue at all.
+
+-  When closing an issue, it should always have one of these milestones:
+
+   -  **next minor release** because the issue has been addressed
+   -  **next major release** because the issue has been addressed
+   -  **no action** because the issue *will not* be addressed, or it is
+      a duplicate/non-issue.
+
+In general: When in doubt, mark with **next release**. We can always
+push back when we get closer to a given release.
+
+Labels and issues
+-----------------
+
+Issues should always be labeled once they are confirmed (not necessary
+for issues that are still being clarified, or may be duplicates or not
+issues at all).
+
+Some significant labels:
+
+-  ``needs-info``: issue needs more information from submitter before
+   progress can be made
+-  ``bug``: errors are raised, or unintended behavior occurs
+-  ``enhancement``: improvements that are not bugs
+-  
+
+   .. raw:: html
+
+      <del>
+
+   backport-X.Y.Z: Any fix for this issue should be backported to the
+   maintenance branch. backports are expressed with milestones, starting
+   with 2.1.
+-  ``prio-foo``: a priority level for ranking issues - nonessential, but
+   prio-high/low are useful for explicitly promoting/demoting issues,
+   particularly when nearing release.
+-  ``ClosedPR``: This issue is a reminder for a PR that was closed for
+   going stale.
+-  ``sprint-friendly``: Obvious or easy fixes, where
+
+All confirmed issues should at least have a ``bug`` or ``enhancement``
+label, and be marked with any affected components (e.g ``parallel``,
+``qtconsole``, ``htmlnotebook``), or particular sources of error (e.g.
+``py3k`` or ``unicode``) if we have appropriate labels.
+
+The ``sprint-friendly`` label is probably the best place for new
+contributors to start.
+
+Pull Requests
+-------------
+
+-  All work is submitted via Pull Requests.
+-  Pull Requests can be submitted as soon as there is code worth
+   discussing. Pull Requests track the branch, so you can continue to
+   work after the PR is submitted. Review and discussion can begin well
+   before the work is complete, and the more discussion the better. The
+   worst case is that the PR is closed.
+-  Pull Requests that have stalled should be closed (see [[our policy on
+   closing PRs\|Dev: Closing Pull Requests]])
+-  Pull Requests should always be made against master (backporting PRs
+   is described below).
+-  Pull Requests should be tested, if feasible:
+
+   -  bugfixes should include regression tests
+   -  new behavior should at least get minimal exercise
+
+`Travis <https://travis-ci.org/ipython/ipython>`__ does a pretty good
+job testing IPython and Pull Requests, but it may make sense to manually
+perform tests (possibly with our ``test_pr`` script), particularly for
+PRs that affect ``IPython.parallel`` or Windows.
+
+Opening an Issue
+----------------
+
+When opening a new issue, please take the following steps:
+
+1. Search GitHub and/or Google for your issue to avoid duplicate
+   reports. Keyword searches for your error messages are most helpful.
+2. If possible, try updating to master and reproducing your issue,
+   because we may have already fixed it.
+3. Try to include a minimal reproducible test case
+4. Include relevant system information. Start with the output of:
+
+   ::
+
+       python -c "import IPython; print(IPython.sys_info())"
+
+And include any relevant package versions, depending on the issue, such
+as matplotlib, numpy, Qt, Qt bindings (PyQt/PySide), tornado, web
+browser, etc.
+
+Backporting
+-----------
+
+-  We should keep an ``A.x`` maintenance branch for backporting fixes
+   from master.
+-  That branch shall be called ``A.x``, e.g. ``2.x``, not ``2.1``. This
+   way, there is only one maintenance branch per release series.
+-  When an Issue is determined to be appropriate for backporting, it
+   should be marked with the ``A.B`` milestone.
+-  Any Pull Request which addresses a backport issue should also receive
+   the same milestone.
+-  Patches are backported to the maintenance branch by applying the pull
+   request patch to the maintenance branch (currently with the
+   `backport\_pr <https://github.com/ipython/ipython/blob/master/tools/backport_pr.py>`__
+   script).

--- a/docs/source/development_guide/index.rst
+++ b/docs/source/development_guide/index.rst
@@ -1,0 +1,48 @@
+IPython Development Guide
+=========================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+IPython does all of its development using GitHub. All of our development
+information is hosted on this GitHub wiki. This page indexes all of that
+information. Developers interested in getting involved with IPython
+development should start here.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Core Documents
+
+   github_workflow
+   pull_request
+   coding_style
+   documenting_ipython
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Lab Meetings
+
+   lab_meetings
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Development Policies
+
+   closing_prs
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Other Information
+
+   testing
+   less
+   releasing
+   sphinx_directive
+   py3compat
+   rest_api
+   js_events
+   boot2docker
+   testing_kernels
+
+A template for new Python files in IPython:
+`template.py <./template.py>`__

--- a/docs/source/development_guide/js_events.rst
+++ b/docs/source/development_guide/js_events.rst
@@ -1,0 +1,234 @@
+.. _js_events:
+
+JavaScript Events
+=================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+(Note: this page is not currently consistent with IPython master)
+
+Javascript events are used to notify unrelated parts of the notebook
+interface when something happens. For example, if the kernel is busy
+executing code, it may send an event announcing as such, which can then
+be picked up by other services, like the notification area. For details
+on how the events themselves work, see the `JQuery
+documentation <http://api.jquery.com/on/>`__.
+
+This page documents the core set of events, and explains when and why
+they are triggered.
+
+Cell-related events
+-------------------
+
+-  `command\_mode.Cell <#command_modecell>`__
+-  `create.Cell <#createcell>`__
+-  `delete.Cell <#deletecell>`__
+-  `edit\_mode.Cell <#edit_modecell>`__
+-  `select.Cell <#selectcell>`__
+-  `output\_appended.OutputArea <#output_appendedoutputarea>`__
+
+CellToolbar-related events
+--------------------------
+
+-  `preset\_activated.CellToolbar <#preset_activatedcelltoolbar>`__
+-  `preset\_added.CellToolbar <#preset_addedcelltoolbar>`__
+
+Dashboard-related events
+------------------------
+
+-  `app\_initialized.DashboardApp <#app_initializeddashboardapp>`__
+-  `sessions\_loaded.Dashboard <#sessions_loadeddashboard>`__
+
+app\_initialized.DashboardApp
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the iPython Notebook browser window opens for the first time and
+initializes the Dashboard App. The Dashboard App lists the files and
+notebooks in the current directory. Additionally, it lets you create and
+open new iPython Notebooks.
+
+Kernel-related events
+---------------------
+
+-  `execution\_request.Kernel <#execution_requestkernel>`__
+-  `input\_reply.Kernel <#input_replykernel>`__
+-  `kernel\_autorestarting.Kernel <#kernel_autorestartingkernel>`__
+-  `kernel\_busy.Kernel <#kernel_busykernel>`__
+-  `kernel\_connected.Kernel <#kernel_connectedkernel>`__
+-  `kernel\_connection\_failed.Kernel <#kernel_connection_failedkernel>`__
+-  `kernel\_created.Kernel <#kernel_createdkernel>`__
+-  `kernel\_created.Session <#kernel_createdsession>`__
+-  `kernel\_dead.Kernel <#kernel_deadkernel>`__
+-  `kernel\_dead.Session <#kernel_deadsession>`__
+-  `kernel\_disconnected.Kernel <#kernel_disconnectedkernel>`__
+-  `kernel\_idle.Kernel <#kernel_idlekernel>`__
+-  `kernel\_interrupting.Kernel <#kernel_interruptingkernel>`__
+-  `kernel\_killed.Kernel <#kernel_killedkernel>`__
+-  `kernel\_killed.Session <#kernel_killedsession>`__
+-  `kernel\_ready.Kernel <#kernel_readykernel>`__
+-  `kernel\_reconnecting.Kernel <#kernel_reconnectingkernel>`__
+-  `kernel\_restarting.Kernel <#kernel_restartingkernel>`__
+-  `kernel\_starting.Kernel <#kernel_startingkernel>`__
+-  `send\_input\_reply.Kernel <#send_input_replykernel>`__
+-  `shell\_reply.Kernel <#shell_replykernel>`__
+-  `spec\_changed.Kernel <#spec_changedkernel>`__
+
+kernel\_created.Kernel
+^^^^^^^^^^^^^^^^^^^^^^
+
+The kernel has been successfully created or re-created through
+``/api/kernels``, but a connection to it has not necessarily been
+established yet.
+
+kernel\_created.Session
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The kernel has been successfully created or re-created through
+``/api/sessions``, but a connection to it has not necessarily been
+established yet.
+
+kernel\_reconnecting.Kernel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An attempt is being made to reconnect (via websockets) to the kernel
+after having been disconnected.
+
+kernel\_connected.Kernel
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+A connection has been established to the kernel. This is triggered as
+soon as all websockets (e.g. to the shell, iopub, and stdin channels)
+have been opened. This does not necessarily mean that the kernel is
+ready to do anything yet, though.
+
+kernel\_starting.Kernel
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The kernel is starting. This is triggered once when the kernel process
+is starting up, and can be sent as a message by the kernel, or may be
+triggered by the frontend if it knows the kernel is starting (e.g., it
+created the kernel and is connected to it, but hasn't been able to
+communicate with it yet).
+
+kernel\_ready.Kernel
+^^^^^^^^^^^^^^^^^^^^
+
+Like kernel\_idle.Kernel, but triggered after the kernel has fully
+started up.
+
+kernel\_restarting.Kernel
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The kernel is restarting. This is triggered at the beginning of an
+restart call to ``/api/kernels``.
+
+kernel\_autorestarting.Kernel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The kernel is restarting on its own, which probably also means that
+something happened to cause the kernel to die. For example, running the
+following code in the notebook would cause the kernel to autorestart:
+
+::
+
+    import os
+    os._exit(1)
+
+kernel\_interrupting.Kernel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The kernel is being interrupted. This is triggered at the beginning of a
+interrupt call to ``/api/kernels``.
+
+kernel\_disconnected.Kernel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connection to the kernel has been lost.
+
+kernel\_connection\_failed.Kernel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Not only was the connection lost, but it was lost due to an error (i.e.,
+we did not tell the websockets to close).
+
+kernel\_idle.Kernel
+^^^^^^^^^^^^^^^^^^^
+
+The kernel's execution state is 'idle'.
+
+kernel\_busy.Kernel
+^^^^^^^^^^^^^^^^^^^
+
+The kernel's execution state is 'busy'.
+
+kernel\_killed.Kernel
+^^^^^^^^^^^^^^^^^^^^^
+
+The kernel has been manually killed through ``/api/kernels``.
+
+kernel\_killed.Session
+^^^^^^^^^^^^^^^^^^^^^^
+
+The kernel has been manually killed through ``/api/sessions``.
+
+kernel\_dead.Kernel
+^^^^^^^^^^^^^^^^^^^
+
+This is triggered if the kernel dies, and the kernel manager attempts to
+restart it, but is unable to. For example, the following code run in the
+notebook will cause the kernel to die and for the kernel manager to be
+unable to restart it:
+
+::
+
+    import os
+    from IPython.kernel.connect import get_connection_file
+    with open(get_connection_file(), 'w') as f:
+        f.write("garbage")
+    os._exit(1)
+
+kernel\_dead.Session
+^^^^^^^^^^^^^^^^^^^^
+
+The kernel could not be started through ``/api/sessions``. This might be
+because the requested kernel type isn't installed. Another reason for
+this message is that the kernel died or was killed, but the session
+wasn't.
+
+Notebook-related events
+-----------------------
+
+-  `app\_initialized.NotebookApp <#app_initializednotebookapp>`__
+-  `autosave\_disabled.Notebook <#autosave_disablednotebook>`__
+-  `autosave\_enabled.Notebook <#autosave_enablednotebook>`__
+-  `checkpoint\_created.Notebook <#checkpoint_creatednotebook>`__
+-  `checkpoint\_delete\_failed.Notebook <#checkpoint_delete_failednotebook>`__
+-  `checkpoint\_deleted.Notebook <#checkpoint_deletednotebook>`__
+-  `checkpoint\_failed.Notebook <#checkpoint_failednotebook>`__
+-  `checkpoint\_restore\_failed.Notebook <#checkpoint_restore_failednotebook>`__
+-  `checkpoint\_restored.Notebook <#checkpoint_restorednotebook>`__
+-  `checkpoints\_listed.Notebook <#checkpoints_listednotebook>`__
+-  `command\_mode.Notebook <#command_modenotebook>`__
+-  `edit\_mode.Notebook <#edit_modenotebook>`__
+-  `list\_checkpoints\_failed.Notebook <#list_checkpoints_failednotebook>`__
+-  `notebook\_load\_failed.Notebook <#notebook_load_failednotebook>`__
+-  `notebook\_loaded.Notebook <#notebook_loadednotebook>`__
+-  `notebook\_loading.Notebook <#notebook_loadingnotebook>`__
+-  `notebook\_rename\_failed.Notebook <#notebook_rename_failednotebook>`__
+-  `notebook\_renamed.Notebook <#notebook_renamednotebook>`__
+-  `notebook\_restoring.Notebook <#notebook_restoringnotebook>`__
+-  `notebook\_save\_failed.Notebook <#notebook_save_failednotebook>`__
+-  `notebook\_saved.Notebook <#notebook_savednotebook>`__
+-  `notebook\_saving.Notebook <#notebook_savingnotebook>`__
+-  `rename\_notebook.Notebook <#rename_notebooknotebook>`__
+-  `selected\_cell\_type\_changed.Notebook <#selected_cell_type_changednotebook>`__
+-  `set\_dirty.Notebook <#set_dirtynotebook>`__
+-  `set\_next\_input.Notebook <#set_next_inputnotebook>`__
+-  `trust\_changed.Notebook <#trust_changednotebook>`__
+
+Other
+-----
+
+-  `open\_with\_text.Pager <#open_with_textpager>`__
+-  `rebuild.QuickHelp <#rebuildquickhelp>`__

--- a/docs/source/development_guide/lab_meetings.rst
+++ b/docs/source/development_guide/lab_meetings.rst
@@ -1,0 +1,46 @@
+.. _lab_meetings:
+
+Lab Meetings on Air
+===================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+Academic labs have long had the tradition of the weekly lab meeting,
+where all topics of interest to the lab are discussed. IPython has
+strong roots in academia, but it is also an open source project that
+needs to engage an active international community. So while our goal
+with IPython is not to publish the next paper, we've been thinking about
+the value these regular discussions bring to how teams work on sustained
+efforts involving difficult problems, and wanted to bring that bit of
+academic practice into the open source workflow. So we have decided to
+conduct weekly "lab meetings" for IPython, that will be held publicly
+using a Google Hangout on Air.
+
+Logistics
+---------
+
+We are trying to keep things simple and with a minimum of new moving
+parts:
+
+-  Meetings happen on Tuesdays at 10am California time (i.e. UTC-8 or -7
+   depending on the time of year).
+-  We broadcast the meeting as it happens via G+ and leave the public
+   YouTube link afterwards.
+-  During the meeting, all chat that needs to happen by typing can be
+   done on our `Gitter chat
+   room <https://www.gitter.im/ipython/ipython>`__.
+-  We keep a running document with `minutes of the meeting on
+   HackPad <http://ipython.hackpad.com>`__ where we summarize main
+   points. (`2015 part 1 <https://ipython.hackpad.com/3YJG5lv2Hws>`__)
+
+We welcome and encourage help from others in updating these minutes
+during the meeting, but we'll make no major effort in ensuring that they
+are a detailed and accurate record of the whole discussion. We simply
+don't have the time for that.
+
+Prior meetings
+--------------
+
+You can find a list of the videos on the `ipythondev YouTube user
+page <https://www.youtube.com/user/ipythondev>`__.

--- a/docs/source/development_guide/less.rst
+++ b/docs/source/development_guide/less.rst
@@ -1,0 +1,27 @@
+.. _less:
+
+How to Compile .less Files
+==========================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+For testing your development work in CSS, you'll need to compile the
+.less files to CSS. Make sure you have dependencies that LESS requires,
+including fabric, node, and lessc. Follow the below steps to compile the
+.less files:
+
+::
+
+    python setup.py css
+
+Alternatively, you can:
+
+::
+
+    $ cd ipython/IPython/html
+    $ fab css
+    [localhost] local: components/less.js/bin/lessc -x  style/style.less style/style.min.css
+    [localhost] local: components/less.js/bin/lessc -x  style/ipython.less style/ipython.min.css
+
+    Done

--- a/docs/source/development_guide/pull_request.rst
+++ b/docs/source/development_guide/pull_request.rst
@@ -1,0 +1,64 @@
+.. _pull_request:
+
+The Perfect Pull Request
+========================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+A brief guide to making and reviewing pull requests.
+
+1. It works
+-----------
+
+The code does what it's supposed to!
+
+2. It works on all of the platforms that IPython officially supports
+--------------------------------------------------------------------
+
+IPython has to work on:
+
+-  Linux of various kinds, Windows & Mac
+-  Python 2 & 3
+
+3. Handles unicode issues properly
+----------------------------------
+
+Much of our code base deals with strings and unicode. This needs to be
+done in a manner that is unicode aware and works on Python 2 and 3.
+[This article] (http://www.joelonsoftware.com/articles/Unicode.html) is
+a good intro to unicode.
+
+4. Adheres to our coding style
+------------------------------
+
+Coding style refers to how source code is formatted and how variables,
+functions, methods and classes are named. Your code should follow our
+coding style, which is described [[here\|Dev: Coding style]].
+
+5. Clean & commented
+--------------------
+
+The code should be well organized, and have inline comments where
+appropriate. When we look at the code, it should be clear what it's
+doing and why. It should not break abstractions that we have established
+in the project.
+
+6. Tested
+---------
+
+If it fixes a bug, the pull request should ideally add an automated test
+that fails without the fix, and passes with it. Normally it should be
+sufficient to copy an existing test and tweak it. New functionality
+should come with its own tests as well. Details about testing IPython
+can be found [[here\|Dev: Testing]].
+
+7. Well documented
+------------------
+
+Don't forget to update docstrings, and any relevant parts of `the
+official
+documentation <http://ipython.org/ipython-doc/stable/index.html>`__. New
+features or significant changes warrant an entry in the *What's New*
+section too. Details about documenting IPython can be found [[here\|Dev:
+Documenting IPython]].

--- a/docs/source/development_guide/py3compat.rst
+++ b/docs/source/development_guide/py3compat.rst
@@ -1,0 +1,31 @@
+.. _py3compat:
+
+Python 3 Compatibility Module
+=============================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+The ``IPython.utils.py3compat`` module provides a number of functions to make it easier to write code for Python 2 and 3. We also use 2to3 in the setup process to change syntax, and the ``io.open()`` function, which is essentially the built in open function from Python 3.
+
+The names provided are:
+
+* **PY3**: True in Python 3, False in Python 2.
+
+Unicode related
+---------------
+* **decode**, **encode**: Shortcuts to decode or encode strings, using ``sys.stdin.encoding`` by default, and using replacement characters on errors.
+* **str_to_unicode**, **unicode_to_str**, **str_to_bytes**, **bytes_to_str**: Convert to/from the platform's standard ``str`` type (bytes in Python 2, unicode in Python 3). Each function is a no-op on one of the two platforms.
+* **cast_unicode**, **cast_bytes**: Accept unknown unicode or byte strings, and convert them accordingly.
+* **cast_bytes_py2**: Casts unicode to byte strings on Python 2, but doesn't do anything on Python 3.
+
+Miscellaneous
+-------------
+* **input**: Refers to ``raw_input`` on Python 2, ``input`` on Python 3 (needed because 2to3 only converts calls to raw_input, not assignments to other names).
+* **builtin_mod_name**: The string name you import to get the builtins (``__builtin__`` --> ``builtins``).
+* **isidentifier**: Checks if a string is a valid Python identifier.
+* **open**: Simple wrapper for Python 3 unicode-enabled open. Similar to ``codecs.open``, but allows universal newlines. The current implementation only supports the very simplest use.
+* **MethodType**: ``types.MethodType`` from Python 3. Takes only two arguments: function, instance. The class argument for Python 2 is filled automatically.
+* **doctest_refactor_print**: Can be called on a string or a function (or used as a decorator). In Python 3, it converts print statements in doctests to print() calls. 2to3 does this for real doctests, but we need it in several other places. It simply uses a regex, which is good enough for the current cases.
+* **u_format**: Where tests use the repr() of a unicode string, it should be written ``'{u}"thestring"'``, and fed to this function, which will produce ``'u"thestring"'`` for Python 2, and ``'"thestring"'`` for Python 3. Can also be used as a decorator, to work on a docstring.
+* **execfile**: Makes a return on Python 3 (where it's no longer a builtin), and upgraded to handle Unicode filenames on Python 2.

--- a/docs/source/development_guide/releasing.rst
+++ b/docs/source/development_guide/releasing.rst
@@ -1,0 +1,147 @@
+.. _releasing:
+
+Steps for Releasing IPython
+===========================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+This document contains notes about the process that is used to release
+IPython. Our release process is currently not very formal and could be
+improved.
+
+Most of the release process is automated by the ``release`` script in
+the ``tools`` directory of our main repository. This document is just a
+handy reminder for the release manager.
+
+0. Environment variables
+------------------------
+
+You can set some env variables to note previous release tag and current
+release milestone, version, and git tag:
+
+::
+
+    PREV_RELEASE=rel-1.0.0
+    MILESTONE=1.1
+    VERSION=1.1.0
+    TAG="rel-$VERSION"
+    BRANCH=master
+
+These will be used later if you want to copy/paste, or you can just type
+the appropriate command when the time comes. These variables are not
+used by scripts (hence no ``export``).
+
+1. Finish release notes
+-----------------------
+
+-  If a major release:
+
+-  merge any pull request notes into what's new:
+
+   ::
+
+         python tools/update_whatsnew.py
+
+-  update ``docs/source/whatsnew/development.rst``, to ensure it covers
+   the major points.
+-  move the contents of ``development.rst`` to ``versionX.rst``
+-  generate summary of GitHub contributions, which can be done with:
+
+   ::
+
+       python tools/github_stats.py --milestone $MILESTONE > stats.rst
+
+which may need some manual cleanup. Add the cleaned up result and add it
+to ``docs/source/whatsnew/github-stats-X.rst`` (make a new file, or add
+it to the top, depending on whether it is a major release). You can use:
+
+::
+
+        git log --format="%aN <%aE>" $PREV_RELEASE... | sort -u -f
+
+to find duplicates and update ``.mailmap``. Before generating the GitHub
+stats, verify that all closed issues and pull requests :ref:`have appropriate
+milestones <github_workflow_milestones>`.
+`This
+search <https://github.com/ipython/ipython/issues?q=is%3Aclosed+no%3Amilestone+is%3Aissue>`__
+should return no results.
+
+2. Run the ``tools/build_release`` script
+-----------------------------------------
+
+This does all the file checking and building that the real release
+script will do. This will let you do test installations, check that the
+build procedure runs OK, etc. You may want to also do a test build of
+the docs.
+
+3. Create and push the new tag
+------------------------------
+
+Edit ``IPython/core/release.py`` to have the current version.
+
+Commit the changes to release.py and jsversion:
+
+::
+
+    git commit -am "release $VERSION"
+    git push origin $BRANCH
+
+Create and push the tag:
+
+::
+
+    git tag -am "release $VERSION" "$TAG"
+    git push origin --tags
+
+Update release.py back to ``x.y-dev`` or ``x.y-maint``, and push:
+
+::
+
+    git commit -am "back to development"
+    git push origin $BRANCH
+
+4. Get a fresh clone of the tag for building the release:
+---------------------------------------------------------
+
+::
+
+    cd /tmp
+    git clone --depth 1 https://github.com/ipython/ipython.git -b "$TAG" 
+
+5. Run the ``release`` script
+-----------------------------
+
+::
+
+    cd tools && ./release
+
+This makes the tarballs, zipfiles, and wheels. It posts them to
+archive.ipython.org and registers the release with PyPI.
+
+This will require that you have current wheel, Python 3.4 and Python
+2.7.
+
+7. Update the IPython website
+-----------------------------
+
+-  release announcement (news, announcements)
+-  update current version and download links
+-  (If major release) update links on the documentation page
+
+8. Drafting a short release announcement
+----------------------------------------
+
+This should include i) highlights and ii) a link to the html version of
+the *What's new* section of the documentation.
+
+Post to mailing list, and link from Twitter.
+
+9. Update milestones on GitHub
+------------------------------
+
+-  close the milestone you just released
+-  open new milestone for (x, y+1), if it doesn't exist already
+
+10. Celebrate!
+--------------

--- a/docs/source/development_guide/rest_api.rst
+++ b/docs/source/development_guide/rest_api.rst
@@ -1,0 +1,956 @@
+.. _rest_api:
+
+Architecture of IPython notebook's Dashboard
+============================================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+The tables below show the current RESTful web service architecture
+implemented in IPython notebook. The listed URL's use the HTTP verbs to
+return representations of the desired resource.
+
+We are in the process of creating a new dashboard architecture for the
+IPython notebook, which will allow the user to navigate through multiple
+directory files to find desired notebooks.
+
+Current Architecture
+--------------------
+
+Miscellaneous
+
++--------+--------+-------+
+| HTTP   | URL    | Actio |
+| verb   |        | n     |
++========+========+=======+
+| ``GET` | /.\*/  |
+| `      | \|     |
+|        | Strips |
+|        | traili |
+|        | ng     |
+|        | slashe |
+|        | s.     |
+|        | \| \|  |
+|        | ``GET` |
+|        | `      |
+|        | \|     |
+|        | /api   |
+|        | \|     |
+|        | Return |
+|        | s      |
+|        | api    |
+|        | versio |
+|        | n      |
+|        | inform |
+|        | ation. |
+|        | \| \|  |
+|        | ``*``  |
+|        | \|     |
+|        | /api/n |
+|        | oteboo |
+|        | ks     |
+|        | \|     |
+|        | Deprec |
+|        | ated:  |
+|        | redire |
+|        | ct     |
+|        | to     |
+|        | /api/c |
+|        | ontent |
+|        | s      |
+|        | \| \|  |
+|        | ``GET` |
+|        | `      |
+|        | \|     |
+|        | /api/n |
+|        | bconve |
+|        | rt     |
+|        | \| \|  |
++--------+--------+-------+
+
+Notebook contents API.
+
++--------+--------+-------+
+| HTTP   | URL    | Actio |
+| verb   |        | n     |
++========+========+=======+
+| ``GET` | /api/c | Retur |
+| `      | ontent | n     |
+|        | s      | a     |
+|        |        | model |
+|        |        | for   |
+|        |        | the   |
+|        |        | base  |
+|        |        | direc |
+|        |        | tory. |
+|        |        | See   |
+|        |        | /api/ |
+|        |        | conte |
+|        |        | nts/< |
+|        |        | path> |
+|        |        | /<fil |
+|        |        | e>.   |
++--------+--------+-------+
+| ``GET` | /api/c | Retur |
+| `      | ontent | n     |
+|        | s/<fil | a     |
+|        | e>     | model |
+|        |        | for   |
+|        |        | the   |
+|        |        | given |
+|        |        | file  |
+|        |        | in    |
+|        |        | the   |
+|        |        | base  |
+|        |        | direc |
+|        |        | tory. |
+|        |        | See   |
+|        |        | /api/ |
+|        |        | conte |
+|        |        | nts/< |
+|        |        | path> |
+|        |        | /<fil |
+|        |        | e>.   |
++--------+--------+-------+
+| ``GET` | /api/c | Retur |
+| `      | ontent | n     |
+|        | s/<pat | a     |
+|        | h>/<fi | model |
+|        | le>    | for a |
+|        |        | file  |
+|        |        | or    |
+|        |        | direc |
+|        |        | tory. |
+|        |        | A     |
+|        |        | direc |
+|        |        | tory  |
+|        |        | model |
+|        |        | conta |
+|        |        | ins   |
+|        |        | a     |
+|        |        | list  |
+|        |        | of    |
+|        |        | model |
+|        |        | s     |
+|        |        | (with |
+|        |        | out   |
+|        |        | conte |
+|        |        | nt)   |
+|        |        | of    |
+|        |        | the   |
+|        |        | files |
+|        |        | and   |
+|        |        | direc |
+|        |        | torie |
+|        |        | s     |
+|        |        | it    |
+|        |        | conta |
+|        |        | ins.  |
++--------+--------+-------+
+| ``PUT` | /api/c | Saves |
+| `      | ontent | the   |
+|        | s/<pat | file  |
+|        | h>/<fi | in    |
+|        | le>    | the   |
+|        |        | locat |
+|        |        | ion   |
+|        |        | speci |
+|        |        | fied  |
+|        |        | by    |
+|        |        | name  |
+|        |        | and   |
+|        |        | path. |
+|        |        | PUT   |
+|        |        | is    |
+|        |        | very  |
+|        |        | simil |
+|        |        | ar    |
+|        |        | to    |
+|        |        | POST, |
+|        |        | but   |
+|        |        | the   |
+|        |        | reque |
+|        |        | ster  |
+|        |        | speci |
+|        |        | fies  |
+|        |        | the   |
+|        |        | name, |
+|        |        | where |
+|        |        | as    |
+|        |        | with  |
+|        |        | POST, |
+|        |        | the   |
+|        |        | serve |
+|        |        | r     |
+|        |        | picks |
+|        |        | the   |
+|        |        | name. |
+|        |        | PUT   |
+|        |        | /api/ |
+|        |        | conte |
+|        |        | nts/p |
+|        |        | ath/N |
+|        |        | ame.i |
+|        |        | pynb  |
+|        |        | Save  |
+|        |        | noteb |
+|        |        | ook   |
+|        |        | at    |
+|        |        | ``pat |
+|        |        | h/Nam |
+|        |        | e.ipy |
+|        |        | nb``. |
+|        |        | Noteb |
+|        |        | ook   |
+|        |        | struc |
+|        |        | ture  |
+|        |        | is    |
+|        |        | speci |
+|        |        | fied  |
+|        |        | in    |
+|        |        | ``con |
+|        |        | tent` |
+|        |        | `     |
+|        |        | key   |
+|        |        | of    |
+|        |        | JSON  |
+|        |        | reque |
+|        |        | st    |
+|        |        | body. |
+|        |        | If    |
+|        |        | conte |
+|        |        | nt    |
+|        |        | is    |
+|        |        | not   |
+|        |        | speci |
+|        |        | fied, |
+|        |        | creat |
+|        |        | e     |
+|        |        | a new |
+|        |        | empty |
+|        |        | noteb |
+|        |        | ook.  |
+|        |        | PUT   |
+|        |        | /api/ |
+|        |        | conte |
+|        |        | nts/p |
+|        |        | ath/N |
+|        |        | ame.i |
+|        |        | pynb  |
+|        |        | with  |
+|        |        | JSON  |
+|        |        | body: |
+|        |        | :{    |
+|        |        | "copy |
+|        |        | \_fro |
+|        |        | m"    |
+|        |        | :     |
+|        |        | "[pat |
+|        |        | h/to/ |
+|        |        | ]Othe |
+|        |        | rNote |
+|        |        | book. |
+|        |        | ipynb |
+|        |        | "     |
+|        |        | }     |
+|        |        | Copy  |
+|        |        | Other |
+|        |        | Noteb |
+|        |        | ook   |
+|        |        | to    |
+|        |        | Name  |
++--------+--------+-------+
+| ``PATC | /api/c | PATCH |
+| H``    | ontent | renam |
+|        | s/<pat | es    |
+|        | h>/<fi | a     |
+|        | le>    | noteb |
+|        |        | ook   |
+|        |        | witho |
+|        |        | ut    |
+|        |        | re-up |
+|        |        | loadi |
+|        |        | ng    |
+|        |        | conte |
+|        |        | nt.   |
++--------+--------+-------+
+| ``POST | /api/c | Creat |
+| ``     | ontent | e     |
+|        | s/<pat | a new |
+|        | h>/<fi | file  |
+|        | le>    | or    |
+|        |        | direc |
+|        |        | tory  |
+|        |        | in    |
+|        |        | the   |
+|        |        | speci |
+|        |        | fied  |
+|        |        | path. |
+|        |        | POST  |
+|        |        | creat |
+|        |        | es    |
+|        |        | new   |
+|        |        | files |
+|        |        | or    |
+|        |        | direc |
+|        |        | torie |
+|        |        | s.    |
+|        |        | The   |
+|        |        | serve |
+|        |        | r     |
+|        |        | alway |
+|        |        | s     |
+|        |        | decid |
+|        |        | es    |
+|        |        | on    |
+|        |        | the   |
+|        |        | name. |
+|        |        | POST  |
+|        |        | /api/ |
+|        |        | conte |
+|        |        | nts/p |
+|        |        | ath   |
+|        |        | New   |
+|        |        | untit |
+|        |        | led   |
+|        |        | noteb |
+|        |        | ook   |
+|        |        | in    |
+|        |        | path. |
+|        |        | If    |
+|        |        | conte |
+|        |        | nt    |
+|        |        | speci |
+|        |        | fied, |
+|        |        | uploa |
+|        |        | d     |
+|        |        | a     |
+|        |        | noteb |
+|        |        | ook,  |
+|        |        | other |
+|        |        | wise  |
+|        |        | start |
+|        |        | empty |
+|        |        | .     |
+|        |        | POST  |
+|        |        | /api/ |
+|        |        | conte |
+|        |        | nts/p |
+|        |        | ath   |
+|        |        | with  |
+|        |        | body  |
+|        |        | {"cop |
+|        |        | y\_fr |
+|        |        | om"   |
+|        |        | :     |
+|        |        | "Othe |
+|        |        | rNote |
+|        |        | book. |
+|        |        | ipynb |
+|        |        | "}    |
+|        |        | New   |
+|        |        | copy  |
+|        |        | of    |
+|        |        | Other |
+|        |        | Noteb |
+|        |        | ook   |
+|        |        | in    |
+|        |        | path  |
++--------+--------+-------+
+| ``DELE | /api/c | delet |
+| TE``   | ontent | e     |
+|        | s/<pat | a     |
+|        | h>/<fi | file  |
+|        | le>    | in    |
+|        |        | the   |
+|        |        | given |
+|        |        | path  |
++--------+--------+-------+
+| ``GET` | /api/c | get   |
+| `      | ontent | lists |
+|        | s/<pat | check |
+|        | h>/<fi | point |
+|        | le>/ch | s     |
+|        | eckpoi | for a |
+|        | nts    | file. |
++--------+--------+-------+
+| ``POST | /api/c | post  |
+| ``     | ontent | creat |
+|        | s/<pat | es    |
+|        | h>/<fi | a new |
+|        | le>/ch | check |
+|        | eckpoi | point |
+|        | nts    | .     |
++--------+--------+-------+
+| ``POST | /api/c | post  |
+| ``     | ontent | resto |
+|        | s/<pat | res   |
+|        | h>/<fi | a     |
+|        | le>/ch | file  |
+|        | eckpoi | from  |
+|        | nts/<c | a     |
+|        | heckpo | check |
+|        | int\_i | point |
+|        | d>     | .     |
++--------+--------+-------+
+| ``DELE | /api/c | delet |
+| TE``   | ontent | e     |
+|        | s/<pat | clear |
+|        | h>/<fi | s     |
+|        | le>/ch | a     |
+|        | eckpoi | check |
+|        | nts/<c | point |
+|        | heckpo | for a |
+|        | int\_i | given |
+|        | d>     | file. |
++--------+--------+-------+
+
+Kernel API
+
++--------+--------+-------+
+| HTTP   | URI    | Actio |
+| verb   |        | n     |
++========+========+=======+
+| ``GET` | /api/k | Retur |
+| `      | ernels | n     |
+|        |        | a     |
+|        |        | model |
+|        |        | of    |
+|        |        | all   |
+|        |        | kerne |
+|        |        | ls.   |
++--------+--------+-------+
+| ``GET` | /api/k | Retur |
+| `      | ernels | n     |
+|        | /<kern | a     |
+|        | el\_id | model |
+|        | >      | of    |
+|        |        | kerne |
+|        |        | l     |
+|        |        | with  |
+|        |        | given |
+|        |        | kerne |
+|        |        | l     |
+|        |        | id.   |
++--------+--------+-------+
+| ``POST | /api/k | Start |
+| ``     | ernels | a new |
+|        |        | kerne |
+|        |        | l     |
+|        |        | with  |
+|        |        | defau |
+|        |        | lt    |
+|        |        | or    |
+|        |        | given |
+|        |        | name. |
++--------+--------+-------+
+| ``DELE | /api/k | Shutd |
+| TE``   | ernels | own   |
+|        | /<kern | the   |
+|        | el\_id | given |
+|        | >      | kerne |
+|        |        | l.    |
++--------+--------+-------+
+| ``POST | /api/k | Perfo |
+| ``     | ernels | rm    |
+|        | /<kern | actio |
+|        | el\_id | n     |
+|        | >/<act | on    |
+|        | ion>   | kerne |
+|        |        | l     |
+|        |        | with  |
+|        |        | given |
+|        |        | kerne |
+|        |        | l     |
+|        |        | id.   |
+|        |        | Actio |
+|        |        | ns    |
+|        |        | can   |
+|        |        | be    |
+|        |        | "inte |
+|        |        | rrupt |
+|        |        | "     |
+|        |        | or    |
+|        |        | "rest |
+|        |        | art". |
++--------+--------+-------+
+| ``WS`` | /api/k | Webso |
+|        | ernels | cket  |
+|        | /<kern | strea |
+|        | el\_id | m     |
+|        | >/chan |       |
+|        | nels   |       |
++--------+--------+-------+
+| ``GET` | /api/k | Retur |
+| `      | ernels | n     |
+|        | pecs   | a     |
+|        |        | spec  |
+|        |        | model |
+|        |        | of    |
+|        |        | all   |
+|        |        | avail |
+|        |        | able  |
+|        |        | kerne |
+|        |        | ls.   |
++--------+--------+-------+
+| ``GET` | /api/k | Retur |
+| `      | ernels | n     |
+|        | pecs/< | a     |
+|        | kernel | spec  |
+|        | \_name | model |
+|        | >      | of    |
+|        |        | avail |
+|        |        | able  |
+|        |        | kerne |
+|        |        | ls    |
+|        |        | with  |
+|        |        | given |
+|        |        | kerne |
+|        |        | l     |
+|        |        | name. |
++--------+--------+-------+
+
+Sessions API
+
++--------+--------+-------+
+| HTTP   | URL    | Actio |
+| verb   |        | n     |
++========+========+=======+
+| ``GET` | /api/s | Retur |
+| `      | ession | n     |
+|        | s      | model |
+|        |        | of    |
+|        |        | activ |
+|        |        | e     |
+|        |        | sessi |
+|        |        | ons.  |
++--------+--------+-------+
+| ``POST | /api/s | If    |
+| ``     | ession | sessi |
+|        | s      | on    |
+|        |        | does  |
+|        |        | not   |
+|        |        | alrea |
+|        |        | dy    |
+|        |        | exist |
+|        |        | ,     |
+|        |        | creat |
+|        |        | e     |
+|        |        | a new |
+|        |        | sessi |
+|        |        | on    |
+|        |        | with  |
+|        |        | given |
+|        |        | noteb |
+|        |        | ook   |
+|        |        | name  |
+|        |        | and   |
+|        |        | path  |
+|        |        | and   |
+|        |        | given |
+|        |        | kerne |
+|        |        | l     |
+|        |        | name. |
+|        |        | Retur |
+|        |        | n     |
+|        |        | activ |
+|        |        | e     |
+|        |        | sessi |
+|        |        | on.   |
++--------+--------+-------+
+| ``GET` | /api/s | Retur |
+| `      | ession | n     |
+|        | s/<ses | model |
+|        | sion\_ | of    |
+|        | id>    | activ |
+|        |        | e     |
+|        |        | sessi |
+|        |        | on    |
+|        |        | with  |
+|        |        | given |
+|        |        | sessi |
+|        |        | on    |
+|        |        | id.   |
++--------+--------+-------+
+| ``PATC | /api/s | Chang |
+| H``    | ession | e     |
+|        | s/<ses | noteb |
+|        | sion\_ | ook   |
+|        | id>    | name  |
+|        |        | or    |
+|        |        | path  |
+|        |        | of    |
+|        |        | sessi |
+|        |        | on    |
+|        |        | with  |
+|        |        | given |
+|        |        | sessi |
+|        |        | on    |
+|        |        | id.   |
++--------+--------+-------+
+| ``DELE | /api/s | Delet |
+| TE``   | ession | e     |
+|        | s/<ses | activ |
+|        | sion\_ | e     |
+|        | id>    | sessi |
+|        |        | on    |
+|        |        | with  |
+|        |        | given |
+|        |        | sessi |
+|        |        | on    |
+|        |        | id.   |
++--------+--------+-------+
+
+Clusters API
+
++--------+--------+-------+
+| HTTP   | URL    | Actio |
+| verb   |        | n     |
++========+========+=======+
+| ``GET` | /api/c | Retur |
+| `      | luster | n     |
+|        | s      | model |
+|        |        | of    |
+|        |        | clust |
+|        |        | ers.  |
++--------+--------+-------+
+| ``GET` | /api/c | Retur |
+| `      | luster | n     |
+|        | s/<clu | model |
+|        | ster\_ | of    |
+|        | id>    | given |
+|        |        | clust |
+|        |        | er.   |
++--------+--------+-------+
+| ``POST | /api/c | Perfo |
+| ``     | luster | rm    |
+|        | s/<clu | actio |
+|        | ster\_ | n     |
+|        | id>/<a | with  |
+|        | ction> | given |
+|        |        | clust |
+|        |        | ers.  |
+|        |        | Valid |
+|        |        | actio |
+|        |        | ns    |
+|        |        | are   |
+|        |        | "star |
+|        |        | t"    |
+|        |        | or    |
+|        |        | "stop |
+|        |        | "     |
++--------+--------+-------+
+
+Old Architecture
+----------------
+
+This chart shows the web-services in the single directory IPython
+notebook.
+
++--------+--------+-------+
+| HTTP   | URL    | Actio |
+| verb   |        | n     |
++========+========+=======+
+| ``GET` | /noteb | retur |
+| `      | ooks   | ns    |
+|        |        | list  |
+|        |        | of    |
+|        |        | dicts |
+|        |        | with  |
+|        |        | each  |
+|        |        | noteb |
+|        |        | ook's |
+|        |        | info  |
++--------+--------+-------+
+| ``POST | /noteb | if    |
+| ``     | ooks   | sendi |
+|        |        | ng    |
+|        |        | a     |
+|        |        | body, |
+|        |        | savin |
+|        |        | g     |
+|        |        | that  |
+|        |        | body  |
+|        |        | as a  |
+|        |        | new   |
+|        |        | noteb |
+|        |        | ook;  |
+|        |        | if no |
+|        |        | body, |
+|        |        | creat |
+|        |        | e     |
+|        |        | a new |
+|        |        | noteb |
+|        |        | ooks  |
++--------+--------+-------+
+| ``GET` | /noteb | get   |
+| `      | ooks/< | JSON  |
+|        | notebo | data  |
+|        | ok\_id | for   |
+|        | >      | noteb |
+|        |        | ook   |
++--------+--------+-------+
+| ``PUT` | /noteb | saves |
+| `      | ooks/< | an    |
+|        | notebo | exist |
+|        | ok\_id | ing   |
+|        | >      | noteb |
+|        |        | ook   |
+|        |        | with  |
+|        |        | body  |
+|        |        | data  |
++--------+--------+-------+
+| ``DELE | /noteb | delet |
+| TE``   | ooks/< | es    |
+|        | notebo | the   |
+|        | ok\_id | noteb |
+|        | >      | ook   |
+|        |        | with  |
+|        |        | the   |
+|        |        | given |
+|        |        | ID    |
++--------+--------+-------+
+
+This chart shows the architecture for the IPython notebook website.
+
++--------+--------+-------+
+| HTTP   | URI    | Actio |
+| verb   |        | n     |
++========+========+=======+
+| ``GET` | /      | navig |
+| `      |        | ates  |
+|        |        | user  |
+|        |        | to    |
+|        |        | dashb |
+|        |        | oard  |
+|        |        | of    |
+|        |        | noteb |
+|        |        | ooks  |
+|        |        | and   |
+|        |        | clust |
+|        |        | ers   |
++--------+--------+-------+
+| ``GET` | /<note | go to |
+| `      | book\_ | webpa |
+|        | id>    | ge    |
+|        |        | for   |
+|        |        | that  |
+|        |        | noteb |
+|        |        | ook   |
++--------+--------+-------+
+| ``GET` | /new   | creat |
+| `      |        | es    |
+|        |        | a new |
+|        |        | noteb |
+|        |        | ook   |
+|        |        | with  |
+|        |        | profi |
+|        |        | le    |
+|        |        | (or   |
+|        |        | defau |
+|        |        | lt,   |
+|        |        | if no |
+|        |        | profi |
+|        |        | le    |
+|        |        | exist |
+|        |        | s)    |
+|        |        | setti |
+|        |        | ngs   |
++--------+--------+-------+
+| ``GET` | /<note | opens |
+| `      | book\_ | a     |
+|        | id>/co | dupli |
+|        | py     | cate  |
+|        |        | copy  |
+|        |        | of    |
+|        |        | the   |
+|        |        | noteb |
+|        |        | ook   |
+|        |        | with  |
+|        |        | the   |
+|        |        | given |
+|        |        | ID in |
+|        |        | a new |
+|        |        | tab   |
++--------+--------+-------+
+| ``GET` | /<note | print |
+| `      | book\_ | s     |
+|        | id>/pr | the   |
+|        | int    | noteb |
+|        |        | ook   |
+|        |        | with  |
+|        |        | the   |
+|        |        | given |
+|        |        | ID;   |
+|        |        | if    |
+|        |        | noteb |
+|        |        | ook   |
+|        |        | ID    |
+|        |        | doesn |
+|        |        | 't    |
+|        |        | exist |
+|        |        | ,     |
+|        |        | displ |
+|        |        | ays   |
+|        |        | error |
+|        |        | messa |
+|        |        | ge    |
++--------+--------+-------+
+| ``GET` | /login | navig |
+| `      |        | ates  |
+|        |        | to    |
+|        |        | login |
+|        |        | page; |
+|        |        | if no |
+|        |        | user  |
+|        |        | profi |
+|        |        | le    |
+|        |        | is    |
+|        |        | defin |
+|        |        | ed,   |
+|        |        | it    |
+|        |        | navig |
+|        |        | ates  |
+|        |        | user  |
+|        |        | to    |
+|        |        | dashb |
+|        |        | oard  |
++--------+--------+-------+
+| ``GET` | /logou | logs  |
+| `      | t      | out   |
+|        |        | of    |
+|        |        | curre |
+|        |        | nt    |
+|        |        | profi |
+|        |        | le,   |
+|        |        | and   |
+|        |        | navig |
+|        |        | ates  |
+|        |        | user  |
+|        |        | to    |
+|        |        | login |
+|        |        | page  |
++--------+--------+-------+
+
+This chart shows the Web services that act on the kernels and clusters.
+
++--------+--------+-------+
+| HTTP   | URL    | Actio |
+| verb   |        | n     |
++========+========+=======+
+| ``GET` | /kerne | retur |
+| `      | ls     | n     |
+|        |        | the   |
+|        |        | list  |
+|        |        | of    |
+|        |        | kerne |
+|        |        | l     |
+|        |        | ID's  |
+|        |        | curre |
+|        |        | ntly  |
+|        |        | runni |
+|        |        | ng    |
++--------+--------+-------+
+| ``GET` | /kerne | ---   |
+| `      | ls/<ke |       |
+|        | rnel\_ |       |
+|        | id>    |       |
++--------+--------+-------+
+| ``GET` | /kerne | perfo |
+| `      | ls/<ke | rms   |
+|        | rnel\_ | actio |
+|        | id>/<k | n     |
+|        | ernel\ | (rest |
+|        | _actio | art/k |
+|        | n>     | ill)  |
+|        |        | kerne |
+|        |        | l     |
+|        |        | with  |
+|        |        | given |
+|        |        | ID    |
++--------+--------+-------+
+| ``GET` | /kerne | ---   |
+| `      | ls/<ke |       |
+|        | rnel\_ |       |
+|        | id>/io |       |
+|        | pub    |       |
++--------+--------+-------+
+| ``GET` | /kerne | ---   |
+| `      | ls/<ke |       |
+|        | rnel\_ |       |
+|        | id>/sh |       |
+|        | ell    |       |
++--------+--------+-------+
+| ``GET` | /rstse | ---   |
+| `      | rvice/ |       |
+|        | render |       |
++--------+--------+-------+
+| ``GET` | /files |
+| `      | /(.\*) |
+|        | \| --- |
+|        | \| \|  |
+|        | ``GET` |
+|        | `      |
+|        | \|     |
+|        | /clust |
+|        | ers    |
+|        | \|     |
+|        | return |
+|        | s      |
+|        | a list |
+|        | of     |
+|        | dicts  |
+|        | with   |
+|        | each   |
+|        | cluste |
+|        | r's    |
+|        | inform |
+|        | ation  |
+|        | \| \|  |
+|        | ``POST |
+|        | ``     |
+|        | \|     |
+|        | /clust |
+|        | ers/<p |
+|        | rofile |
+|        | \_id>/ |
+|        | <clust |
+|        | er\_ac |
+|        | tion>  |
+|        | \|     |
+|        | perfor |
+|        | ms     |
+|        | action |
+|        | (start |
+|        | /stop) |
+|        | on     |
+|        | cluste |
+|        | r      |
+|        | with   |
+|        | given  |
+|        | profil |
+|        | e      |
+|        | ID \|  |
+|        | \|     |
+|        | ``GET` |
+|        | `      |
+|        | \|     |
+|        | /clust |
+|        | ers/<p |
+|        | rofile |
+|        | \_id>  |
+|        | \|     |
+|        | return |
+|        | s      |
+|        | the    |
+|        | JSON   |
+|        | data   |
+|        | for    |
+|        | cluste |
+|        | r      |
+|        | with   |
+|        | given  |
+|        | profil |
+|        | e      |
+|        | ID \|  |
++--------+--------+-------+

--- a/docs/source/development_guide/sphinx_directive.rst
+++ b/docs/source/development_guide/sphinx_directive.rst
@@ -1,0 +1,421 @@
+.. _sphinx_directive:
+
+IPython Sphinx Directive
+========================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+The ipython directive is a stateful ipython shell for embedding in
+sphinx documents.  It knows about standard ipython prompts, and
+extracts the input and output lines.  These prompts will be renumbered
+starting at ``1``.  The inputs will be fed to an embedded ipython
+interpreter and the outputs from that interpreter will be inserted as
+well.  For example, code blocks like the following::
+
+  .. ipython::
+
+     In [136]: x = 2
+
+     In [137]: x**3
+     Out[137]: 8
+
+will be rendered as
+
+.. ipython::
+
+   In [136]: x = 2
+
+   In [137]: x**3
+   Out[137]: 8
+
+.. note::
+    
+   This tutorial should be read side-by-side with the Sphinx source
+   for this document because otherwise you will see only the rendered 
+   output and not the code that generated it.  Excepting the example 
+   above, we will not in general be showing the literal ReST in this 
+   document that generates the rendered output.
+   
+
+The state from previous sessions is stored, and standard error is
+trapped. At doc build time, ipython's output and std err will be
+inserted, and prompts will be renumbered. So the prompt below should
+be renumbered in the rendered docs, and pick up where the block above
+left off.
+
+.. ipython::
+
+  In [138]: z = x*3   # x is recalled from previous block
+
+  In [139]: z
+  Out[139]: 6
+
+  In [140]: print z
+  --------> print(z)
+  6
+
+  In [141]: q = z[)   # this is a syntax error -- we trap ipy exceptions
+  ------------------------------------------------------------
+     File "<ipython console>", line 1
+       q = z[)   # this is a syntax error -- we trap ipy exceptions
+       ^
+  SyntaxError: invalid syntax
+
+
+The embedded interpreter supports some limited markup.  For example,
+you can put comments in your ipython sessions, which are reported
+verbatim.  There are some handy "pseudo-decorators" that let you
+doctest the output.  The inputs are fed to an embedded ipython
+session and the outputs from the ipython session are inserted into
+your doc.  If the output in your doc and in the ipython session don't
+match on a doctest assertion, an error will be
+
+
+.. ipython::
+
+   In [1]: x = 'hello world'
+
+   # this will raise an error if the ipython output is different
+   @doctest
+   In [2]: x.upper()
+   Out[2]: 'HELLO WORLD'
+
+   # some readline features cannot be supported, so we allow
+   # "verbatim" blocks, which are dumped in verbatim except prompts
+   # are continuously numbered
+   @verbatim
+   In [3]: x.st<TAB>
+   x.startswith  x.strip
+
+
+Multi-line input is supported. 
+
+.. ipython::
+
+   In [130]: url = 'http://ichart.finance.yahoo.com/table.csv?s=CROX\
+      .....: &d=9&e=22&f=2009&g=d&a=1&br=8&c=2006&ignore=.csv'
+
+   In [131]: print url.split('&')
+   --------> print(url.split('&'))
+   ['http://ichart.finance.yahoo.com/table.csv?s=CROX', 'd=9', 'e=22',
+
+You can do doctesting on multi-line output as well.  Just be careful
+when using non-deterministic inputs like random numbers in the ipython
+directive, because your inputs are ruin through a live interpreter, so
+if you are doctesting random output you will get an error.  Here we
+"seed" the random number generator for deterministic output, and we
+suppress the seed line so it doesn't show up in the rendered output
+
+.. ipython::
+
+   In [133]: import numpy.random
+
+   @suppress
+   In [134]: numpy.random.seed(2358)
+
+   @doctest
+   In [135]: numpy.random.rand(10,2)
+   Out[135]:
+   array([[ 0.64524308,  0.59943846],
+    [ 0.47102322,  0.8715456 ],
+    [ 0.29370834,  0.74776844],
+    [ 0.99539577,  0.1313423 ],
+    [ 0.16250302,  0.21103583],
+    [ 0.81626524,  0.1312433 ],
+    [ 0.67338089,  0.72302393],
+    [ 0.7566368 ,  0.07033696],
+    [ 0.22591016,  0.77731835],
+    [ 0.0072729 ,  0.34273127]])
+
+
+Another demonstration of multi-line input and output
+
+.. ipython::
+
+   In [106]: print x
+   --------> print(x)
+   jdh
+
+   In [109]: for i in range(10):
+      .....:     print i
+      .....:
+      .....:
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+   7
+   8
+   9
+
+
+Most of the "pseudo-decorators" can be used an options to ipython
+mode.  For example, to setup matplotlib pylab but suppress the output,
+you can do.  When using the matplotlib ``use`` directive, it should
+occur before any import of pylab.  This will not show up in the
+rendered docs, but the commands will be executed in the embedded
+interpreter and subsequent line numbers will be incremented to reflect
+the inputs::
+
+
+  .. ipython::
+     :suppress:
+
+     In [144]: from pylab import *
+
+     In [145]: ion()
+
+.. ipython::
+   :suppress:
+
+   In [144]: from pylab import *
+
+   In [145]: ion()
+
+Likewise, you can set ``:doctest:`` or ``:verbatim:`` to apply these
+settings to the entire block.  For example,
+
+.. ipython::
+   :verbatim:
+
+   In [9]: cd mpl/examples/
+   /home/jdhunter/mpl/examples
+
+   In [10]: pwd
+   Out[10]: '/home/jdhunter/mpl/examples'
+
+
+   In [14]: cd mpl/examples/<TAB>
+   mpl/examples/animation/        mpl/examples/misc/
+   mpl/examples/api/              mpl/examples/mplot3d/
+   mpl/examples/axes_grid/        mpl/examples/pylab_examples/
+   mpl/examples/event_handling/   mpl/examples/widgets
+
+   In [14]: cd mpl/examples/widgets/
+   /home/msierig/mpl/examples/widgets
+
+   In [15]: !wc *
+       2    12    77 README.txt
+      40    97   884 buttons.py
+      26    90   712 check_buttons.py
+      19    52   416 cursor.py
+     180   404  4882 menu.py
+      16    45   337 multicursor.py
+      36   106   916 radio_buttons.py
+      48   226  2082 rectangle_selector.py
+      43   118  1063 slider_demo.py
+      40   124  1088 span_selector.py
+     450  1274 12457 total
+
+You can create one or more pyplot plots and insert them with the
+``@savefig`` decorator.
+
+.. ipython::
+
+   @savefig plot_simple.png width=4in
+   In [151]: plot([1,2,3]);
+
+   # use a semicolon to suppress the output
+   @savefig hist_simple.png width=4in
+   In [151]: hist(np.random.randn(10000), 100);
+
+In a subsequent session, we can update the current figure with some
+text, and then resave 
+
+.. ipython::
+
+
+   In [151]: ylabel('number')
+
+   In [152]: title('normal distribution')
+
+   @savefig hist_with_text.png width=4in
+   In [153]: grid(True)
+
+You can also have function definitions included in the source.
+
+.. ipython::
+
+   In [3]: def square(x):   
+      ...:     """
+      ...:     An overcomplicated square function as an example.
+      ...:     """
+      ...:     if x < 0:
+      ...:         x = abs(x)
+      ...:     y = x * x
+      ...:     return y
+      ...: 
+
+Then call it from a subsequent section.
+
+.. ipython::
+
+   In [4]: square(3)
+   Out [4]: 9
+
+   In [5]: square(-2)
+   Out [5]: 4
+
+
+Writing Pure Python Code
+------------------------
+
+Pure python code is supported by the optional argument `python`. In this pure
+python syntax you do not include the output from the python interpreter. The 
+following markup::
+
+   .. ipython:: python
+      
+      foo = 'bar'
+      print foo
+      foo = 2
+      foo**2
+
+Renders as
+
+.. ipython:: python
+
+   foo = 'bar'
+   print foo
+   foo = 2
+   foo**2
+
+We can even plot from python, using the savefig decorator, as well as, suppress
+output with a semicolon
+
+.. ipython:: python
+
+   @savefig plot_simple_python.png width=4in
+   plot([1,2,3]);
+
+Similarly, std err is inserted
+
+.. ipython:: python
+
+   foo = 'bar'
+   foo[)
+
+Comments are handled and state is preserved
+
+.. ipython:: python
+
+   # comments are handled
+   print foo
+
+If you don't see the next code block then the options work.
+
+.. ipython:: python
+   :suppress:
+
+   ioff()
+   ion()
+
+Multi-line input is handled.
+
+.. ipython:: python
+
+   line = 'Multi\
+           line &\
+           support &\
+           works'
+   print line.split('&')
+
+Functions definitions are correctly parsed
+
+.. ipython:: python
+
+   def square(x):
+       """
+       An overcomplicated square function as an example.
+       """
+       if x < 0:
+           x = abs(x)
+       y = x * x
+       return y
+
+And persist across sessions
+
+.. ipython:: python
+
+   print square(3)
+   print square(-2)
+
+Pretty much anything you can do with the ipython code, you can do with
+with a simple python script. Obviously, though it doesn't make sense 
+to use the doctest option.
+
+Pseudo-Decorators
+=================
+
+Here are the supported decorators, and any optional arguments they
+take.  Some of the decorators can be used as options to the entire
+block (eg ``verbatim`` and ``suppress``), and some only apply to the
+line just below them (eg ``savefig``).
+
+@suppress
+
+    execute the ipython input block, but suppress the input and output
+    block from the rendered output.  Also, can be applied to the entire
+    ``..ipython`` block as a directive option with ``:suppress:``.
+
+@verbatim
+
+    insert the input and output block in verbatim, but auto-increment
+    the line numbers. Internally, the interpreter will be fed an empty
+    string, so it is a no-op that keeps line numbering consistent.
+    Also, can be applied to the entire ``..ipython`` block as a
+    directive option with ``:verbatim:``.
+
+@savefig OUTFILE [IMAGE_OPTIONS]
+
+    save the figure to the static directory and insert it into the
+    document, possibly binding it into a minipage and/or putting
+    code/figure label/references to associate the code and the
+    figure. Takes args to pass to the image directive (*scale*,
+    *width*, etc can be kwargs); see `image options
+    <http://docutils.sourceforge.net/docs/ref/rst/directives.html#image>`_
+    for details.
+
+@doctest
+
+    Compare the pasted in output in the ipython block with the output
+    generated at doc build time, and raise errors if they donâ€™t
+    match. Also, can be applied to the entire ``..ipython`` block as a
+    directive option with ``:doctest:``.
+
+Configuration Options
+=====================
+
+ipython_savefig_dir
+
+    The directory in which to save the figures. This is relative to the
+    Sphinx source directory. The default is `html_static_path`.
+
+ipython_rgxin
+
+    The compiled regular expression to denote the start of IPython input 
+    lines. The default is re.compile('In \[(\d+)\]:\s?(.*)\s*'). You 
+    shouldn't need to change this.
+
+ipython_rgxout
+
+    The compiled regular expression to denote the start of IPython output 
+    lines. The default is re.compile('Out\[(\d+)\]:\s?(.*)\s*'). You 
+    shouldn't need to change this.
+
+
+ipython_promptin
+
+    The string to represent the IPython input prompt in the generated ReST. 
+    The default is 'In [%d]:'. This expects that the line numbers are used
+    in the prompt.
+
+ipython_promptout
+
+    The string to represent the IPython prompt in the generated ReST. The
+    default is 'Out [%d]:'. This expects that the line numbers are used
+    in the prompt.

--- a/docs/source/development_guide/template.py
+++ b/docs/source/development_guide/template.py
@@ -1,0 +1,35 @@
+"""A one-line description.
+
+A longer description that spans multiple lines.  Explain the purpose of the
+file and provide a short list of the key classes/functions it contains.  This
+is the docstring shown when some does 'import foo;foo?' in IPython, so it
+should be reasonably useful and informative.
+"""
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+from __future__ import print_function
+
+# [remove this comment in production]
+#
+# List all imports, sorted within each section (stdlib/third-party/ipython).
+# For 'import foo', use one import per line.  For 'from foo.bar import a, b, c'
+# it's OK to import multiple items, use the parenthesized syntax 'from foo
+# import (a, b, ...)' if the list needs multiple lines.
+# Separate stdlib, third-party, and IPython imports by a blank line.
+
+
+# [remove this comment in production]
+#
+# If a file is large and has many sections, you may want to use broad section
+# headers like this one that make it easier to navigate the file,
+# with descriptive titles.  For complex classes, simliar (but indented)
+# headers are useful to organize the internal class structure.
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Local utilities
+#-----------------------------------------------------------------------------
+

--- a/docs/source/development_guide/testing.rst
+++ b/docs/source/development_guide/testing.rst
@@ -1,0 +1,492 @@
+.. _testing:
+
+Testing IPython for users and developers
+========================================
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+Overview
+--------
+
+It is extremely important that all code contributed to IPython has
+tests. Tests should be written as unittests, doctests or other entities
+that the IPython test system can detect. See below for more details on
+this.
+
+Each subpackage in IPython should have its own ``tests`` directory that
+contains all of the tests for that subpackage. All of the files in the
+``tests`` directory should have the word "tests" in them to enable the
+testing framework to find them.
+
+In docstrings, examples (either using IPython prompts like ``In [1]:``
+or 'classic' python ``>>>`` ones) can and should be included. The
+testing system will detect them as doctests and will run them; it offers
+control to skip parts or all of a specific doctest if the example is
+meant to be informative but shows non-reproducible information (like
+filesystem data).
+
+If a subpackage has any dependencies beyond the Python standard library,
+the tests for that subpackage should be skipped if the dependencies are
+not found. This is very important so users don't get tests failing
+simply because they don't have dependencies.
+
+The testing system we use is an extension of the
+`nose <http://code.google.com/p/python-nose>`__ test runner. In
+particular we've developed a nose plugin that allows us to paste
+verbatim IPython sessions and test them as doctests, which is extremely
+important for us.
+
+Running the test suite
+----------------------
+
+You can run IPython from the source download directory without even
+installing it system-wide or having configure anything, by typing at the
+terminal:
+
+.. code:: bash
+
+       python2 -c "import IPython; IPython.start_ipython();"
+
+To start the webbased notebook you can use:
+
+.. code:: bash
+
+       python2 -c "import IPython; IPython.start_ipython(['notebook']);"
+
+In order to run the test suite, you must at least be able to import
+IPython, even if you haven't fully installed the user-facing scripts yet
+(common in a development environment). You can then run the tests with:
+
+.. code:: bash
+
+      python -c "import IPython; IPython.test()"
+
+Once you have installed IPython either via a full install or using:
+
+.. code:: bash
+
+      python setup.py develop
+
+you will have available a system-wide script called ``iptest`` that runs
+the full test suite. You can then run the suite with:
+
+.. code:: bash
+
+       iptest  [args]
+
+By default, this excludes the relatively slow tests for
+``IPython.parallel``. To run these, use ``iptest --all``.
+
+Please note that the iptest tool will run tests against the code
+imported by the Python interpreter. If the command
+``python setup.py symlink`` has been previously run then this will
+always be the test code in the local directory via a symlink. However,
+if this command has not been run for the version of Python being tested,
+there is the possibility that iptest will run the tests against an
+installed version of IPython.
+
+Regardless of how you run things, you should eventually see something
+like:
+
+.. code:: text
+
+       **********************************************************************
+       Test suite completed for system with the following information:
+       {'commit_hash': '144fdae',
+        'commit_source': 'repository',
+        'ipython_path': '/home/fperez/usr/lib/python2.6/site-packages/IPython',
+        'ipython_version': '0.11.dev',
+        'os_name': 'posix',
+        'platform': 'Linux-2.6.35-22-generic-i686-with-Ubuntu-10.10-maverick',
+        'sys_executable': '/usr/bin/python',
+        'sys_platform': 'linux2',
+        'sys_version': '2.6.6 (r266:84292, Sep 15 2010, 15:52:39) \n[GCC 4.4.5]'}
+
+       Tools and libraries available at test time:
+          curses matplotlib pymongo qt sqlite3 tornado wx wx.aui zmq
+
+       Ran 9 test groups in 67.213s
+
+       Status:
+       OK
+
+If not, there will be a message indicating which test group failed and
+how to rerun that group individually. For example, this tests the
+``IPython.utils`` subpackage, the ``-v`` option shows progress
+indicators:
+
+.. code:: /bash
+
+       $ iptest IPython.utils -- -v
+       ..........................SS..SSS............................S.S...
+       .........................................................
+       ----------------------------------------------------------------------
+       Ran 125 tests in 0.119s
+
+       OK (SKIP=7)
+
+Because the IPython test machinery is based on nose, you can use all
+nose syntax. Options after ``--`` are passed to nose. For example, this
+lets you run the specific test ``test_rehashx`` inside the
+``test_magic`` module:
+
+.. code:: bash
+
+       $ iptest IPython.core.tests.test_magic:test_rehashx -- -vv
+       IPython.core.tests.test_magic.test_rehashx(True,) ... ok
+       IPython.core.tests.test_magic.test_rehashx(True,) ... ok
+
+       ----------------------------------------------------------------------
+       Ran 2 tests in 0.100s
+
+       OK
+
+When developing, the ``--pdb`` and ``--pdb-failures`` of nose are
+particularly useful, these drop you into an interactive pdb session at
+the point of the error or failure respectively:
+``iptest mymodule -- --pdb``.
+
+The system information summary printed above is accessible from the top
+level package. If you encounter a problem with IPython, it's useful to
+include this information when reporting on the mailing list; use::
+
+.. code:: python
+
+        from IPython import sys_info
+        print sys_info()
+
+and include the resulting information in your query.
+
+Testing pull requests
+---------------------
+
+We have a script that fetches a pull request from Github, merges it with
+master, and runs the test suite on different versions of Python. This
+uses a separate copy of the repository, so you can keep working on the
+code while it runs. To run it:
+
+.. code:: bash
+
+        python tools/test_pr.py -p 1234
+
+The number is the pull request number from Github; the ``-p`` flag makes
+it post the results to a comment on the pull request. Any further
+arguments are passed to ``iptest``.
+
+This requires the `requests <http://pypi.python.org/pypi/requests>`__
+and `keyring <http://pypi.python.org/pypi/keyring>`__ packages.
+
+For developers: writing tests
+-----------------------------
+
+By now IPython has a reasonable test suite, so the best way to see
+what's available is to look at the ``tests`` directory in most
+subpackages. But here are a few pointers to make the process easier.
+
+Main tools: ``IPython.testing``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``IPython.testing`` package is where all of the machinery to test
+IPython (rather than the tests for its various parts) lives. In
+particular, the ``iptest`` module in there has all the smarts to control
+the test process. In there, the ``make_exclude`` function is used to
+build a blacklist of exclusions, these are modules that do not get even
+imported for tests. This is important so that things that would fail to
+even import because of missing dependencies don't give errors to end
+users, as we stated above.
+
+The ``decorators`` module contains a lot of useful decorators,
+especially useful to mark individual tests that should be skipped under
+certain conditions (rather than blacklisting the package altogether
+because of a missing major dependency).
+
+Our nose plugin for doctests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``plugin`` subpackage in testing contains a nose plugin called
+``ipdoctest`` that teaches nose about IPython syntax, so you can write
+doctests with IPython prompts. You can also mark doctest output with
+``# random`` for the output corresponding to a single input to be
+ignored (stronger than using ellipsis and useful to keep it as an
+example). If you want the entire docstring to be executed but none of
+the output from any input to be checked, you can use the
+``# all-random`` marker. The ``IPython.testing.plugin.dtexample`` module
+contains examples of how to use these; for reference here is how to use
+``# random``:
+
+.. code:: python
+
+        def ranfunc():
+        """A function with some random output.
+
+           Normal examples are verified as usual:
+           >>> 1+3
+           4
+
+           But if you put '# random' in the output, it is ignored:
+           >>> 1+3
+           junk goes here...  # random
+
+           >>> 1+2
+           again,  anything goes #random
+           if multiline, the random mark is only needed once.
+
+           >>> 1+2
+           You can also put the random marker at the end:
+           # random
+
+           >>> 1+2
+           # random
+           .. or at the beginning.
+
+           More correct input is properly verified:
+           >>> ranfunc()
+           'ranfunc'
+        """
+        return 'ranfunc'
+
+and an example of ``# all-random``:
+
+.. code:: python
+
+        def random_all():
+        """A function where we ignore the output of ALL examples.
+
+        Examples:
+
+          # all-random
+
+          This mark tells the testing machinery that all subsequent examples
+          should be treated as random (ignoring their output).  They are still
+          executed, so if a they raise an error, it will be detected as such,
+          but their output is completely ignored.
+
+          >>> 1+3
+          junk goes here...
+
+          >>> 1+3
+          klasdfj;
+
+        In [8]: print 'hello'
+        world  # random
+
+        In [9]: iprand()
+        Out[9]: 'iprand'
+        """
+        return 'iprand'
+
+When writing docstrings, you can use the ``@skip_doctest`` decorator to
+indicate that a docstring should *not* be treated as a doctest at all.
+The difference between ``# all-random`` and ``@skip_doctest`` is that
+the former executes the example but ignores output, while the latter
+doesn't execute any code. ``@skip_doctest`` should be used for
+docstrings whose examples are purely informational.
+
+If a given docstring fails under certain conditions but otherwise is a
+good doctest, you can use code like the following, that relies on the
+'null' decorator to leave the docstring intact where it works as a test:
+
+.. code:: python
+
+      # The docstring for full_path doctests differently on win32 (different path
+      # separator) so just skip the doctest there, and use a null decorator
+      # elsewhere:
+      
+      doctest_deco = dec.skip_doctest if sys.platform == 'win32' else dec.null_deco
+
+      @doctest_deco
+      def full_path(startPath,files):
+          """Make full paths for all the listed files, based on startPath..."""
+
+          # function body follows...
+
+With our nose plugin that understands IPython syntax, an extremely
+effective way to write tests is to simply copy and paste an interactive
+session into a docstring. You can writing this type of test, where your
+docstring is meant *only* as a test, by prefixing the function name with
+``doctest_`` and leaving its body *absolutely empty* other than the
+docstring. In ``IPython.core.tests.test_magic`` you can find several
+examples of this, but for completeness sake, your code should look like
+this (a simple case):
+
+.. code:: python
+
+        def doctest_time():
+        """
+        In [10]: %time None
+        CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
+        Wall time: 0.00 s
+        """
+
+This function is only analyzed for its docstring but it is not
+considered a separate test, which is why its body should be empty.
+
+JavaScript Tests
+~~~~~~~~~~~~~~~~
+
+We currently use `casperjs <http://casperjs.org/>`__ for testing the
+notebook javascript user interface.
+
+To run the JS test suite by itself, you can either use ``iptest js``,
+which will start up a new notebook server and test against it, or you
+can open up a notebook server yourself, and then:
+
+::
+
+    cd IPython/html/tests/casperjs;
+    casperjs test --includes=util.js test_cases
+
+If your testing notebook server uses something other than the default
+port (8888), you will have to pass that as a parameter to the test suite
+as well.
+
+::
+
+    casperjs test --includes=util.js --port=8889 test_cases
+
+Running individual tests
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To speed up development, you usually are working on getting one test
+passing at a time. To do this, just pass the filename directly to the
+``casperjs test`` command like so:
+
+::
+
+    casperjs test --includes=util.js  test_cases/execute_code_cell.js
+
+Wrapping your head around the javascript within javascript:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+CasperJS is a browser that's written in javascript, so we write
+javascript code to drive it. The Casper browser itself also has a
+javascript implementation (like the ones that come with Firefox and
+Chrome), and in the test suite we get access to those using
+``this.evaluate``, and it's cousins (``this.theEvaluate``, etc).
+Additionally, because of the asynchronous / callback nature of
+everything, there are plenty of ``this.then`` calls which define steps
+in test suite. Part of the reason for this is that each step has a
+timeout (default of 5 or 10 seconds). Additionally, there are already
+convenience functions in ``util.js`` to help you wait for output in a
+given cell, etc. In our javascript tests, if you see functions which
+``look_like_pep8_naming_convention``, those are probably coming from
+``util.js``, whereas functions that come with casper
+``haveCamelCaseNamingConvention``
+
+Each file in ``test_cases`` looks something like this (this is
+``test_cases/check_interrupt.js``):
+
+::
+
+    casper.notebook_test(function () {
+        this.evaluate(function () {
+            var cell = IPython.notebook.get_cell(0);
+            cell.set_text('import time\nfor x in range(3):\n    time.sleep(1)');
+            cell.execute();
+        });
+
+
+        // interrupt using menu item (Kernel -> Interrupt)
+        this.thenClick('li#int_kernel');
+
+        this.wait_for_output(0);
+
+        this.then(function () {
+            var result = this.get_output_cell(0);
+            this.test.assertEquals(result.ename, 'KeyboardInterrupt', 'keyboard interrupt (mouseclick)');
+        });
+
+        // run cell 0 again, now interrupting using keyboard shortcut
+        this.thenEvaluate(function () {
+            cell.clear_output();
+            cell.execute();
+        });
+
+        // interrupt using Ctrl-M I keyboard shortcut
+        this.thenEvaluate( function() {
+            IPython.utils.press_ghetto(IPython.utils.keycodes.I)
+        });
+        
+        this.wait_for_output(0);
+        
+        this.then(function () {
+            var result = this.get_output_cell(0);
+            this.test.assertEquals(result.ename, 'KeyboardInterrupt', 'keyboard interrupt (shortcut)');
+        });
+    });
+
+For an example of how to pass parameters to the client-side javascript
+from casper test suite, see the ``casper.wait_for_output``
+implementation in ``IPython/html/tests/casperjs/util.js``
+
+Testing system design notes
+---------------------------
+
+This section is a set of notes on the key points of the IPython testing
+needs, that were used when writing the system and should be kept for
+reference as it eveolves.
+
+Testing IPython in full requires modifications to the default behavior
+of nose and doctest, because the IPython prompt is not recognized to
+determine Python input, and because IPython admits user input that is
+not valid Python (things like ``%magics`` and ``!system commands``.
+
+We basically need to be able to test the following types of code:
+
+-  
+
+   (1) Pure Python files containing normal tests. These are not a
+       problem, since Nose will pick them up as long as they conform to
+       the (flexible) conventions used by nose to recognize tests.
+
+-  
+
+   (2) Python files containing doctests. Here, we have two
+       possibilities:
+
+-  The prompts are the usual ``>>>`` and the input is pure Python.
+-  The prompts are of the form ``In [1]:`` and the input can contain
+   extended IPython expressions.
+
+In the first case, Nose will recognize the doctests as long as it is
+called with the ``--with-doctest`` flag. But the second case will likely
+require modifications or the writing of a new doctest plugin for Nose
+that is IPython-aware.
+
+-  
+
+   (3) ReStructuredText files that contain code blocks. For this type of
+       file, we have three distinct possibilities for the code blocks:
+
+-  They use ``>>>`` prompts.
+-  They use ``In [1]:`` prompts.
+-  They are standalone blocks of pure Python code without any prompts.
+
+The first two cases are similar to the situation #2 above, except that
+in this case the doctests must be extracted from input code blocks using
+docutils instead of from the Python docstrings.
+
+In the third case, we must have a convention for distinguishing code
+blocks that are meant for execution from others that may be snippets of
+shell code or other examples not meant to be run. One possibility is to
+assume that all indented code blocks are meant for execution, but to
+have a special docutils directive for input that should not be executed.
+
+For those code blocks that we will execute, the convention used will
+simply be that they get called and are considered successful if they run
+to completion without raising errors. This is similar to what Nose does
+for standalone test functions, and by putting asserts or other forms of
+exception-raising statements it becomes possible to have literate
+examples that double as lightweight tests.
+
+-  
+
+   (4) Extension modules with doctests in function and method
+       docstrings. Currently Nose simply can't find these docstrings
+       correctly, because the underlying doctest DocTestFinder object
+       fails there. Similarly to #2 above, the docstrings could have
+       either pure python or IPython prompts.
+
+Of these, only 3-c (reST with standalone code blocks) is not implemented
+at this point.

--- a/docs/source/development_guide/testing_kernels.rst
+++ b/docs/source/development_guide/testing_kernels.rst
@@ -1,0 +1,114 @@
+.. _testing_kernels:
+
+Testing Kernels
+===============
+
+.. attention::
+    This is copied verbatim from the old IPython wiki and is currently under development. Much of the information in this part of the development guide is out of date.
+
+IPython makes it very easy to create wrapper kernels using its kernel
+framework. It requires extending the Kernel class and implementing a set
+of methods for the core functions like execute, history etc. Its also
+possible to write a full blown kernel in a language of your choice
+implementing listeners for all the zmq ports.
+
+The key problem for any kernel implemented by these methods is to ensure
+that it meets the message specification. The kerneltest command is a
+means to test the installed kernel against the message spec and validate
+the results.
+
+The kerneltest tool
+-------------------
+
+The kerneltest tool is part of IPython.testing and is also included in
+the scripts similar to iptest. This takes 2 parameters - the name of the
+kernel to test and the test script file. The test script file should be
+in json format as described in the next section.
+
+::
+
+    kerneltest python test_script.json
+
+You can also pass in an optional message spec version to the command. At
+the moment only the version 5 is supported, but as newer versions are
+released this can be used to test the kernel against a specific version
+of the kernel.
+
+::
+
+    kerneltest python test_script.json 5
+
+The kernel to be tested needs to be installed and the kernelspec
+available in the user IPython directory. The tool will instantiate the
+kernel and send the commands over ZMQ. For each command executed on the
+kernel, the tool will validate the reply to ensure that it matches the
+message specification. In some cases the output is also checked, but the
+reply is always returned and printed out on the console. This can be
+used to validate that apart from meeting the message spec the kernel
+also produced the correct output.
+
+The test script file
+--------------------
+
+The test script file is a simple json file that specifies the command to
+execute and the test code to execute for the command.
+
+::
+
+    {
+        "command":{
+               "test_code":<code>
+        }
+    }
+
+For some commands in the message specification like kernel\_info there
+is no need to specify the test\_code parameter. The tool validates if it
+has all the inputs needed to execute the command and will print out an
+error to the console if it finds a missing parameter. Since the
+validation is built in, and only required parameters are passed, it is
+possible to add additional fields in the json file for test
+documentation.
+
+::
+
+    {
+        "command":{
+               "test_name":"sample test",
+               "test_description":"sample test to show how the test script file is created",
+               "test_code":<code>
+        }
+    }
+
+A sample test script for the redis kernel will look like this
+
+::
+
+    {
+      "execute":{
+        "test_code":"get a",
+        "comments":"test basic code execution"
+      },
+      "complete":{
+        "test_code":"get",
+        "comments":"test getting command auto complete"
+      },
+      "kernel_info":{
+        "comments":"simple kernel info check"
+      },
+      "single_payload":{
+        "test_code":"get a",
+        "comments":"test one payload"
+      },
+      "history_tail":{
+        "test_code":"get a",
+        "comments":"test tail history"
+      },
+      "history_range":{
+        "test_code":"get a",
+        "comments":"test range history"
+      },
+      "history_search":{
+        "test_code":"get a",
+        "comments":"test search history"
+      }
+    }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,3 +86,8 @@ newsletter.
 
    data_science
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Old IPython Wiki
+
+   development_guide/index


### PR DESCRIPTION
Ping @willingc 

This converts all the old ipython wiki pages beginning with "Dev" to rst and makes sure the links in them are correct. This doesn't do any sort of organization or updating of out-of-date content. I specifically added a "caution" banner to each page warning people that this stuff is unorganized and out of date.