### PR TITLE
Let this metapackage work with installation via mitsuhiko/pipsi

### DIFF
--- a/jupyter_run.py
+++ b/jupyter_run.py
@@ -5,6 +5,9 @@ Alias to jupyter_core
 
 __version__ = '1.0.0'
 
-if __name__ == '__main__':
+def main():
     from runpy import run_module
     run_module('jupyter_core')
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup_args = dict(
     long_description    = """Install the Jupyter system, including the notebook, qtconsole, and the IPython kernel.""",
     author              = "Jupyter Development Team",
     author_email        = "jupyter@googlegroups.org",
-    py_modules          = ['jupyter'],
+    py_modules          = ['jupyter_run'],
     install_requires    = [
         'notebook',
         'qtconsole',
@@ -45,6 +45,11 @@ setup_args = dict(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
+    entry_points        = {
+        'console_scripts': [
+            'jupyter=jupyter_run:main'
+        ]
+    }
 )
 
 if any(bdist in sys.argv for bdist in ['bdist_wheel', 'bdist_egg']):


### PR DESCRIPTION
[mitsuhiko/pipsi](https://github.com/mitsuhiko/pipsi) has a method of transparently installing scripts in virtualenvs so that they remain easily-accessible from the command line but also don't pollute the system-wide packages.

It's a bit picky about what it installs, though, and requires there be an entry point configured in `setup.py`. These changes make that installation possible.