### PR TITLE
adding some resources on events

### DIFF
--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -68,10 +68,42 @@ Governance
 - Jupyter Enhancement Proposal (JEP) process: Details about the process can
   be found in the `jupyter/enhancement-proposals GitHub repo <https://github.com/jupyter/enhancement-proposals>`_.
 
+
 Code of conduct
 ---------------
 
 Information can be found in the `Jupyter Governance repo on GitHub <https://github.com/jupyter/governance>`_.
+
+
+Running Jupyter Events
+----------------------
+
+Members of the Jupyter community often get together to share what they're
+working on, to work together, and to teach and learn from one another.
+
+If you're organizing an event with the Jupyter community (whether it's as
+small as a JupyterDays meetup, or as large as JupyterCon) you should ensure
+that the event follows the values and goals of the Jupyter project - to be a
+place where *everyone* feels welcome and supported and that reflects the
+diversity of developers and users in the Jupyter community.
+
+If you're organizing a Jupyter event,
+here are some resources to have the best event possible.
+
+* The `Mozilla Open Events guide <https://foundation.mozilla.org/en/opportunity/open-events-guide/>`_.
+  This is an excellent resource for planning and running an open, inclusive
+  event. In particular, `this section on making events more inviting <https://foundation.mozilla.org/en/opportunity/open-events-guide/make-it-more-inviting/>`_
+  is a good way to make your event more welcoming, interesting, and accessible
+  to the Jupyter community.
+* The `NumFocus DISCOVER cookbook <https://discover-cookbook.numfocus.org/>`_
+  is another collection of resources for making your event more productive,
+  diverse, and inclusive.
+
+Ultimately, making events more inclusive is not rocket science and there is
+no magic bullet. It requires clear, focused dedication, planning ahead,
+and sustained resources and effort over time. However, we believe this effort
+is worth it!
+
 
 What is a Jovyan?
 -----------------

--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -87,17 +87,27 @@ that the event follows the values and goals of the Jupyter project - to be a
 place where *everyone* feels welcome and supported and that reflects the
 diversity of developers and users in the Jupyter community.
 
-If you're organizing a Jupyter event,
-here are some resources to have the best event possible.
+Shoot for having **25% of your participants come from under-represented
+groups**. If you're organizing a Jupyter event,
+here are some resources to help out.
 
-* The `Mozilla Open Events guide <https://foundation.mozilla.org/en/opportunity/open-events-guide/>`_.
+* **Mozilla** has a number of excellent resources on hosting open events.
+  The `Mozilla Open Events guide <https://foundation.mozilla.org/en/opportunity/open-events-guide/>`_.
   This is an excellent resource for planning and running an open, inclusive
   event. In particular, `this section on making events more inviting <https://foundation.mozilla.org/en/opportunity/open-events-guide/make-it-more-inviting/>`_
   is a good way to make your event more welcoming, interesting, and accessible
-  to the Jupyter community.
+  to the Jupyter community. Finally, the `Diversity and Inclusion wiki includes
+  conference calls related to this topic <https://wiki.mozilla.org/Diversity_and_Inclusion_for_Communities_and_Contributors>`_.
 * The `NumFocus DISCOVER cookbook <https://discover-cookbook.numfocus.org/>`_
   is another collection of resources for making your event more productive,
   diverse, and inclusive.
+* The `National Center for Women & Information Technology <https://www.ncwit.org/>`_ has an excellent
+  collection of resources for creating a diverse and inclusive environment. In
+  particular, we recommend their `Inclusive Environment Assessment Guide <https://www.ncwit.org/sites/default/files/file_type/ncwit_inclusiveenvironmentalassessment_guide.pdf>`_
+  and `10 actionable ways to actually increase diversity <https://www.ncwit.org/resources/10-actionable-ways-actually-increase-diversity-tech>`_.
+* The `PyCascades <https://pycascades.com>`_ community has `several efforts in improving diversity and inclusion <https://2019.pycascades.com/diversity-and-inclusion/>`_.
+* `Write the Docs <http://www.writethedocs.org/>`_ has a `Welcome Wagon Guide <https://www.writethedocs.org/organizer-guide/confs/welcome-wagon/>`_
+  to help first-time attendees feel welcome and included.
 
 Ultimately, making events more inclusive is not rocket science and there is
 no magic bullet. It requires clear, focused dedication, planning ahead,


### PR DESCRIPTION
I couldn't find any guidelines or resources for people hosting events within the Jupyter community, so this PR adds a short section in the "Community" documentation with references to resources for hosting inclusive, effective events.