### PR TITLE
Edit Community contents page

### DIFF
--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -3,14 +3,19 @@ Community Guides
 ================
 
 
-Welcome to the Community Guides for Jupyter. These guides are intended to provide information about the Jupyter community such as background, events, and communication channels. As our community is highly dynamic, information here can become out of
-date quickly. Feel free to tell us when this is the case, or if anything is
-missing.
+Welcome to the Community Guides for Jupyter. These guides are intended to
+provide information about the Jupyter community such as background, events,
+and communication channels. As our community is highly dynamic, information
+may change, and we will do our best to keep it up to date.
 
 Weekly Dev meeting
 ------------------
 
-The core developers have weekly meetings to discuss and demo what they have been working on, discuss future plans, and bootstrap conversation. These meetings are public. The direct link to attend the meeting will be posted to the `Hackpad <https://jupyter.hackpad.com>`_ before the meeting. Afterwards, the recording of the meeting will be posted to the `IPython channel
+The core developers have weekly meetings to discuss and demo what they have
+been working on, discuss future plans, and bootstrap conversation. These
+meetings are public. The direct link to attend the meeting will be posted to
+the `Hackpad <https://jupyter.hackpad.com>`_ before the meeting. Afterwards,
+the recording of the meeting will be posted to the `IPython channel
 <https://www.youtube.com/channel/UCUuzz1eYiKIzu_Uw1ZQLNoQ>`_ on YouTube.
 
 **Jupyter/IPython meetings:**
@@ -24,45 +29,37 @@ The core developers have weekly meetings to discuss and demo what they have been
 Collaborative notes are taken before/during the meeting on
 `Hackpad <https://jupyter.hackpad.com>`_. Hackpads are organized by month.
 
-We will ping the `dev-meeting-attendance Gitter channel <https://gitter.im/jupyter/dev-meeting-attendance>`_ 1-2 days before each meeting to
-know who is likely going to attend.
+We will ping the `dev-meeting-attendance Gitter channel <https://gitter.im/jupyter/dev-meeting-attendance>`_ 
+1-2 days before each meeting to know who is likely going to attend.
 
 .. contents:: Contents
    :local:
 
-Events
---------
-- JupyterCon
-- JupyterDays
-- User group workshop and training
+.. Events
+.. --------
 
-Conferences
------------
-- PyData
-- SciPy
 
-Jupyter communications and social media
----------------------------------------
-- Blog
-- Newsletter
-- Website
-- Links to social media channels
-- Mailing lists (Jupyter, Jupyter in Education)
+.. Jupyter communications and social media
+.. ---------------------------------------
 
-Publications about Jupyter and IPython
---------------------------------------
-- Papers
-- Talks
-- Posters
-- Books
+
+.. Publications about Jupyter and IPython
+.. --------------------------------------
+.. - Papers
+.. - Talks
+.. - Posters
+.. - Books
 
 .. Project history and timeline
 .. ----------------------------
 
 Governance
 ----------
-- Steering council
-- JEP process
+
+- Steering council: Information about the steering council and its members
+  can be found on the `Jupyter website <https://jupyter.org>`_.
+- Jupyter Enhancement Proposal (JEP) process: Details about the process can
+  be found in the `jupyter/enhancement-proposals GitHub repo <https://github.com/jupyter/enhancement-proposals>`_.
 
 Code of conduct
 ---------------

--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -35,23 +35,14 @@ We will ping the `dev-meeting-attendance Gitter channel <https://gitter.im/jupyt
 .. contents:: Contents
    :local:
 
-.. Events
-.. --------
+Jupyter communications
+----------------------
 
-
-.. Jupyter communications and social media
-.. ---------------------------------------
-
-
-.. Publications about Jupyter and IPython
-.. --------------------------------------
-.. - Papers
-.. - Talks
-.. - Posters
-.. - Books
-
-.. Project history and timeline
-.. ----------------------------
+- Blog `<https://blog.jupyter.org/>`_
+- Newsletter `<https://newsletter.jupyter.org/>`_
+- Website `<https://jupyter.org>`_
+- Twitter `<https://twitter.com/ProjectJupyter>`_
+- Mailing lists (Jupyter, Jupyter in Education) `<https://jupyter.org/community.html>`_
 
 Governance
 ----------
@@ -64,7 +55,4 @@ Governance
 Code of conduct
 ---------------
 
-.. note::
-
-      We're actively working on this section of the documentation to improve
-      it for you. Thanks for your patience.
+Information can be found in the `Jupyter Governance repo on GitHub <https://github.com/jupyter/governance>`_.


### PR DESCRIPTION
- Temporarily remove sections on Events and Communication.
- Add  content for governance
- Reflow text