### PR TITLE
Travis CI: Add Python 3.6 and 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: python
-sudo: false
 python:
-    - 3.5
     - 3.4
+    - 3.5
+    - 3.6
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+
 install:
     - pip install --upgrade pip
     - pip install --upgrade sphinx


### PR DESCRIPTION
* [Travis are now recommending removing __sudo__](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
* Add Python 3.6 to the testing
* [Add Python 3.7 to the testing](https://docs.travis-ci.com/user/languages/python/#development-releases-support)