### PR TITLE
Integrate jupyter/help contributing guide

### DIFF
--- a/docs/source/developer-docs/contrib_first_time.rst
+++ b/docs/source/developer-docs/contrib_first_time.rst
@@ -1,0 +1,88 @@
+===============================
+Contributing for the First Time
+===============================
+
+.. contents:: Contents
+   :local:
+
+Welcome fellow contributor! We appreciate your help.
+
+We typically label issues appropriate for new contributors as ``good first
+issue`` or ``help wanted``.  To start an issue, you may comment to let everyone
+know that you'll be working on it.  Our repos typically provide development
+installation instructions in each repo's ``CONTRIBUTING.md`` or ``README.md``.
+**Should you find an issue with our development installation instructions please
+let us know in our issues.**  We want to ensure that our documentation for
+development installation is accurate.  Additionally, other contributors are
+often available to answer questions about fixing the issue on the issue number
+or on the repo's gitter channel.
+
+We strive to have a inclusive, welcoming community.  Please read our `code of
+conduct <https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`__
+to learn more.
+
+Major Repos and Issue Types
+===========================
+
+Python
+------
+
+IPython, nbgrader, JupyterHub, repo2docker, and Binder are major repos written primarily in Python.
+
+* `IPython <https://github.com/ipython/ipython>`__
+    * `Notable Issues <https://github.com/ipython/ipython/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__
+    * `Development Installation <https://github.com/ipython/ipython#development-and-instant-running>`__
+    * `Gitter Channel <https://gitter.im/ipython/ipython>`__
+* `nbgrader <https://github.com/jupyter/nbgrader>`__
+    * `Notable Issues <https://github.com/jupyter/nbgrader/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__
+    * `Development Installation <https://nbgrader.readthedocs.io/en/latest/contributor_guide/installation_developer.html>`__
+* `JupyterHub <https://github.com/jupyterhub/jupyterhub>`__
+    *  `Notable Issues <https://github.com/jupyterhub/jupyterhub/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__
+    *  `Development Installation <https://github.com/jupyterhub/jupyterhub#contributing>`__
+    * `Gitter Channel <https://gitter.im/jupyterhub/jupyterhub>`__
+* `repo2docker <https://github.com/jupyter/repo2docker>`__
+    *  `Notable Issues <https://github.com/jupyter/repo2docker/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__
+    * `Development Installation <https://github.com/jupyter/repo2docker#installation>`__
+    * `Gitter Channel <https://gitter.im/jupyterhub/jupyterhub>`__
+* `Binder <https://github.com/jupyterhub/binderhub>`__
+    * `Notable Issues <https://github.com/jupyterhub/binderhub/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22>`__
+    * `Development Installation <https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md>`__
+    * `Gitter Channel <https://gitter.im/jupyterhub/binder>`__
+  
+Documentation
+-------------
+
+All our repos have documentation issues that are relevant for new contributors. For example, the source
+for the documentation you are reading right now can be found in the `jupyter/jupyter repository on GitHub <https://github.com/jupyter/jupyter>`__.
+
+JavaScript/TypeScript
+---------------------
+
+Jupyter Notebook, JupyterLab, and IPyWidgets use JavaScript and TypeScript.
+
+* `Jupyter Notebook <https://github.com/jupyter/notebook>`__
+    * `Notable Issues <https://github.com/jupyter/notebook/issues?q=is%3Aissue+is%3Aopen+label%3A%22tag%3ANew+Contributor%22>`__
+    * `Development Installation <https://github.com/jupyter/notebook/blob/master/CONTRIBUTING.rst>`__
+    * `Gitter Channel <https://gitter.im/jupyter/notebook>`__
+* `JupyterLab <https://github.com/jupyterlab/jupyterlab>`__
+    * `Notable Issues <https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3AHelp+Wanted%22>`__
+    * `Development Installation <https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`__
+    * `Gitter Channel <https://gitter.im/jupyterlab/jupyterlab>`__
+* `IPyWidgets <https://github.com/jupyter-widgets/ipywidgets>`__
+    * `Notable Issues <https://github.com/jupyter-widgets/ipywidgets/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__
+    * `Development Instalation <https://ipywidgets.readthedocs.io/en/latest/dev_install.html>`__
+    * `Gitter Channel <https://gitter.im/jupyter-widgets/Lobby>`__
+
+DevOps
+------
+
+JupyterHub, repo2docker, and Binder have many issues related to devops.  See the links above.
+
+Web Development
+---------------
+
+We have issues related to the website.
+
+* `Project Jupyter's Website <https://github.com/jupyter/jupyter.github.io/>`__
+    * `Notable Issues <https://github.com/jupyter/jupyter.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Asprint-friendly>`__
+    * `Developer Installation <https://github.com/jupyter/jupyter.github.io#quick-local-testing>`__

--- a/docs/source/developer-docs/index.rst
+++ b/docs/source/developer-docs/index.rst
@@ -7,6 +7,7 @@ Developer Guide
 .. toctree::
    :maxdepth: 1
 
+   contrib_first_time.rst
    contrib_guide_code.rst
    contrib_guide_bugs_enh.rst
    jupyter_enhancement_proposals.rst

--- a/docs/source/development_guide/rest_api.rst
+++ b/docs/source/development_guide/rest_api.rst
@@ -222,7 +222,7 @@ This chart shows the architecture for the IPython notebook website.
 |            |                 | setings                                |
 +------------+-----------------+----------------------------------------+
 | ``GET``    | /<notebook\_id> | opens a duplicate copy or the notebook |
-|            | /copy           | with the given ID in a new tab       |
+|            | /copy           | with the given ID in a new tab         |
 +------------+-----------------+----------------------------------------+
 | ``GET``    | /<notebook\_id> | prints the notebook with the given ID; |
 |            | /print          | if notebook doesn't exist, displays    |


### PR DESCRIPTION
jupyter/help has been archived. This PR migrates the constributing.md file from the repo into this repo as a "first time" page in the developer contribution guide section of the site.

I made only minor fixes and did not attempt to remove redundant content at this time.

XRef: https://github.com/jupyter/jupyter.github.io/pull/330