### PR TITLE
Add documentation to run specific Notebook

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -54,6 +54,13 @@ notebooks. Often this will be your home directory.
 Introducing the Notebook Server's Command Line Options
 ------------------------------------------------------
 
+How do I run a specific Notebook?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+    jupyter notebook notebook.ipynb
+
 How do I start the Notebook using a custom IP or port?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR adds instructions on how to run a specific Notebook from the command line, as some people might not know how to do so: https://github.com/jupyter/notebook/issues/3396

<img width="1186" alt="screen shot 2018-04-10 at 12 05 39 pm" src="https://user-images.githubusercontent.com/11889765/38568844-b69d7dc8-3cb7-11e8-9bce-8729e16ce066.png">
