### PR TITLE
added one dependency more to build docs using sphinx

### DIFF
--- a/docs/source/contrib_docs/getting-started.rst
+++ b/docs/source/contrib_docs/getting-started.rst
@@ -41,7 +41,7 @@ we recommend that you install the stable development version Sphinx
 (``pip install git+https://github.com/sphinx-doc/sphinx@stable``) or the
 current released version of Sphinx (``pip install sphinx``).
 
-In addition, you may need the following packages: sphinxcontrib-spelling, sphinx_rtd_theme, and pyenchant, which can be installed via ``pip install sphinxcontrib-spelling sphinx_rtd_theme pyenchant``.
+In addition, you may need the following packages: sphinxcontrib-spelling, sphinx_rtd_theme, nbsphinx and pyenchant, which can be installed via ``pip install sphinxcontrib-spelling sphinx_rtd_theme nbsphinx pyenchant``.
 
 If you are on Linux, you may also need to install the Enchant C library by running ``sudo apt-get install enchant``.
 


### PR DESCRIPTION
`nbsphinx` was not listed in the dependencies to build the docs of several Jupyter projects.