### PR TITLE
Update links

### DIFF
--- a/docs/source/_templates/index.html
+++ b/docs/source/_templates/index.html
@@ -80,12 +80,7 @@
          <a href="https://github.com/jupyter/tmpnb">{%trans%}tmpnb{%endtrans%}</a><br/>
          <a href="http://traitlets.readthedocs.io/en/stable/">{%trans%}traitlets{%endtrans%}</a></p>
       <p>JupyterLab</p>
-         <a href="https://github.com/jupyter/jupyter-js-notebook">{%trans%}jupyter-js-notebook{%endtrans%}</a><br/>
-         <a href="https://github.com/jupyter/jupyter-js-phosphide">{%trans%}jupyter-js-phosphide{%endtrans%}</a><br/>
-         <a href="https://github.com/jupyter/jupyter-js-plugins">{%trans%}jupyter-js-plugins{%endtrans%}</a><br/>
          <a href="https://github.com/jupyterlab/services">{%trans%}jupyter-js-services{%endtrans%}</a><br/>
-         <a href="https://github.com/jupyter-attic/jupyter-js-ui">{%trans%}jupyter-js-ui{%endtrans%}</a><br/>
-         <a href="https://github.com/jupyter-attic/jupyter-js-utils">{%trans%}jupyter-js-utils{%endtrans%}</a></p>
 </td></tr>
 </table>
 

--- a/docs/source/_templates/index.html
+++ b/docs/source/_templates/index.html
@@ -83,9 +83,9 @@
          <a href="https://github.com/jupyter/jupyter-js-notebook">{%trans%}jupyter-js-notebook{%endtrans%}</a><br/>
          <a href="https://github.com/jupyter/jupyter-js-phosphide">{%trans%}jupyter-js-phosphide{%endtrans%}</a><br/>
          <a href="https://github.com/jupyter/jupyter-js-plugins">{%trans%}jupyter-js-plugins{%endtrans%}</a><br/>
-         <a href="http://jupyter.org/jupyter-js-services/">{%trans%}jupyter-js-services{%endtrans%}</a><br/>
-         <a href="http://jupyter.org/jupyter-js-ui/">{%trans%}jupyter-js-ui{%endtrans%}</a><br/>
-         <a href="http://jupyter.org/jupyter-js-utils/">{%trans%}jupyter-js-utils{%endtrans%}</a></p>
+         <a href="https://github.com/jupyterlab/services">{%trans%}jupyter-js-services{%endtrans%}</a><br/>
+         <a href="https://github.com/jupyter-attic/jupyter-js-ui">{%trans%}jupyter-js-ui{%endtrans%}</a><br/>
+         <a href="https://github.com/jupyter-attic/jupyter-js-utils">{%trans%}jupyter-js-utils{%endtrans%}</a></p>
 </td></tr>
 </table>
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -167,6 +167,6 @@ graphviz_output_format = 'svg'
 # if calling sphinx-build directly - if using the make.bat file first do:
 # set SPHINXOPTS=-D graphviz_dot="C:\Program Files (x86)\Graphviz2.38\bin\dot.exe"
 # or similar, if all else fails, something like:
-# graphviz_dot=r'c:\Program Files (x86)\Graphviz2.38\bin\dot.exe' 
+# graphviz_dot=r'c:\Program Files (x86)\Graphviz2.38\bin\dot.exe'
 # with your path to graphviz in should work if added to this file.
 # BUT Please do not commit with the path on your computer in place.


### PR DESCRIPTION
I was going through all of the repositories listed on the main documentation page and noticed the `services`, `ui`, and `utils` links were not updated under JupyterLab.