### PR TITLE
Link out to Virtual DOM spec

### DIFF
--- a/docs/source/reference/mimetype.md
+++ b/docs/source/reference/mimetype.md
@@ -30,3 +30,4 @@ As types may contain vendor specific items, a
   `application/geo+json`
 * `application/geo+json` - preferred [GeoJSON spec](http://geojson.org/geojson-spec.html)
 * `application/vnd.plotly.v1+json` - [Plotly JSON Schema](http://help.plot.ly/json-chart-schema/)
+* `application/vdom.v1+json` - [Virtual DOM spec](https://github.com/nteract/vdom/blob/master/docs/spec.md)


### PR DESCRIPTION
Once https://github.com/nteract/vdom/pull/2 is merged, this will properly link to the spec doc for vdom. I thought about writing it here too (which is totally fine), wasn't sure of the right spot though.