### PR TITLE
Addresses: #165: Add .gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.py text
+*.yaml text
+*.md text
+*.rst text
+*.html text
+
+# The following files need to be converted for them to work properly
+*.bat text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary


### PR DESCRIPTION
Add `.gitattributes` to ensure that .bat files are always checked out with CRLF line enddings. Addresses: #165