### PR TITLE
issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,12 @@
+Welcome to the jupyter meta repository! 👋🏻
+
+This repository is the home of the Jupyter-wide documentation. However,
+it **not** the best place to ask questions about Jupyter.
+
+If you have a question or an issue about one of the tools in Jupyter,
+we recommend asking in the Jupyter community Discourse forum at the
+link below:
+
+https://discourse.jupyter.org
+
+Thanks!


### PR DESCRIPTION
adding an issue template that directs folks to the Discourse page. A lot of people seem to be asking generic Jupyter questions in the issues here, but there aren't that many 👀 on the repository so many aren't being answered. I think it'd be helpful if we directed folks to Discourse, which has more attention and would probably be more useful for people.