### PR TITLE
Migrating clarification

### DIFF
--- a/docs/source/migrating.rst
+++ b/docs/source/migrating.rst
@@ -142,8 +142,8 @@ If you just want to change the config file, you can do:
 
     jupyter notebook --config=/path/to/myconfig.py
 
-Changing kernelspecs
-~~~~~~~~~~~~~~~~~~~~
+Changing IPython's profile using custom kernelspecs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you do want to change the IPython kernel's profile, you
 can't do this at the server command-line anymore. Kernel arguments must
@@ -154,6 +154,23 @@ One approach uses ``jupyter kernelspec list`` to find the
 ``kernel.json`` file and then modifies it, e.g. ``kernels/python3/kernel.json``,
 by hand. Alternatively, `a2km <https://github.com/minrk/a2km>`__ is an
 experimental project that tries to make these things easier.
+
+For example, add the ``--profile`` option to a custom kernelspec under ``kernels/mycustom/kernel.json``
+(see the Jupyter kernelspec directions
+`here <https://jupyter-client.readthedocs.io/en/latest/kernels.html#kernel-specs>`_):
+
+.. code-block:: json
+
+    {
+     "argv": ["python", "-m", "ipykernel",
+              "--profile=my-ipython-profile",
+              "-f", "{connection_file}"],
+     "display_name": "Custom Profile Python",
+     "language": "python"
+    }
+q
+You can then run Jupyter with the ``--kernel=mycustom`` command-line option and IPython
+will find the appropriate profile.
 
 Understanding Installation Changes
 ----------------------------------

--- a/docs/source/migrating.rst
+++ b/docs/source/migrating.rst
@@ -157,7 +157,7 @@ experimental project that tries to make these things easier.
 
 For example, add the ``--profile`` option to a custom kernelspec under ``kernels/mycustom/kernel.json``
 (see the Jupyter kernelspec directions
-`here <https://jupyter-client.readthedocs.io/en/latest/kernels.html#kernel-specs>`_):
+`here <https://jupyter-client.readthedocs.io/en/latest/kernels.html#kernel-specs>`__):
 
 .. code-block:: json
 
@@ -168,7 +168,7 @@ For example, add the ``--profile`` option to a custom kernelspec under ``kernels
      "display_name": "Custom Profile Python",
      "language": "python"
     }
-q
+
 You can then run Jupyter with the ``--kernel=mycustom`` command-line option and IPython
 will find the appropriate profile.
 


### PR DESCRIPTION
There occurred a discussion between myself and @takluyver on this closed issue:

https://github.com/jupyter/notebook/issues/624

I maintained that the current documentation regarding how to use custom IPython profiles from within Jupyter was lacking in clarity - I think that most people including myself do not quickly understand that it is possible to use a custom IPython profile within Jupyter but only by creating a custom kernelspec, hence the leap from Jupyter configuration to kernelspecs is unintuitive.

Here is my attempt to create something a bit more clear - two minor changes to the documentation on the migration page.  I altered the title of the relevant section slightly, and added an example.