### PR TITLE
Use 'jupyter-notebook' on Ubuntu/Linux

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -17,6 +17,14 @@ Basic Steps
 
 2. You should see the notebook open in your browser.
 
+.. note::
+
+    On Ubuntu/Linux, if you cannot run the `jupyter notebook` command, try the following:
+
+    .. code-block:: bash
+
+        jupyter-noteboook
+
 Starting the Notebook Server
 ----------------------------
 


### PR DESCRIPTION
The command 'jupyter notebook' does not work on Ubuntu 16.04. It is necessary to run the command as 'jupyter-notebook':

https://github.com/jupyter/notebook/issues/448#issuecomment-141687894