### PR TITLE
Cloud theme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 install:
     - pip install --upgrade pip
     - pip install --upgrade sphinx
-    - pip install jupyter_sphinx_theme
+    - pip install cloud-sptheme
     - pip install recommonmark
 script:
     - cd docs && make html

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,3 +6,4 @@ dependencies:
     - recommonmark
     - nbsphinx
     - jupyter_sphinx_theme==0.0.6
+    - cloud-sptheme

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,5 +5,4 @@ dependencies:
     - sphinx
     - recommonmark
     - nbsphinx
-    - jupyter_sphinx_theme==0.0.6
     - cloud-sptheme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,8 +11,8 @@ import os
 import shlex
 import recommonmark.parser
 
-from jupyter_sphinx_theme import *
-init_theme()
+#from jupyter_sphinx_theme import *
+#init_theme()
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -170,3 +170,32 @@ graphviz_output_format = 'svg'
 # graphviz_dot=r'c:\Program Files (x86)\Graphviz2.38\bin\dot.exe' 
 # with your path to graphviz in should work if added to this file.
 # BUT Please do not commit with the path on your computer in place.
+
+# -- ReadTheDocs and Themes
+
+# Documentation is being built on readthedocs, this will be true.
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if on_rtd:
+    import cloud_sptheme as csp
+
+    html_theme = 'cloud'
+    html_theme_options = {"roottarget": "index"}
+
+    # Add any paths that contain custom themes here, relative to this directory.
+    html_theme_path = [csp.get_theme_dir()]
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+#
+
+if not on_rtd:
+
+    import cloud_sptheme as csp
+
+    html_theme = 'cloud'
+    html_theme_options = { "roottarget": "index" }
+
+    # Add any paths that contain custom themes here, relative to this directory.
+    html_theme_path = [csp.get_theme_dir()]
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,9 +11,6 @@ import os
 import shlex
 import recommonmark.parser
 
-#from jupyter_sphinx_theme import *
-#init_theme()
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -194,7 +191,7 @@ if not on_rtd:
     import cloud_sptheme as csp
 
     html_theme = 'cloud'
-    html_theme_options = { "roottarget": "index" }
+    html_theme_options = {"roottarget": "index"}
 
     # Add any paths that contain custom themes here, relative to this directory.
     html_theme_path = [csp.get_theme_dir()]


### PR DESCRIPTION
Move to cloud-sptheme in interim until RTD standard theme is modified.

Since this theme is used by xonsh and is maintained more actively than the jupyter theme, I propose we move the high level jupyter docs to the cloud theme.

This PR moves over to the cloud theme without any other modifications. I think it is more readable than the theme currently in use and more visually appealing than the out of the box RTD sphinx theme.

Let's merge this and then iterate some clean up edits and then move full steam ahead on improving the RTD theme for widgets. [Rendered docs with cloud theme](http://test-jupyter.readthedocs.io/en/cloud-theme/index.html).

cc/ @Carreau @ellisonbg @gnestor @SylvainCorlay @michaelpacer @takluyver @JamiesHQ @fperez
