### PR TITLE
fixed hyper-links in diagram

### DIFF
--- a/docs/source/projects/content-projects.rst
+++ b/docs/source/projects/content-projects.rst
@@ -104,12 +104,12 @@ How do I decide which packages I need?
 			label="Extensions", 
 			tooltip="Install & use extensions", 
 			target="_blank", color=blue, // External Link 
-			href="https://github.com/jupyter/help"]
+			href="https://github.com/ipython-contrib/IPython-notebook-extensions"]
 		dash [
 			label="Dashboards", 
 			tooltip="Install & use dashboards",
 			target="_blank", color=blue, // External Link 
-			href="https://github.com/ipython-contrib/IPython-notebook-extensions"]
+			href="https://github.com/jupyter/dashboards"]
 		help [
 			label="Help", 
 			tooltip="Ask on jupyter help", 


### PR DESCRIPTION
On [this page in the docs](
http://jupyter.readthedocs.io/en/latest/projects/content-projects.html#how-do-i-decide-which-packages-i-need) is a diagram, that contains hyper-links. Some of those links didn't make sense to me. 

- "Extensions" now links to https://github.com/ipython-contrib/jupyter_contrib_nbextensions
- "Dasboards" now links to https://github.com/jupyter/dashboards

This is my first contribution here. Please be gentle~