### PR TITLE
logo aligns with sidebar

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -4,9 +4,9 @@
 {% set bootswatch_css_custom = ['_static/custom.css'] %}
 
 {% block relbar1 %}
-<div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px; width=100%; height=auto">
+<div class="container" style="background-color: white; text-align: left; padding: 10px 10px 15px 15px; width=100%; height=auto">
 <a href="{{ pathto('index') }}"><img src="{{
-pathto("_static/_images/jupyter.svg", 1) }}" border="0" alt="jupyter" width=600></a>
+pathto("_static/_images/jupyter.svg", 1) }}" border="0" alt="jupyter" width=200></a>
 </div>
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
This does two little things:

1. Adds the `container` class to the div in which the logo resides.
2. Makes the logo a bit smaller

The main effect is that the logo now lines up with the sidebar to the left. I think it's still big enough to be seen, but doesn't dominate the page as much.

Here's a screenshot of how it looks on my machine:

![image](https://user-images.githubusercontent.com/1839645/55183010-257faf00-514c-11e9-870f-54a50acd54f3.png)

What do folks think about it?

I think this closes https://github.com/jupyter/jupyter/issues/152 although I'm not sure about how it behaves on mobile etc