### PR TITLE
update install-kernel to reflect jupyter

### DIFF
--- a/docs/source/install-kernel.rst
+++ b/docs/source/install-kernel.rst
@@ -42,4 +42,4 @@ need to install additional kernels. For more information, see the full
     :ref:`Kernels documentation for Jupyter client <kernels>`
         Technical information about kernels.
 
-.. _`list of available kernels`: https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages
+.. _`list of available kernels`: https://github.com/jupyter/jupyter/wiki/Jupyter-kernels


### PR DESCRIPTION
change #L45 to directly link the Jupyter repository for available kernels, rather than clicking through the redirect at iPython.