### PR TITLE
Configure Transifex for initial en, es locales

### DIFF
--- a/docs/.tx/config
+++ b/docs/.tx/config
@@ -1,0 +1,2 @@
+[main]
+host = https://www.transifex.com

--- a/docs/.tx/config
+++ b/docs/.tx/config
@@ -1,2 +1,123 @@
-[main]
+[main-po--master]
 host = https://www.transifex.com
+
+[jupyter-meta-documentation.contrib_docs-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/contrib_docs.po
+source_file = source/locale/en/LC_MESSAGES/contrib_docs.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.releases-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/releases.po
+source_file = source/locale/en/LC_MESSAGES/releases.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.ipython-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/ipython.po
+source_file = source/locale/en/LC_MESSAGES/ipython.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.community-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/community.po
+source_file = source/locale/en/LC_MESSAGES/community.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.install-kernel-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/install-kernel.po
+source_file = source/locale/en/LC_MESSAGES/install-kernel.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.developer-docs-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/developer-docs.po
+source_file = source/locale/en/LC_MESSAGES/developer-docs.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.contributor-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/contributor.po
+source_file = source/locale/en/LC_MESSAGES/contributor.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.architecture-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/architecture.po
+source_file = source/locale/en/LC_MESSAGES/architecture.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.reference-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/reference.po
+source_file = source/locale/en/LC_MESSAGES/reference.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.install-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/install.po
+source_file = source/locale/en/LC_MESSAGES/install.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.projects-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/projects.po
+source_file = source/locale/en/LC_MESSAGES/projects.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.running-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/running.po
+source_file = source/locale/en/LC_MESSAGES/running.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.glossary-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/glossary.po
+source_file = source/locale/en/LC_MESSAGES/glossary.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.sphinx-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/sphinx.po
+source_file = source/locale/en/LC_MESSAGES/sphinx.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.content-quickstart-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/content-quickstart.po
+source_file = source/locale/en/LC_MESSAGES/content-quickstart.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.contents-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/contents.po
+source_file = source/locale/en/LC_MESSAGES/contents.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.tryjupyter-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/tryjupyter.po
+source_file = source/locale/en/LC_MESSAGES/tryjupyter.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.use-cases-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/use-cases.po
+source_file = source/locale/en/LC_MESSAGES/use-cases.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.development_guide-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/development_guide.po
+source_file = source/locale/en/LC_MESSAGES/development_guide.po
+source_lang = en
+type = PO
+
+[jupyter-meta-documentation.migrating-po--master]
+file_filter = source/locale/<lang>/LC_MESSAGES/migrating.po
+source_file = source/locale/en/LC_MESSAGES/migrating.po
+source_lang = en
+type = PO
+

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,9 +1,10 @@
 name: jupyter_docs
 dependencies:
-- python=3.5
-- sphinx_rtd_theme
-- pip:
-    - sphinx
-    - recommonmark
-    - nbsphinx
-    - jupyter_sphinx_theme==0.0.6
+  - python=3.7
+  - sphinx_rtd_theme
+  - pip:
+      - sphinx>=1.6
+      - sphinx-intl
+      - recommonmark==0.5.0
+      - nbsphinx
+      - jupyter_sphinx_theme==0.0.6

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,3 +170,8 @@ graphviz_output_format = 'svg'
 # graphviz_dot=r'c:\Program Files (x86)\Graphviz2.38\bin\dot.exe'
 # with your path to graphviz in should work if added to this file.
 # BUT Please do not commit with the path on your computer in place.
+
+# -- Translation ----------------------------------------------------------
+
+gettext_uuid = True
+locale_dirs = ['locale/']

--- a/docs/source/locale/en/LC_MESSAGES/architecture.po
+++ b/docs/source/locale/en/LC_MESSAGES/architecture.po
@@ -1,0 +1,252 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 0bc823304e0d4ab39f2774b29044df9b
+#: ../../source/architecture/content-architecture.rst:2
+msgid "Architecture Guides"
+msgstr ""
+
+# 8ce5c1bb3b244604b361cd2384066f68
+#: ../../source/architecture/how_jupyter_ipython_work.rst:2
+msgid "How IPython and Jupyter Notebook work"
+msgstr ""
+
+# 242c15d658d64a13a2b8b13502845298
+#: ../../source/architecture/how_jupyter_ipython_work.rst:5
+msgid "Contents"
+msgstr ""
+
+# a7b9fc6771f845528e8f7135c51754fa
+#: ../../source/architecture/how_jupyter_ipython_work.rst:8
+msgid "Abstract"
+msgstr ""
+
+# 3b9b38491da4493b95225b77bcd32438
+#: ../../source/architecture/how_jupyter_ipython_work.rst:9
+msgid ""
+"This section focuses on IPython and Jupyter notebook and how they "
+"interact. When we discuss ``IPython``, we talk about two fundamental "
+"roles:"
+msgstr ""
+
+# 676993980a9e4a9082f9f313e09af108
+#: ../../source/architecture/how_jupyter_ipython_work.rst:12
+msgid "Terminal IPython as the familiar REPL"
+msgstr ""
+
+# 5164fcd91a8a4700ac734562245773ad
+#: ../../source/architecture/how_jupyter_ipython_work.rst:13
+msgid ""
+"The IPython kernel that provides computation and communication with the "
+"frontend interfaces, like the notebook"
+msgstr ""
+
+# e79b4b9cf0d4461e8c91e35c54941346
+#: ../../source/architecture/how_jupyter_ipython_work.rst:16
+msgid ""
+"Jupyter Notebook and its flexible interface extends the notebook beyond "
+"code to visualization, multimedia, collaboration, and more."
+msgstr ""
+
+# f0e8484a13374e5ba11bc5673feecc30
+#: ../../source/architecture/how_jupyter_ipython_work.rst:20
+msgid "Terminal IPython"
+msgstr ""
+
+# d52946417b8a4a04a551622ce78e0c78
+#: ../../source/architecture/how_jupyter_ipython_work.rst:22
+msgid ""
+"When you type ``ipython``, you get the original IPython interface, "
+"running in the terminal. It does something like this::"
+msgstr ""
+
+# 9c51878d67554820815080da49295cb3
+#: ../../source/architecture/how_jupyter_ipython_work.rst:29
+msgid ""
+"Of course, it's much more complex, because it has to deal with multi-line"
+" code, tab completion using :mod:`readline`, magic commands, and so on. "
+"But the model is like code example: prompt the user for some code, and "
+"when they've entered it, execute it in the same process. This model is "
+"often called a :term:`REPL`, or Read-Eval-Print-Loop."
+msgstr ""
+
+# 6948d86fd4fd47a1a4ca54d29e72d46e
+#: ../../source/architecture/how_jupyter_ipython_work.rst:36
+msgid "The IPython Kernel"
+msgstr ""
+
+# 61f9b43b0f3148a1b6c8c770dbe95970
+#: ../../source/architecture/how_jupyter_ipython_work.rst:38
+msgid ""
+"All the other interfaces —- the Notebook, the Qt console, ``ipython "
+"console`` in the terminal, and third party interfaces —- use the IPython "
+"Kernel. The IPython Kernel is a separate process which is responsible for"
+" running user code, and things like computing possible completions. "
+"Frontends, like the notebook or the Qt console, communicate with the "
+"IPython Kernel using JSON messages sent over `ZeroMQ "
+"<http://zeromq.org/>`_ sockets; the protocol used between the frontends "
+"and the IPython Kernel is described in :ref:`jupyterclient:messaging`."
+msgstr ""
+
+# 6560f963da914c78b12c61e8795a9852
+#: ../../source/architecture/how_jupyter_ipython_work.rst:47
+msgid ""
+"The core execution machinery for the kernel is shared with terminal "
+"IPython:"
+msgstr ""
+
+# b5bd0a2f608542fe92f8b57ddcb9ea7b
+#: ../../source/architecture/how_jupyter_ipython_work.rst:51
+msgid ""
+"A kernel process can be connected to more than one frontend "
+"simultaneously. In this case, the different frontends will have access to"
+" the same variables."
+msgstr ""
+
+# 59dd6f3fbb4a46008c898b307aec5a25
+#: ../../source/architecture/how_jupyter_ipython_work.rst:56
+msgid ""
+"This design was intended to allow easy development of different frontends"
+" based on the same kernel, but it also made it possible to support new "
+"languages in the same frontends, by developing kernels in those "
+"languages, and we are refining IPython to make that more practical."
+msgstr ""
+
+# e35918a2fb124784a83c135812faf800
+#: ../../source/architecture/how_jupyter_ipython_work.rst:61
+msgid ""
+"Today, there are two ways to develop a kernel for another language. "
+"Wrapper kernels reuse the communications machinery from IPython, and "
+"implement only the core execution part. Native kernels implement "
+"execution and communications in the target language:"
+msgstr ""
+
+# 3395f44193b54f5cb9b9d380fa4a16bd
+#: ../../source/architecture/how_jupyter_ipython_work.rst:68
+msgid ""
+"Wrapper kernels are easier to write quickly for languages that have good "
+"Python wrappers, like `octave_kernel "
+"<https://pypi.python.org/pypi/octave_kernel>`_, or languages where it's "
+"impractical to implement the communications machinery, like `bash_kernel "
+"<https://pypi.python.org/pypi/bash_kernel>`_. Native kernels are likely "
+"to be better maintained by the community using them, like `IJulia "
+"<https://github.com/JuliaLang/IJulia.jl>`_ or `IHaskell "
+"<https://github.com/gibiansky/IHaskell>`_."
+msgstr ""
+
+# 59d8323c382a4adeb3d622424943b708
+#: ../../source/architecture/how_jupyter_ipython_work.rst:78
+msgid ":ref:`jupyterclient:kernels`"
+msgstr ""
+
+# 3418914ee39240879155089a0b29a69e
+#: ../../source/architecture/how_jupyter_ipython_work.rst:80
+msgid ":ref:`Kernels <kernels-langs>`"
+msgstr ""
+
+# 4866548d799b4cfc95159d7494d66afb
+#: ../../source/architecture/how_jupyter_ipython_work.rst:83
+msgid "Notebooks"
+msgstr ""
+
+# f414110d9cde4b048d6d4d0c65f274dd
+#: ../../source/architecture/how_jupyter_ipython_work.rst:85
+msgid ""
+"The Notebook frontend does something extra. In addition to running your "
+"code, it stores code and output, together with markdown notes, in an "
+"editable document called a notebook. When you save it, this is sent from "
+"your browser to the notebook server, which saves it on disk as a JSON "
+"file with a ``.ipynb`` extension."
+msgstr ""
+
+# ce4a6fb377344df295e9512b1d36743c
+#: ../../source/architecture/how_jupyter_ipython_work.rst:93
+msgid ""
+"The notebook server, not the kernel, is responsible for saving and "
+"loading notebooks, so you can edit notebooks even if you don't have the "
+"kernel for that language—you just won't be able to run code. The kernel "
+"doesn't know anything about the notebook document: it just gets sent "
+"cells of code to execute when the user runs them."
+msgstr ""
+
+# 9041dc2c7e0b46e19e1694f6bb081592
+#: ../../source/architecture/how_jupyter_ipython_work.rst:100
+msgid "Exporting notebooks to other formats"
+msgstr ""
+
+# dedd7458edfc44a99f423e2a9b8e1d93
+#: ../../source/architecture/how_jupyter_ipython_work.rst:102
+msgid ""
+"The Nbconvert tool in Jupyter converts notebook files to other formats, "
+"such as HTML, LaTeX, or reStructuredText. This conversion goes through a "
+"series of steps:"
+msgstr ""
+
+# 082ebb9d5777479da8f71672f538c484
+#: ../../source/architecture/how_jupyter_ipython_work.rst:108
+msgid ""
+"Preprocessors modify the notebook in memory. E.g. ExecutePreprocessor "
+"runs the code in the notebook and updates the output."
+msgstr ""
+
+# c6be8db7ca164f379d97800723004956
+#: ../../source/architecture/how_jupyter_ipython_work.rst:110
+msgid ""
+"An exporter converts the notebook to another file format. Most of the "
+"exporters use templates for this."
+msgstr ""
+
+# 9de2fa198489488fa316b950d1228fa3
+#: ../../source/architecture/how_jupyter_ipython_work.rst:112
+msgid "Postprocessors work on the file produced by exporting."
+msgstr ""
+
+# e00d7f3b870a40879882ee53ed417463
+#: ../../source/architecture/how_jupyter_ipython_work.rst:114
+msgid ""
+"The `nbviewer <http://nbviewer.jupyter.org/>`_ website uses nbconvert "
+"with the HTML exporter. When you give it a URL, it fetches the notebook "
+"from that URL, converts it to HTML, and serves that HTML to you."
+msgstr ""
+
+# e30efeea3614465f95ff49220796d182
+#: ../../source/architecture/how_jupyter_ipython_work.rst:119
+msgid "IPython.parallel"
+msgstr ""
+
+# 074d0dac254c44b58ea96c7b4a451d27
+#: ../../source/architecture/how_jupyter_ipython_work.rst:121
+msgid ""
+"IPython also includes a parallel computing framework, `IPython.parallel "
+"<https://ipyparallel.readthedocs.io/en/latest/>`_. This allows you to "
+"control many individual engines, which are an extended version of the "
+"IPython kernel described above."
+msgstr ""
+
+# 0118a72a2b1e4c14800c1c3dd77b6c4e
+#: ../../source/architecture/visual_overview.rst:2
+msgid "A Visual Overview of Projects"
+msgstr ""
+
+# cc1b649f66b949ebb3984ea361c9ee45
+#: ../../source/architecture/visual_overview.rst:4
+msgid "**A high level visual overview of project relationships**"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/community.po
+++ b/docs/source/locale/en/LC_MESSAGES/community.po
@@ -1,0 +1,419 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 70d1cfa46ec24e65819ddd4624a9ca6e
+#: ../../source/community/community-call-notes/2019-april.md:1
+msgid "All-Jupyter Community Video Call - April 2019"
+msgstr ""
+
+# 2f49975ac531463b8c6e2c761c400dc1
+#: ../../source/community/community-call-notes/2019-april.md:3
+msgid "Date: 30 April 2019 at 9am PST (your timezome)"
+msgstr ""
+
+# 3ff834bb5e6f4062bd88ace0a2863bdd
+# 4037dac263a44247abfb27d9873dd712
+#: ../../source/community/community-call-notes/2019-april.md:5
+#: ../../source/community/community-call-notes/2019-march.md:5
+msgid "Video-conference link: https://calpoly.zoom.us/my/jupyter"
+msgstr ""
+
+# 683dfa91bfde466eb4283e7adb0dd4d3
+# c7caa4e78e38454cb84d44620583084b
+#: ../../source/community/community-call-notes/2019-april.md:8
+#: ../../source/community/community-call-notes/2019-march.md:9
+msgid "Welcome to the Team Meeting"
+msgstr ""
+
+# 04d5ac5c03974dc3ad3024b473dd04b9
+# f796eb5b94c1489a9a5078a95e84a502
+# 678a64e0a30e4d9e8e37391ffb59c761
+#: ../../source/community/community-call-notes/2019-april.md:10
+#: ../../source/community/community-call-notes/2019-march.md:11
+#: ../../source/community/community-call-notes/2019-may.md:12
+msgid "Hello!"
+msgstr ""
+
+# 5f85661b1cfe4ac3973039ac4ba67b95
+# 4583925b76234b589f464156251e5ec0
+# bf9319f9db9a4d19970ee91c2740086f
+#: ../../source/community/community-call-notes/2019-april.md:12
+#: ../../source/community/community-call-notes/2019-march.md:13
+#: ../../source/community/community-call-notes/2019-may.md:34
+msgid ""
+"The purpose of these monthly video conference calls is to share and "
+"demonstrate the awesome things happening in Jupyter community. We invite "
+"anyone to present their work, engage in discussion, or just sit in and "
+"listen. Whether you have a new lab extension you've created, a new "
+"jupyterhub deployment you're excited about, or an nteract papermill "
+"pipeline powering your business, we'd love to hear about it! And, we'll  "
+"record and publish these calls on YouTube for anyone unable to attend."
+msgstr ""
+
+# eb8b2b49c8344b9c9f86af3e3bdd709d
+# 9bd556f607d047e8a63acd17380c885c
+# 60805fe9261f4111b779c3958058cd47
+#: ../../source/community/community-call-notes/2019-april.md:14
+#: ../../source/community/community-call-notes/2019-march.md:15
+#: ../../source/community/community-call-notes/2019-may.md:36
+msgid "For more discussion on the format of these calls, see the thread here."
+msgstr ""
+
+# 9b8670fc875040e7a301c3fa32fbc0cb
+# ee073abf726949b3b7548766058b87f9
+# 7463b23704b541d999d54d62cc43733c
+#: ../../source/community/community-call-notes/2019-april.md:16
+#: ../../source/community/community-call-notes/2019-march.md:17
+#: ../../source/community/community-call-notes/2019-may.md:38
+msgid "Short reports, celebrations, shout-outs"
+msgstr ""
+
+# b45b39d83ba8498b9e6e6201e0a0e1a3
+# 4d646269262148788ea6a42810d3598f
+# f9ba94f81af2444fb13543d874f67075
+#: ../../source/community/community-call-notes/2019-april.md:18
+#: ../../source/community/community-call-notes/2019-march.md:19
+#: ../../source/community/community-call-notes/2019-may.md:40
+msgid ""
+"This is a place to make short announcements (without a need for "
+"discussion). This is also a great place to give shout-outs to "
+"contributors! We’ll read through these at the beginning of the meeting."
+msgstr ""
+
+# 86e3c39710ba4d4687e570352ded4fa0
+# 9865f0ad138d4fe4a990ef00b514b730
+# 2a1e1ccf1a0c487da922d8dce791ffd1
+#: ../../source/community/community-call-notes/2019-april.md:32
+#: ../../source/community/community-call-notes/2019-march.md:30
+#: ../../source/community/community-call-notes/2019-may.md:48
+msgid "Agenda Items"
+msgstr ""
+
+# 53ec054add254945959fe787b4987fbb
+# 5797de76ce064ac98b3d80b2df943b4e
+#: ../../source/community/community-call-notes/2019-april.md:34
+#: ../../source/community/community-call-notes/2019-may.md:50
+msgid ""
+"Add your potential agenda item here 24 hours before the meeting at the "
+"latest. We will reorganize the agenda so that it fits in the 60m meeting "
+"slot."
+msgstr ""
+
+# bbf4c673748c458fbf4ee88129b415ab
+#: ../../source/community/community-call-notes/2019-april.md:82
+msgid "University of Edinburgh materials and contact:"
+msgstr ""
+
+# 83efbe0c91e740faa2548c87d0be912a
+# d1ad78f64d1e48d090bbcc353cade2c6
+#: ../../source/community/community-call-notes/2019-april.md:90
+#: ../../source/community/community-call-notes/2019-march.md:85
+msgid "In Attendance"
+msgstr ""
+
+# 42562fcb34704715bff217a5180cd439
+#: ../../source/community/community-call-notes/2019-april.md:92
+msgid "Name / Institution / Github Handle"
+msgstr ""
+
+# 286362fe622748019eea29d3a4524bfa
+#: ../../source/community/community-call-notes/2019-march.md:1
+msgid "All-Jupyter Community Video Call - March 2019"
+msgstr ""
+
+# d3ccd0d36a8d4ff9bf551dec59aa23bf
+#: ../../source/community/community-call-notes/2019-march.md:3
+msgid "Date: 26 March 2019 at 9am PST (your timezome)"
+msgstr ""
+
+# 2bae86b710b0411fa1380daeefcb57c4
+#: ../../source/community/community-call-notes/2019-march.md:7
+msgid "Link to prior meeting's virtual meeting report"
+msgstr ""
+
+# 9a919edea46042fda80ad5719ba42c25
+#: ../../source/community/community-call-notes/2019-march.md:83
+msgid "Don't get limitted to technical discusions !"
+msgstr ""
+
+# 6a1d536f3f6c46b2b79fcdecd6491c4c
+#: ../../source/community/community-call-notes/2019-march.md:87
+msgid "Name              | Institution             | Github Handle"
+msgstr ""
+
+# 67d530ac592947f79ea603b5ff446c15
+# b17fcf6338a54b82a41b9406cba398cb
+#: ../../source/community/community-call-notes/2019-may.md:1
+#: ../../source/community/community-call-notes/index.rst:5
+msgid "Jupyter Community Call"
+msgstr ""
+
+# 158d1e8d768f4477b23a3b164ca9655b
+#: ../../source/community/community-call-notes/2019-may.md:3
+msgid "May 28th, 2019"
+msgstr ""
+
+# 12428c2c96ec4c04aefe1b9d747f88d9
+#: ../../source/community/community-call-notes/2019-may.md:5
+msgid "Date: 28 May 2019 at 9am PST (your timezome)"
+msgstr ""
+
+# 79384d54cd5e4953a63c65329e467e2c
+#: ../../source/community/community-call-notes/2019-may.md:7
+msgid "Link: Youtube Video"
+msgstr ""
+
+# 34838ee2bdd046babf35699d0a2b17d3
+#: ../../source/community/community-call-notes/2019-may.md:10
+msgid "Welcome to the All-Jupyter Community Meeting"
+msgstr ""
+
+# 1ba7041adbf8498ebcaf7bfa6b1be2ed
+#: ../../source/community/community-call-notes/2019-may.md:14
+msgid ""
+"If you are joining the All-Jupyter Community video meeting, sign in below"
+" so we know who was here. Roll call:"
+msgstr ""
+
+# 087428f3c619458ab1215faa7725bfb7
+#: ../../source/community/community-call-notes/2019-may.md:32
+msgid "Purpose"
+msgstr ""
+
+# 2bdfad80e4bc4c62a0f6f6a24e0fd7f2
+#: ../../source/community/community-call-notes/index.rst:7
+msgid ""
+"The Jupyter Community Call is an open video call. Think of this as a "
+"\"monthly, virtual JupyterCon\". It's a place for *anyone* to announce "
+"and share fun things happening in the Jupyter community. Everyone is "
+"welcome (even if you're not presenting). We record these videos and post "
+"them on YouTube. For more information, `read this discourse thread "
+"<https://discourse.jupyter.org/t/all-jupyter-community-calls/668>`__."
+msgstr ""
+
+# 1267e686bd0d4b039cedfdb4f29dd262
+#: ../../source/community/community-call-notes/index.rst:9
+msgid "**Previous Community Calls**"
+msgstr ""
+
+# ba90bd9d9ad94b8c98e873ac5b4431e6
+#: ../../source/community/content-community.rst:5
+msgid "Community Guides"
+msgstr ""
+
+# d54af2f83db8471499576db794d43eb0
+#: ../../source/community/content-community.rst:8
+msgid ""
+"Welcome to the Community Guides for Jupyter. These guides are intended to"
+" provide information about the Jupyter community such as background, "
+"events, and communication channels. As our community is highly dynamic, "
+"information may change, and we will do our best to keep it up to date."
+msgstr ""
+
+# ddb34dc7214346588c43db31dd75a02c
+#: ../../source/community/content-community.rst:15
+msgid "Monthly Meetings"
+msgstr ""
+
+# 1619503c14774902b78d65ca9b79d141
+#: ../../source/community/content-community.rst:17
+msgid ""
+"The core developers of various Jupyter sub-projects have regular meetings"
+" to discuss and demo what they have been working on, discuss future "
+"plans, and bootstrap conversation. These meetings are public and you are "
+"welcome to join remotely."
+msgstr ""
+
+# f34a0721b4874356a8ac819e93fef795
+#: ../../source/community/content-community.rst:21
+msgid ""
+"Each team has their own processes around logistics and planning for the "
+"team meetings. The following pages should help you find the information "
+"for each."
+msgstr ""
+
+# e191ff6ab041422b94c082b8194f1bb5
+#: ../../source/community/content-community.rst:24
+msgid ""
+"**All-Jupyter Community Calls** happen on the last Tuesday of every "
+"month, and are focused around demonstrations and sharing information "
+"across all of the Jupyter projects."
+msgstr ""
+
+# bab41d17142c4f01a84e8931031ef15b
+#: ../../source/community/content-community.rst:27
+msgid ""
+"Find information on `this Discourse thread "
+"<https://discourse.jupyter.org/t/all-jupyter-community-calls/668>`_."
+msgstr ""
+
+# b14012ac8c7d4f7d9b1fa40ad998d8a5
+#: ../../source/community/content-community.rst:28
+msgid ""
+"Watch previous calls on `our YouTube channel "
+"<https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP>`_."
+msgstr ""
+
+# 94fd509d19b04c98ac0e82a0aa3003aa
+#: ../../source/community/content-community.rst:29
+msgid "Read the `notes from previous calls <community-call-notes/index.html>`_."
+msgstr ""
+
+# b6c188f529e043bb8740f19fad6db3a2
+#: ../../source/community/content-community.rst:32
+msgid ""
+"**JupyterHub meetings** happen monthly. For a calendar of future team "
+"meetings, see `the JupyterHub team compass repository <https"
+"://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html>`_."
+msgstr ""
+
+# d87217c537f04a3e94fee9b03871ddb8
+#: ../../source/community/content-community.rst:35
+msgid ""
+"**JupyterLab meetings** happen weekly. For more information about when "
+"these meetings happen, as well as notes from each meeting, see `the "
+"JupyterLab README <https://github.com/jupyterlab/jupyterlab#weekly-dev-"
+"meeting>`_."
+msgstr ""
+
+# 5cb8eb65c5d342cb82cd6e06b515c4bb
+#: ../../source/community/content-community.rst:38
+msgid ""
+"**General meeting conversation and planning** often happens in the `dev-"
+"meeting-attendance Gitter channel <https://gitter.im/jupyter/dev-meeting-"
+"attendance>`_. We recommend checking it periodically for new information "
+"about when meetings are happening."
+msgstr ""
+
+# 85d662482e654ca8a60eb03ea3c16a49
+#: ../../source/community/content-community.rst:47
+msgid "Jupyter communications"
+msgstr ""
+
+# af1931399f504fde9b5c379ab97c3788
+#: ../../source/community/content-community.rst:49
+msgid ""
+"As a general rule, most project-wide conversation happens in the `Jupyter"
+" community forum <https://discourse.jupyter.org>`_. There are also many "
+"other kinds of communication that happens within the community. See below"
+" for links and other relevant information."
+msgstr ""
+
+# 2c02c8ede4514562b849edfba6bcc50e
+#: ../../source/community/content-community.rst:54
+msgid "Community forum `<https://discourse.jupyter.org/>`_"
+msgstr ""
+
+# fb525140606947bebc38796903ee7659
+#: ../../source/community/content-community.rst:55
+msgid "Blog `<https://blog.jupyter.org/>`_"
+msgstr ""
+
+# 64fab8ffafb24a7bb060d4359ec04feb
+#: ../../source/community/content-community.rst:56
+msgid "Newsletter `<https://newsletter.jupyter.org/>`_"
+msgstr ""
+
+# ef8f773e0424467eb83e939805663888
+#: ../../source/community/content-community.rst:57
+msgid "Website `<https://jupyter.org>`_"
+msgstr ""
+
+# 8e575a689ab845919c525a57feacbdb3
+#: ../../source/community/content-community.rst:58
+msgid "Twitter `<https://twitter.com/ProjectJupyter>`_"
+msgstr ""
+
+# 80103b709d94489da4c958855044ce23
+#: ../../source/community/content-community.rst:59
+msgid "Gitter `<https://gitter.im/jupyter/jupyter>`_"
+msgstr ""
+
+# dd12e64a1c6242688e11b1e72d4b7d17
+#: ../../source/community/content-community.rst:60
+msgid ""
+"Mailing lists (Jupyter, Jupyter in Education) "
+"`<https://jupyter.org/community.html>`_"
+msgstr ""
+
+# d8926bc097014aa68efb0246f0e69e7e
+#: ../../source/community/content-community.rst:64
+msgid "Governance"
+msgstr ""
+
+# 415a23b6140845c1b39b127b61a35e6e
+#: ../../source/community/content-community.rst:66
+msgid ""
+"Steering council: Information about the steering council and its members "
+"can be found on the `Jupyter website <https://jupyter.org>`_."
+msgstr ""
+
+# 9849b1d2be9949b790f8d9cb251e7531
+#: ../../source/community/content-community.rst:68
+msgid ""
+"Jupyter Enhancement Proposal (JEP) process: Details about the process can"
+" be found in the `jupyter/enhancement-proposals GitHub repo "
+"<https://github.com/jupyter/enhancement-proposals>`_."
+msgstr ""
+
+# 03da538fdae3452f9e7fa72740db23a8
+#: ../../source/community/content-community.rst:72
+msgid "Code of conduct"
+msgstr ""
+
+# b6254391831147a4afcef3c22844e45c
+#: ../../source/community/content-community.rst:74
+msgid ""
+"Information can be found in the `Jupyter Governance repo on GitHub "
+"<https://github.com/jupyter/governance>`_."
+msgstr ""
+
+# 4546949c9a144a1298252a5bd089279d
+#: ../../source/community/content-community.rst:77
+msgid "What is a Jovyan?"
+msgstr ""
+
+# c1508a5151854f74bf4c8deb7fde2c73
+#: ../../source/community/content-community.rst:79
+msgid ""
+"You may see the word **Jovyan** used in Jupyter tools (such as the user "
+"ID in the `Jupyter Docker stacks <https://github.com/jupyter/docker-"
+"stacks?`_ or referenced in conversations. But what is a Jovyan?"
+msgstr ""
+
+# 7a43f41ad815452bb5df25efb5a039bb
+#: ../../source/community/content-community.rst:83
+msgid ""
+"In astronomical terms, the word \"Jovian\" means \"like Jupiter\". It "
+"describes `several planets that share Jupyter-like properties "
+"<https://www.universetoday.com/33061/what-are-the-jovian-planets/>`_."
+msgstr ""
+
+# 5f92f3a419da4e1aa815eb1ce1929306
+#: ../../source/community/content-community.rst:86
+msgid ""
+"Much like the planet Jupiter and our solar system, the Jupyter community "
+"is large, distributed, and nebulous. We like to use the word **Jovyan** "
+"to describe members of this community. Jovyans are fellow open "
+"enthusiasts that use, develop, promote, teach, learn, and otherwise enjoy"
+" tools in Jupyter's orbit. They make up the Jupyter community. If you're "
+"not sure whether you're a Jovyan, you probably are :-)"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/content-quickstart.po
+++ b/docs/source/locale/en/LC_MESSAGES/content-quickstart.po
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 313dee758bfc43d485397132ce7413a0
+#: ../../source/content-quickstart.rst:2
+msgid "Jupyter Notebook Quickstart"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/contents.po
+++ b/docs/source/locale/en/LC_MESSAGES/contents.po
@@ -1,0 +1,137 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 33435e4f8e8e4d108f3ee03172fbca55
+#: ../../source/contents.rst:3
+msgid "Project Jupyter and IPython"
+msgstr ""
+
+# a8847d2993b84d8a80a23f7807c1aff3
+#: ../../source/contents.rst:5
+msgid "**Table of Contents**"
+msgstr ""
+
+# 7d38cf5fdf954c39a2fe68592724bc41
+#: ../../source/contents.rst:67
+msgid "Indices and tables"
+msgstr ""
+
+# 289ae6113b3f4c9eb1d29b8e2c8fb24d
+#: ../../source/contents.rst:69
+msgid ":ref:`genindex`"
+msgstr ""
+
+# 6421140cb92e40758c79f76b99f3e96f
+#: ../../source/contents.rst:70
+msgid ":ref:`glossary`"
+msgstr ""
+
+# a18e0af2c678400f9984da4463c144d0
+#: ../../source/contents.rst:71
+msgid ":ref:`search`"
+msgstr ""
+
+# 03b4d1007ed14d4d910b6c03fd6fd9f2
+#: ../../source/contents.rst:74
+msgid "**Resources:**"
+msgstr ""
+
+# 548ecdd6f5484efa80f8a2b05e4ef451
+#: ../../source/contents.rst:1
+msgid "Site"
+msgstr ""
+
+# 0ff92b1d24764e81957e7d1fc8ff8d9f
+#: ../../source/contents.rst:1
+msgid "Description"
+msgstr ""
+
+# 83e11f238d834561af6f97697b27f6fb
+#: ../../source/contents.rst:1
+msgid "`Jupyter website <https://jupyter.org>`_"
+msgstr ""
+
+# 920fa49c6db7411983595935f7e92f3e
+#: ../../source/contents.rst:1
+msgid "Keep up to date on Jupyter"
+msgstr ""
+
+# 30a274f35cf2474797945a935da85cb4
+#: ../../source/contents.rst:1
+msgid "`IPython website <https://ipython.org>`_"
+msgstr ""
+
+# 88231b674ec542179be7c7445ec8583b
+#: ../../source/contents.rst:1
+msgid "Learn more about IPython"
+msgstr ""
+
+# b8c70c9438f644118a68109f5eba874e
+#: ../../source/contents.rst:1
+msgid "`jupyter/help repo <https://github.com/jupyter/help>`_"
+msgstr ""
+
+# 72da60819619401b9a96f5504ba59c97
+#: ../../source/contents.rst:1
+msgid "Start here for help and support questions"
+msgstr ""
+
+# 0dc8121fb6244c189d0104edd3a0ad5d
+#: ../../source/contents.rst:1
+msgid "`Jupyter mailing list <https://groups.google.com/forum/#!forum/jupyter>`_"
+msgstr ""
+
+# cbdb33adaed94934807dd96aad51d04c
+#: ../../source/contents.rst:1
+msgid "General discussion of Jupyter's use"
+msgstr ""
+
+# 90cd4bd7587a41baaa4fe9b254e06b73
+#: ../../source/contents.rst:1
+msgid ""
+"`Jupyter in Education group <https://groups.google.com/forum/#!forum"
+"/jupyter-education>`_"
+msgstr ""
+
+# a53a7f1c3e0542529b17ea18db13af07
+#: ../../source/contents.rst:1
+msgid "Discussion of Jupyter's use in education"
+msgstr ""
+
+# be4502efd1b8405f9006fcc3b8d830f7
+#: ../../source/contents.rst:1
+msgid "`NumFocus <http://www.numfocus.org>`_"
+msgstr ""
+
+# aad8855017f4495b9d094b28d9a17a7c
+#: ../../source/contents.rst:1
+msgid "Promotes world-class, innovative, open source scientific software"
+msgstr ""
+
+# af4b1ede6ede498c982e94e44261c974
+#: ../../source/contents.rst:1
+msgid "`Donate to Project Jupyter <https://jupyter.org/donate.html>`_"
+msgstr ""
+
+# 46564fbd685543a9a25fb09fe204970a
+#: ../../source/contents.rst:1
+msgid "Please contribute to open science collaboration and sustainability"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/contrib_docs.po
+++ b/docs/source/locale/en/LC_MESSAGES/contrib_docs.po
@@ -1,0 +1,676 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 8951f6f4ecb1413bbb04b398218015c5
+#: ../../source/contrib_docs/doc-future-index.rst:2
+msgid "Setting up a project's documentation infrastructure"
+msgstr ""
+
+# 7cdfc8fab5b84b2a888d19fbfe55aa37
+#: ../../source/contrib_docs/doc-future-index.rst:4
+msgid "Contents:"
+msgstr ""
+
+# 1bde3a53c29249958887df3f45554bdf
+#: ../../source/contrib_docs/doc-future-index.rst:13
+msgid ""
+"This section helps a contributor set up the documentation infrastructure "
+"for a new project or an existing project without Sphinx documentation."
+msgstr ""
+
+# 232486a6287c412b99f0022d6d84e90a
+#: ../../source/contrib_docs/doc-new-build.md:1
+msgid "Building automatically on ReadTheDocs"
+msgstr ""
+
+# fbc01acaa56d459985a5988de5128194
+#: ../../source/contrib_docs/doc-new-build.md:3
+msgid ""
+"This explains how to automatically rebuild documentation on ReadtheDocs "
+"every time a pull request is merged into its corresponding GitHub repo."
+msgstr ""
+
+# 27905f3382e1420588048c37cb32d617
+#: ../../source/contrib_docs/doc-new-build.md:6
+msgid "Using the ReadTheDocs service"
+msgstr ""
+
+# 548f76347eeb494da8083cb3c13d39f2
+#: ../../source/contrib_docs/doc-new-build.md:8
+msgid ""
+"Webhooks and services can be enabled in GitHub repo settings to allow "
+"third party services such as ReadTheDocs. The ReadTheDocs service "
+"rebuilds the project documentation whenever a pull request is merged into"
+" the GitHub repo."
+msgstr ""
+
+# 1ff476bad0cf4c0bab9ba8c06d1af401
+#: ../../source/contrib_docs/doc-new-build.md:12
+msgid "Navigate to Settings"
+msgstr ""
+
+# c3fb69257cb4414f8c0b7af8054e4811
+#: ../../source/contrib_docs/doc-new-build.md:14
+msgid ""
+"Each GitHub repo has a Settings tab at the far right of the repo menubar."
+" Navigate to Settings and then the Webhooks & services submenu tab."
+msgstr ""
+
+# 3dedea5f462f482580216a01d0730972
+#: ../../source/contrib_docs/doc-new-build.md:16
+msgid "Settings and Webhooks & services submenu"
+msgstr ""
+
+# e1791743951046f796933c3014462134
+#: ../../source/contrib_docs/doc-new-build.md:18
+msgid "Add the ReadTheDocs service"
+msgstr ""
+
+# b492918cb93240ed8719e6876a9ef1d9
+#: ../../source/contrib_docs/doc-new-build.md:20
+msgid ""
+"Select Add service and enter ReadTheDocs in the Available Services input "
+"box."
+msgstr ""
+
+# 55a4fff635a5445fb6d765c4e40ce046
+#: ../../source/contrib_docs/doc-new-build.md:22
+msgid ""
+"The Services/Add ReadTheDocs window will open. Press the green Add "
+"service button to activate the ReadTheDocs service."
+msgstr ""
+
+# 505867437b214d4f812e8fb9b70ca0d9
+#: ../../source/contrib_docs/doc-new-build.md:24
+msgid "Add ReadTheDocs service"
+msgstr ""
+
+# 112b55c373134049a1fc640695b3799e
+#: ../../source/contrib_docs/doc-new-build.md:26
+msgid "Success"
+msgstr ""
+
+# f38a664a1d164422ae6a4aa7b3d5bb50
+#: ../../source/contrib_docs/doc-new-build.md:28
+msgid ""
+"The ReadTheDocs service is added successfully. The service will take "
+"effect on the next merged pull request to the project repo."
+msgstr ""
+
+# 4012a2bd5b4a452aa2bc78013a0ae401
+#: ../../source/contrib_docs/doc-new-build.md:30
+msgid "Service successfully added"
+msgstr ""
+
+# c03788a9bdba433c9198fb72eaf07450
+#: ../../source/contrib_docs/doc-new-build.md:33
+msgid "Created: 01-07-2016"
+msgstr ""
+
+# 64bec8ddf86a46e3be1010335ab3b857
+#: ../../source/contrib_docs/doc-new-repos.md:1
+msgid "Setting up a README"
+msgstr ""
+
+# d22ac7f8b0574e0493a17b325c369177
+#: ../../source/contrib_docs/doc-new-repos.md:3
+msgid ""
+"Providing users and developers consistency across repos is a valuable "
+"time saver and improves user productivity."
+msgstr ""
+
+# f3c2890b764d4be989a58f23591ac8f4
+#: ../../source/contrib_docs/doc-new-repos.md:6
+msgid ""
+"On a larger scope, having the Jupyter name appear prominently in a repo's"
+" README.md file improves the project's name awareness."
+msgstr ""
+
+# 36da1d4b745446a184f24d86860ee5cf
+#: ../../source/contrib_docs/doc-new-repos.md:9
+msgid "Recommended elements in Jupyter project repos"
+msgstr ""
+
+# d7ed0a7e260844f3929c586a5bcec7d6
+#: ../../source/contrib_docs/doc-new-repos.md:11
+msgid "Link in repo description"
+msgstr ""
+
+# 3188a81d5e804531bc59f4fc56d45db5
+#: ../../source/contrib_docs/doc-new-repos.md:12
+msgid "Please include a link to the documentation in the repo's description."
+msgstr ""
+
+# 7077cfb8652645adb68f9d5bf15d8c2b
+#: ../../source/contrib_docs/doc-new-repos.md:14
+msgid "Repo description and documentation link"
+msgstr ""
+
+# 362deb326ee04287888a851b40b75f26
+#: ../../source/contrib_docs/doc-new-repos.md:16
+msgid "Badges in README"
+msgstr ""
+
+# ac386bdd61694670af3624cef2c354fa
+#: ../../source/contrib_docs/doc-new-repos.md:17
+msgid ""
+"One common way that individuals find documentation is to look for and "
+"click on the doc badge that commonly is found right after the title. "
+"Another benefit is an easy visual indication if the docs are not "
+"rendering properly."
+msgstr ""
+
+# b7335017aa17487d8a3e44cbdc89d333
+#: ../../source/contrib_docs/doc-new-repos.md:21
+msgid "Badges in README.md"
+msgstr ""
+
+# 16fc8f66cf7b406b8c2876ba146d5761
+#: ../../source/contrib_docs/doc-new-repos.md:23
+msgid "Resources section in README"
+msgstr ""
+
+# 85c29f39bd9e4b7b9148b6d98300bf75
+#: ../../source/contrib_docs/doc-new-repos.md:25
+msgid ""
+"A Resources section at the end of the README.md gives useful links and "
+"information to users about the individual project and the larger Project "
+"Jupyter organization. Make sure to include any links to the individual "
+"project's demo notebooks, if available."
+msgstr ""
+
+# e3415ff12b4b44e49f2851fb583115a4
+#: ../../source/contrib_docs/doc-new-repos.md:30
+msgid "The Resources section includes:"
+msgstr ""
+
+# bbd10f86669b4c6fb425b08981536b35
+#: ../../source/contrib_docs/doc-new-repos.md:32
+msgid "Resources section in"
+msgstr ""
+
+# 49575d164ce8451592d3bc3717307aa3
+#: ../../source/contrib_docs/doc-new-repos.md:35
+msgid "Checklist adding docs to a new or existing GitHub Repo"
+msgstr ""
+
+# 335e33a3a2ec4b8994a769c697be5039
+#: ../../source/contrib_docs/doc-new-repos.md:42
+msgid "Dated: 1-4-2016 Revised: 1-7-2016"
+msgstr ""
+
+# 7f017745d5c34b3f91c54f653b2793d1
+#: ../../source/contrib_docs/doc-tools.rst:2
+msgid "Tools for documentation"
+msgstr ""
+
+# f82aa18212984518ac1371f956fc5f12
+# 0e6a4fd1bdd7427dbc0d45d78f5cd710
+#: ../../source/contrib_docs/doc-tools.rst:5
+#: ../../source/contrib_docs/getting-started.rst:5
+msgid "Contents"
+msgstr ""
+
+# 70ea135c1ab44fbba9a46a8f7992d014
+#: ../../source/contrib_docs/doc-tools.rst:8
+msgid "Packages"
+msgstr ""
+
+# 0cd99c51dc1344f2a28d229978446fdb
+#: ../../source/contrib_docs/doc-tools.rst:9
+msgid ""
+"For user documentation, contributor guides, and communications content, "
+"we use:"
+msgstr ""
+
+# e4db7b119bc747ab932bd5b9475de798
+#: ../../source/contrib_docs/doc-tools.rst:12
+msgid "`Sphinx <http://www.sphinx-doc.org/en/stable>`_"
+msgstr ""
+
+# 89cb08a083b7405b899da55da2c386dc
+#: ../../source/contrib_docs/doc-tools.rst:14
+msgid ""
+"For developer API documentation (especially for JupyterLab js repos), we "
+"use:"
+msgstr ""
+
+# 66229f6c114e4652b13bd066643cae2a
+#: ../../source/contrib_docs/doc-tools.rst:16
+msgid "`swagger <http://swagger.io/>`_"
+msgstr ""
+
+# 4241f08f75b745cc91401487dfb43473
+#: ../../source/contrib_docs/doc-tools.rst:19
+msgid "Source file formats"
+msgstr ""
+
+# 0e502ec731f24f729b096c7ef2aac637
+#: ../../source/contrib_docs/doc-tools.rst:20
+msgid ""
+"We use the following input source file formats when developing Sphinx "
+"documentation:"
+msgstr ""
+
+# c35638daf71349ab94f174d9c40088fa
+#: ../../source/contrib_docs/doc-tools.rst:23
+msgid "reStructuredText (``.rst``)"
+msgstr ""
+
+# 31a7dcfa85f545308ff3c24f7f5fa6da
+#: ../../source/contrib_docs/doc-tools.rst:24
+msgid "Markdown (``.md``)"
+msgstr ""
+
+# 99f22d7ed28e4ec6b6739ab4d3b0fca1
+#: ../../source/contrib_docs/doc-tools.rst:25
+msgid "Notebook (``.ipynb``)"
+msgstr ""
+
+# 6bc8c61685c94741b9a52990ac840a31
+#: ../../source/contrib_docs/doc-tools.rst:27
+msgid ""
+"A modern code editor should be used. Many are available including Atom, "
+"SublimeText, gedit, vim, emacs. `Atom <https://atom.io/>`_ is a good "
+"choice for new contributors."
+msgstr ""
+
+# 36d19549dd2e4365a6c5e8e035cd54c6
+#: ../../source/contrib_docs/doc-tools.rst:32
+msgid "Sphinx themes"
+msgstr ""
+
+# 1eb43a99bb26411382f63038cc477cee
+#: ../../source/contrib_docs/doc-tools.rst:33
+msgid "Our projects use the following themes:"
+msgstr ""
+
+# 29670e07c5044935b15456980e34fae1
+#: ../../source/contrib_docs/doc-tools.rst:35
+msgid "sphinx_rtd_theme (currently used by Jupyter projects)"
+msgstr ""
+
+# f9cd1912e9bc4bd79e22274b5ce9acdf
+#: ../../source/contrib_docs/doc-tools.rst:36
+msgid "jupyter_sphinx_theme (used by ipywidgets)"
+msgstr ""
+
+# d987578c0b164c1ba1296f4b300cac54
+#: ../../source/contrib_docs/doc-tools.rst:39
+msgid "Git and Github Resources"
+msgstr ""
+
+# 50b964b050404597b31edeb7431ffb85
+#: ../../source/contrib_docs/doc-tools.rst:40
+msgid ""
+"If this is your first time working with Github or git, you can leverage "
+"the following resources to learn about the tools."
+msgstr ""
+
+# 0b58d8ea7318429ba17fb25d493dbe11
+#: ../../source/contrib_docs/doc-tools.rst:43
+msgid "`Try Git  <https://try.github.io/levels/1/challenges/1>`_"
+msgstr ""
+
+# 319d5b76f66a42d3894269987178b99c
+#: ../../source/contrib_docs/doc-tools.rst:44
+msgid "`Github Guides  <https://guides.github.com>`_"
+msgstr ""
+
+# 3b0ab86be2604595be117b97ae517309
+#: ../../source/contrib_docs/doc-tools.rst:45
+msgid "`Git Real  <https://www.codeschool.com/courses/git-real>`_"
+msgstr ""
+
+# 9bf487d7abfc44c3ab65fc60610916db
+#: ../../source/contrib_docs/doc-tools.rst:46
+msgid "`Git Documentation <https://git-scm.com/documentation>`_"
+msgstr ""
+
+# 6f130c2608c74cd481206a5302ce6ab4
+#: ../../source/contrib_docs/doc-tools.rst:47
+msgid ""
+"`Git Rebase <https://github.com/pydata/pandas/wiki/Git-Workflows#user-"
+"content-git-rebase>`_"
+msgstr ""
+
+# 73369309d0264c91801dadff4096eda3
+#: ../../source/contrib_docs/doc-workflow.rst:2
+msgid "Understanding our workflow"
+msgstr ""
+
+# 3ad46563bdea4c718af906b06996645d
+#: ../../source/contrib_docs/doc-workflow.rst:4
+msgid "**High level documentation workflow**"
+msgstr ""
+
+# bea011364bb5447f9a5ee2e0a1813bb7
+#: ../../source/contrib_docs/doc-workflow.rst:6
+msgid "Identify a documentation change."
+msgstr ""
+
+# 0ecc5172dfa9449bb3fd7ddee5ab7a8f
+#: ../../source/contrib_docs/doc-workflow.rst:8
+msgid "*Typos:* please go ahead and fix it (or report as a bug)."
+msgstr ""
+
+# d2eec42d01aa43c49c9f599c56cf67f7
+#: ../../source/contrib_docs/doc-workflow.rst:9
+msgid ""
+"*Open issues:* leave a note in the issue comments that you are working on"
+" the issue."
+msgstr ""
+
+# 5594fd91be4844ba8361a65dfea30f57
+#: ../../source/contrib_docs/doc-workflow.rst:11
+msgid ""
+"*New documentation:* open an issue with your idea or suggestion. We'll "
+"review the issue and work with you to identify next steps."
+msgstr ""
+
+# df7b4d15c41f4003b695a2e4ba5f9257
+#: ../../source/contrib_docs/doc-workflow.rst:14
+msgid "Update the source file."
+msgstr ""
+
+# 0a600b26d0214280b77a6ae44f71294f
+#: ../../source/contrib_docs/doc-workflow.rst:16
+msgid "Commit the change."
+msgstr ""
+
+# 241782c238de4ebeb594ebe6cc2fe7a6
+#: ../../source/contrib_docs/doc-workflow.rst:18
+msgid "Test changes locally."
+msgstr ""
+
+# b8f4ff91d74f453e8e4c680f537967de
+#: ../../source/contrib_docs/doc-workflow.rst:20
+msgid "Open a pull request."
+msgstr ""
+
+# e943c50580c64ecaa32dd38a2ac2f8e2
+#: ../../source/contrib_docs/doc-workflow.rst:22
+msgid "Check response of automated tests."
+msgstr ""
+
+# 47edb06fb3c0469f87b591aa0e30925c
+#: ../../source/contrib_docs/doc-workflow.rst:24
+msgid ""
+"If tests pass: Nice job. Wait for reviewer feedback and/ or your pull "
+"request to be merged."
+msgstr ""
+
+# 6b9c7c1cbd7d4772a778cc9c2f33a0d4
+#: ../../source/contrib_docs/doc-workflow.rst:27
+msgid ""
+"If tests show an error: Revise and resubmit your pull request. You do not"
+" need to open a new pull request. If needed, please ask for assistance."
+msgstr ""
+
+# 6c100a83bc8547909df09e2de4fa16f2
+#: ../../source/contrib_docs/doc-workflow.rst:31
+msgid "Celebrate your documentation contribution."
+msgstr ""
+
+# 7f491e4696da4e01af2e68b97352a3f4
+#: ../../source/contrib_docs/doc-workflow.rst:33
+msgid ""
+"Repeat. If you would like suggestions for a new documentation issue to "
+"work on, please ask."
+msgstr ""
+
+# 4837ec4c20d84023875b77de40950374
+#: ../../source/contrib_docs/doc-workflow.rst:37
+msgid "Thanks for contributing!"
+msgstr ""
+
+# 96f8c8d5bd6b48b79a6fbfdadfe293b9
+#: ../../source/contrib_docs/getting-started.rst:2
+msgid "Getting started"
+msgstr ""
+
+# 41b8445aaef14b0f9277132ef8f7c64d
+#: ../../source/contrib_docs/getting-started.rst:8
+msgid "Preparing for your first contribution"
+msgstr ""
+
+# 5ff1615eb97f4322bc6b824fe2975e78
+#: ../../source/contrib_docs/getting-started.rst:9
+msgid "Our documentation uses reStructured Text as well as Jupyter notebooks."
+msgstr ""
+
+# 4f862af8ce2648e6a6f36a65f166c17a
+#: ../../source/contrib_docs/getting-started.rst:10
+msgid "We use Sphinx extensively to build documentation."
+msgstr ""
+
+# 074f79e5aada4cf48e49e75da9a6f2e4
+#: ../../source/contrib_docs/getting-started.rst:11
+msgid "We host our documentation on Read the Docs."
+msgstr ""
+
+# 273c21f2f4c64cdc905c4b9c65df07e6
+#: ../../source/contrib_docs/getting-started.rst:14
+msgid "Developing your contribution"
+msgstr ""
+
+# d34708a450ae4c98b03feb4ff944a1cc
+#: ../../source/contrib_docs/getting-started.rst:16
+msgid ""
+"Jupyter's documentation is split across several projects, listed on the "
+"`Jupyter documentation home page "
+"<https://jupyter.readthedocs.io/en/latest/>`_. These instructions apply "
+"to all Jupyter projects, though some projects have further contribution "
+"guidelines."
+msgstr ""
+
+# 583255d870384645b0b076e657c2e763
+#: ../../source/contrib_docs/getting-started.rst:19
+msgid "Clone the repository"
+msgstr ""
+
+# 024a7bc45f3a45fab5500b2d1904d9bc
+#: ../../source/contrib_docs/getting-started.rst:20
+msgid ""
+"Fork the appropriate project repository on GitHub, depending on which "
+"project's documentation you want to contribute to."
+msgstr ""
+
+# 7e9da73cdb4c469db3dce5d160b5208a
+#: ../../source/contrib_docs/getting-started.rst:21
+msgid "Clone the repository to your system."
+msgstr ""
+
+# 9e4c1b704e594ce19b00ef8075748237
+#: ../../source/contrib_docs/getting-started.rst:24
+msgid "Edit the documentation source file"
+msgstr ""
+
+# a6b8f285170c4f8eb6aecdd1cbfdb7b9
+#: ../../source/contrib_docs/getting-started.rst:26
+msgid ""
+"Source files for projects are typically found in the project's "
+"``docs/source`` directory. The reStructured text filenames end with "
+"``.rst``, and Jupyter notebook files end with ``.ipynb``."
+msgstr ""
+
+# 8b7b25fa65204498b0a9266c8541311e
+#: ../../source/contrib_docs/getting-started.rst:30
+msgid ""
+"In your favorite text editor, make desired changes to the ``.rst`` file "
+"when working with a reStructured text source file."
+msgstr ""
+
+# 28f854c4861346b09d69499d50d03dd4
+#: ../../source/contrib_docs/getting-started.rst:32
+msgid ""
+"If a notebook file requires editing, you will need to install Jupyter "
+"notebook according to the :ref:`Installation <install>` document. Then, "
+"run the Jupyter notebook and edit the desired file. Before saving the "
+"Jupyter ``.ipynb`` file, please clear the output cells. Save the file and"
+" test your change."
+msgstr ""
+
+# 41995af34a5046bca276d62634ae3b10
+#: ../../source/contrib_docs/getting-started.rst:39
+msgid "Testing changes"
+msgstr ""
+
+# 65e377a9fbe04a0b8775881db9467ab8
+#: ../../source/contrib_docs/getting-started.rst:41
+msgid ""
+"Sphinx should be installed to test your documentation changes. For best "
+"results, we recommend that you install the stable development version "
+"Sphinx (``pip install git+https://github.com/sphinx-doc/sphinx@stable``) "
+"or the current released version of Sphinx (``pip install sphinx``)."
+msgstr ""
+
+# 521e95671d3349b79075277e3822bc61
+#: ../../source/contrib_docs/getting-started.rst:46
+msgid ""
+"In addition, you may need the following packages: sphinxcontrib-spelling,"
+" sphinx_rtd_theme, nbsphinx, pyenchant, recommonmark and "
+"jupyter_sphinx_theme, which can be installed via ``pip install "
+"sphinxcontrib-spelling sphinx_rtd_theme nbsphinx pyenchant recommonmark "
+"jupyter_sphinx_theme``."
+msgstr ""
+
+# 1140b74d6bd547d2923b29eb2c769293
+#: ../../source/contrib_docs/getting-started.rst:48
+msgid ""
+"If you are on Linux, you may also need to install the Enchant C library "
+"by running ``sudo apt-get install enchant``."
+msgstr ""
+
+# 710e465eeb7d49f8bcf3279361e211ea
+#: ../../source/contrib_docs/getting-started.rst:50
+msgid ""
+"Once everything is installed, the following commands should be executed "
+"using the Terminal/command line from the ``docs`` directory:"
+msgstr ""
+
+# 874edec47dfe41aab09ca2dc976ac9be
+#: ../../source/contrib_docs/getting-started.rst:53
+msgid ""
+"``make html`` builds a local html version of the documentation. The "
+"output message will either display errors or provide the location of the "
+"html documents. For example, the location provided may be ``build/html`` "
+"and to view these documents in your browser enter ``open "
+"build/html/index.html``."
+msgstr ""
+
+# 3c47075546064151940cfddaa6b97e97
+#: ../../source/contrib_docs/getting-started.rst:58
+msgid ""
+"``make linkcheck`` will check whether the external links in the "
+"documentation are valid or if they are not longer current (i.e. cause a "
+"500 not found error)."
+msgstr ""
+
+# 3b5e8519815b43ab82350bed26580555
+#: ../../source/contrib_docs/getting-started.rst:62
+msgid ""
+"Note: We recommend using Python 3.4+ for building the documentation. If "
+"you are editing the documentation, you can use Python 2.7.9+ or the "
+"Github editor."
+msgstr ""
+
+# 3a598ce6355d49589108ebb8b3584478
+#: ../../source/contrib_docs/getting-started.rst:65
+msgid "Creating a pull request"
+msgstr ""
+
+# c5b5c1b181a54762a10f3d97ce5d19e8
+#: ../../source/contrib_docs/getting-started.rst:66
+msgid ""
+"Once you are satisfied with your changes, submit a GitHub pull request, "
+"per the instructions above. If the documentation change is related to an "
+"open GitHub issue, please mention the issue number in the pull request "
+"message."
+msgstr ""
+
+# 4ae44c0cf02a45b99d0c7f14640c4f6e
+#: ../../source/contrib_docs/getting-started.rst:70
+msgid ""
+"A project reviewer will look over your changes and provide feedback or "
+"merge your changes into the documentation."
+msgstr ""
+
+# baccae949fb54e6491856084b68e4827
+#: ../../source/contrib_docs/getting-started.rst:74
+msgid "Asking questions"
+msgstr ""
+
+# 990c9e57e8fc4e9c9da2ea3980ddebac
+#: ../../source/contrib_docs/getting-started.rst:75
+msgid ""
+"Feel free to ask questions in the Google Group for Jupyter or on an open "
+"issue on GitHub."
+msgstr ""
+
+# 6ad43967c19843df85781d3ee0ba0658
+#: ../../source/contrib_docs/index.rst:5
+msgid "Documentation Guide"
+msgstr ""
+
+# e53cdb8f3ebb4f9d97c7824dfd462fef
+#: ../../source/contrib_docs/index.rst:7
+msgid "**Contents**"
+msgstr ""
+
+# 8710f55c2e51435881a40b68457010b8
+#: ../../source/contrib_docs/index.rst:17
+msgid ""
+"Documentation helps guide new users, fosters communication between "
+"developers, and shares tips and best practices with other community "
+"members. That's why the Jupyter project is focused on documenting new "
+"features and to keeping the documentation up-to-date."
+msgstr ""
+
+# 785e0d441719499ab42d427cbc7d6247
+#: ../../source/contrib_docs/repo-structure.md:1
+msgid "Structuring a repo for docs"
+msgstr ""
+
+# 90d5b35701d841f49957792e24da870a
+#: ../../source/contrib_docs/repo-structure.md:4
+msgid "Root level of the repo"
+msgstr ""
+
+# 7367f9983e43442b8e2e72da5ed51518
+#: ../../source/contrib_docs/repo-structure.md:10
+msgid "Repo root directory"
+msgstr ""
+
+# 98dae640b1424bad968989a88f0bbbac
+#: ../../source/contrib_docs/repo-structure.md:12
+msgid "Inside the docs directory"
+msgstr ""
+
+# 60e584f8cf344d5cbc1bd44ddb579f91
+#: ../../source/contrib_docs/repo-structure.md:19
+msgid "directory"
+msgstr ""
+
+# 18b0121e5dbd4d0cbfdc139f2087f09c
+#: ../../source/contrib_docs/repo-structure.md:22
+msgid "Sphinx"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/contributor.po
+++ b/docs/source/locale/en/LC_MESSAGES/contributor.po
@@ -1,0 +1,409 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 621a2e3dd84a4243839c3502e29814d9
+#: ../../source/contributor/content-contributor.rst:2
+msgid "Contributor Guides"
+msgstr ""
+
+# 1171d51e6719464b968b01a30c2df1d4
+#: ../../source/contributor/content-contributor.rst:13
+msgid ""
+"Whether you are a new, returning, or current contributor to Project "
+"Jupyter's subprojects or IPython, **we welcome you**."
+msgstr ""
+
+# 300e2003927049dab5e95afdb87961d3
+#: ../../source/contributor/content-contributor.rst:16
+msgid ""
+"Project Jupyter has seen steady growth over the past several years, and "
+"it is wonderful to see the many ways people are using these projects. As "
+"a result of this rapid expansion, our project maintainers are balancing "
+"many requirements, needs, and resources. We ask contributors to take some"
+" time to become familiar with our contribution guides and spend some time"
+" learning about our project communication and workflow."
+msgstr ""
+
+# b8bdcf9762b9420b982a51c87522bb59
+#: ../../source/contributor/content-contributor.rst:23
+msgid ""
+"The Contributor Guides and individual project documentation offer "
+"guidance. If you have a question, please ask us. `Community Resources "
+"<https://jupyter.org/community.html>`_ provides information on our "
+"commonly used communication methods."
+msgstr ""
+
+# a6410f8dcf2a40f4bb0ac93598cba376
+#: ../../source/contributor/content-contributor.rst:28
+msgid ""
+"We are very pleased to have you as a contributor, and we hope you will "
+"find valuable your impact on the projects. **Thank you** for sharing your"
+" interests, ideas, and skills with us."
+msgstr ""
+
+# 135f6b0b508342ce97970e34fc45d3e7
+#: ../../source/contributor/content-contributor.rst:33
+msgid "Do I really have something to contribute to Jupyter?"
+msgstr ""
+
+# c019e9e3e874449c97154d6e7a727e78
+#: ../../source/contributor/content-contributor.rst:35
+msgid ""
+"Absolutely ✅. There are always ways to contribute to this community! "
+"Whether it is is contributing code, improving documentation and "
+"communications, teaching others, or participating in conversations in the"
+" community, we welcome and value your contribution!"
+msgstr ""
+
+# 98869a235e8a4a889da32cec31b99573
+#: ../../source/contributor/content-contributor.rst:41
+msgid "What kinds of contributions can I make?"
+msgstr ""
+
+# 8f10671ad67d4eea908dd64ffee52b4c
+#: ../../source/contributor/content-contributor.rst:43
+msgid ""
+"The following sections try to provide inspirations for different ways "
+"that you can contribute to the Jupyter ecosystem. They're non-complete - "
+"if you can think up any way to make an improvement, we appreciate it!"
+msgstr ""
+
+# f409e68056af43bd9e38d096103a3883
+#: ../../source/contributor/content-contributor.rst:48
+msgid "Improving documentation"
+msgstr ""
+
+# 34eefffe7e794af4a56bd5ea20b11a78
+#: ../../source/contributor/content-contributor.rst:50
+msgid ""
+"One of the most important parts of the Jupyter ecosystem is its "
+"documentation. Good documentation makes it easier for users to learn how "
+"to use the tools. It also makes it easier to teach others, and to "
+"maintain and improve the code itself. There are many ways to improve "
+"documentation, such as **reading tutorials and reporting confusing "
+"parts**, **finding type-os and minor errors in docs**, **writing your own"
+" guides and tutorials**, **improving docstrings within the code**, and "
+"**improving documentation style and design**."
+msgstr ""
+
+# 9e1b5f837c5544e0b1b10324e31869ae
+#: ../../source/contributor/content-contributor.rst:57
+msgid ""
+"If you'd like to improve documentation in the Jupyter community, check "
+"out the :ref:`documentation-guide`."
+msgstr ""
+
+# 560230393e4349dd825bc8cb04bd85e8
+#: ../../source/contributor/content-contributor.rst:60
+msgid "Improving code"
+msgstr ""
+
+# d630c52da53f4130862db11c2c4d45e6
+#: ../../source/contributor/content-contributor.rst:62
+msgid ""
+"There are many different codebases that make up the tools in the Jupyter "
+"ecosystem. These are split across many repositories in several GitHub "
+"organizations. They cover many different parts of interactive computing, "
+"such as **user interfaces**, **kernels**, **shared infrastructure**, "
+"**interactive widgets**, or **structured documents**."
+msgstr ""
+
+# 904018e4262349c680f3e06291ab5284
+#: ../../source/contributor/content-contributor.rst:67
+msgid ""
+"We recommend checking out the :ref:`developer-guide` for more information"
+" about how you can find the right project to contribute to, and where to "
+"go next."
+msgstr ""
+
+# 25a6e078d67442a2ba84ead181c460b3
+#: ../../source/contributor/content-contributor.rst:71
+msgid "Participating in the community"
+msgstr ""
+
+# a87966fbbbd14c878db02da9489bce82
+#: ../../source/contributor/content-contributor.rst:73
+msgid ""
+"The most important part of Jupyter is its community - this is a large and"
+" diverse group of people spread across the globe. One of the best ways to"
+" contribute to Jupyter is to simply be a positive and helpful member of "
+"this community. Whether it **participating in online conversations**, "
+"**offering to help others**, **coming to community meetings**, or "
+"**teaching others about Jupyter**, there are many ways to improve the "
+"Jupyter community. For more information about this, we recommend starting"
+" with the :ref:`community-guide`."
+msgstr ""
+
+# 593c43f0e5764d01a171016560a00f00
+#: ../../source/contributor/contrib_guide_blog.rst:3
+msgid "Communications Guide"
+msgstr ""
+
+# 1b294ad959f94bd3b8dba73f56642cb2
+#: ../../source/contributor/contrib_guide_blog.rst:6
+msgid "Contents"
+msgstr ""
+
+# c6416f19a43d4ae1a19bb1f7b9888966
+#: ../../source/contributor/contrib_guide_blog.rst:9
+msgid "Blog"
+msgstr ""
+
+# a9b5e28dfd994ef29cdf392ff8a36fba
+#: ../../source/contributor/contrib_guide_blog.rst:11
+msgid ""
+"We publish our blog at `<https://blog.jupyter.org>`_. We welcome ideas "
+"for posts or guest posts to the Jupyter blog. If you have a suggestion "
+"for a future post, please feel free to share your idea with us. We would "
+"like to discuss the idea with you."
+msgstr ""
+
+# 12ff4c6ea66d445991bcadec7ba0b31f
+#: ../../source/contributor/contrib_guide_blog.rst:16
+msgid ""
+"Do you enjoy writing? Please contact us about becoming a guest blogger. "
+"We can help guide you through the process of creating a post."
+msgstr ""
+
+# b3be44427ae8472a8a215b6e33127cca
+#: ../../source/contributor/contrib_guide_blog.rst:20
+msgid "Technical overview"
+msgstr ""
+
+# f09b1742f1744a83893baf77b9ff4ffc
+#: ../../source/contributor/contrib_guide_blog.rst:22
+msgid ""
+"Jupyter's blog uses the Ghost blog platform for its contributor "
+"flexibility and ease of use. Jupyter's blog is deployed at "
+"`<https://blog.jupyter.org>`_."
+msgstr ""
+
+# 43151242cf8847c792841f97ae59e095
+#: ../../source/contributor/contrib_guide_blog.rst:26
+msgid "Basic workflow from blog idea to published post"
+msgstr ""
+
+# 1be90c5561f143808cb47de0c8c8022a
+#: ../../source/contributor/contrib_guide_blog.rst:28
+msgid ""
+"There are several major steps in the workflow from blog idea to a "
+"published post including:"
+msgstr ""
+
+# 3c5ad2bb281a4aa6ac16b54a10dbdd1e
+#: ../../source/contributor/contrib_guide_blog.rst:31
+msgid "Be inspired to write a post"
+msgstr ""
+
+# 92a83a1a36a144c9ba2bcf30cc4da74b
+#: ../../source/contributor/contrib_guide_blog.rst:32
+msgid ""
+"Send us a message on the Jupyter mailing list and ask us for an author "
+"account on our blog"
+msgstr ""
+
+# 1cd0cdf496bf4a71b38d89513c9351f6
+# c454ba131c7947f3b756d636a19e3d39
+#: ../../source/contributor/contrib_guide_blog.rst:33
+#: ../../source/contributor/contrib_guide_blog.rst:42
+msgid "Creating a draft"
+msgstr ""
+
+# d60237d5d70c48e289be8db755f5488a
+#: ../../source/contributor/contrib_guide_blog.rst:34
+msgid "Draft Review"
+msgstr ""
+
+# 8e5bbd0595ae4f22abc31856f1b54c0d
+# 7a67f5bd5e864a89bdde0121c28c83cb
+#: ../../source/contributor/contrib_guide_blog.rst:35
+#: ../../source/contributor/contrib_guide_blog.rst:99
+msgid "Editorial acceptance"
+msgstr ""
+
+# 2a828f70ea3a42ebb52ab8fe17c58d83
+# 8ca1d1189f084c22a6513a9f7f370c3a
+#: ../../source/contributor/contrib_guide_blog.rst:36
+#: ../../source/contributor/contrib_guide_blog.rst:102
+msgid "Publishing the post"
+msgstr ""
+
+# 205eccbcaafc4d1c87184fdfa20ea1e0
+#: ../../source/contributor/contrib_guide_blog.rst:38
+msgid ""
+"We'll cover each of these as well as how to update a post once it has "
+"been published."
+msgstr ""
+
+# bbeb420a823542ee9f81fb9a9d9e9a4b
+#: ../../source/contributor/contrib_guide_blog.rst:45
+msgid "Title and metadata"
+msgstr ""
+
+# cb2170d8f32f40ab8ddb9dfe33eb88ec
+#: ../../source/contributor/contrib_guide_blog.rst:47
+msgid ""
+"Alway check in the metadata fields that a blog post has a title and a "
+"canonical URL. It is possible to put the date in the canonical URL, in "
+"particular for events like jupyter-day, that can occur several times. The"
+" date of the event can differ from the date of the blog post."
+msgstr ""
+
+# 275b539c7a0b4de092e7cbf9b0d07286
+#: ../../source/contributor/contrib_guide_blog.rst:52
+msgid ""
+"Once a post is published, **never** change the post's title or the url. "
+"These changes will break links of tweets and RSS feeds that have already "
+"referenced the existing, published URL. Keep in mind that when publishing"
+" some platforms cache the url immediately; as a result changing the title"
+" will direct people to a 404 page."
+msgstr ""
+
+# 7c80a8faf2824bd4a6a0a8848026e336
+#: ../../source/contributor/contrib_guide_blog.rst:58
+msgid ""
+"Title and metadata can always be refined after the actual content of the "
+"blog is written, but should not be changed after publication. As a guest "
+"you do not have to worry about metadata, the editor or admins will take "
+"care of that."
+msgstr ""
+
+# af2b4dd47be8465d9f86f09e8f35a907
+#: ../../source/contributor/contrib_guide_blog.rst:63
+msgid "Working with images"
+msgstr ""
+
+# 1dd8d06687a24b8294060cc78eb07ad9
+#: ../../source/contributor/contrib_guide_blog.rst:65
+msgid ""
+"Try not to link to external images. If you want to put an image in the "
+"post, insert ``![]()`` in the editor view and drag and drop an image from"
+" your desktop into the newly created field in the preview. External "
+"images can change, and can break the blog post if they are taken down. "
+"This cannot append if you drag and drop images. Moreover, these images  "
+"will be served from the same CDN (Content Delivery Network) as the blog, "
+"which will insure the best overall experience for our readers."
+msgstr ""
+
+# ae794323faec447a81ebde34bfcd39a1
+#: ../../source/contributor/contrib_guide_blog.rst:73
+msgid ""
+"The featured image you see at the top of a blog posts is set from within "
+"the metadata field, not using the `![]()`. The featured image is treated "
+"differently than inlined images by many feedreaders (especially on "
+"mobile) and allows a user on a slow connection to read the content of the"
+" blog earlier, which is a much better experience for the user than "
+"waiting for the featured image to render."
+msgstr ""
+
+# f8a4d5c3b90a4f598984c027f2b56f71
+#: ../../source/contributor/contrib_guide_blog.rst:80
+msgid "Links"
+msgstr ""
+
+# 5a9171fe32504c848544ef93477c13e0
+#: ../../source/contributor/contrib_guide_blog.rst:82
+msgid ""
+"Do not use minified links when possible. The multiple redirects of "
+"minified links degrades the mobile browsing experience. If you need "
+"analytics of the number of page views, this information is tracked by "
+"Google Analytics."
+msgstr ""
+
+# 36175d5a99a4463b9397b07b190925e3
+#: ../../source/contributor/contrib_guide_blog.rst:87
+msgid "Draft review"
+msgstr ""
+
+# 0b8e6790a0ea441c828238f2a79a627c
+#: ../../source/contributor/contrib_guide_blog.rst:90
+msgid "Ask for a review"
+msgstr ""
+
+# 3db41a20769540a18283ea37c44900b2
+#: ../../source/contributor/contrib_guide_blog.rst:92
+msgid ""
+"Once you think you are done, ask someone else to reread your post, and "
+"check the various parameters that you might have forgotten before "
+"publishing. You are not on your own, this is teamwork, we are here to "
+"help you. If we do things in a hurry you will probably spend more time "
+"fixing mistakes that actually doing things right in a first place."
+msgstr ""
+
+# 95365105a2e44a7d818b9f47b05853dc
+#: ../../source/contributor/contrib_guide_blog.rst:104
+msgid ""
+"Usually an editor or admin will take care of publishing the post. The "
+"task of the Editor/Admin is to check all metadata are correctly set, that"
+" no external images are used, as well as all other quality check describe"
+" before."
+msgstr ""
+
+# 809dc486262e437ebb95ce53542c0b79
+#: ../../source/contributor/contrib_guide_blog.rst:108
+msgid "It is then just a matter of making th post visible to everyone."
+msgstr ""
+
+# 0b9fd999238245dca7a574888ca974b5
+#: ../../source/contributor/contrib_guide_blog.rst:111
+msgid "Changing an existing post"
+msgstr ""
+
+# f7eb7e6e67924638b9fd1079ca1fd4be
+#: ../../source/contributor/contrib_guide_blog.rst:114
+msgid "Posts Updates"
+msgstr ""
+
+# eee44374b12542d9b54cb3618fd3e868
+#: ../../source/contributor/contrib_guide_blog.rst:116
+msgid ""
+"Blog subscribers may receive notification at every update. So use updates"
+" and fixes parsimoniously. It is OK to wait a few hours to fix a typo."
+msgstr ""
+
+# ab638c99ec3c460abfaad8d60a1e8800
+#: ../../source/contributor/contrib_guide_blog.rst:119
+msgid ""
+"If some substantial updates have to be made, like change of location, "
+"time etc, please insert an `[Update]` section at top (or bottom of the "
+"blog post depending on importance) with the Date/Time of the update. If "
+"the information in the body of the blog is wrong, try not to replace it, "
+"and just use strike-through to mark it as obsolete. This would help "
+"reader determine which information is correct when dealing with multiple "
+"source giving different informations."
+msgstr ""
+
+# 5fa61a2b985e43aa94c3cc695b08eed1
+#: ../../source/contributor/contrib_guide_blog.rst:128
+msgid "Newsletter"
+msgstr ""
+
+# 5122c3d734f24dbdb2f00e9731a31a27
+# 424ebb5fc17844658e7b83d9209374ce
+#: ../../source/contributor/contrib_guide_blog.rst:130
+#: ../../source/contributor/contrib_guide_blog.rst:136
+msgid "Documentation in progress."
+msgstr ""
+
+# 174fa91d9686461fa8f40c348d73dda3
+#: ../../source/contributor/contrib_guide_blog.rst:134
+msgid "Website"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/developer-docs.po
+++ b/docs/source/locale/en/LC_MESSAGES/developer-docs.po
@@ -1,0 +1,993 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 4af9f71750c8467e8467b4e5c923c079
+#: ../../source/developer-docs/contrib_first_time.rst:3
+msgid "Contributing for the First Time"
+msgstr ""
+
+# 856e1ce30fea448ebafd494bce7435e0
+# a1a8768c3922479fa3bb8f7c8ec19d78
+#: ../../source/developer-docs/contrib_first_time.rst:6
+#: ../../source/developer-docs/contrib_guide_code.rst:6
+msgid "Contents"
+msgstr ""
+
+# b75b7e5e93d443999da00800903a098c
+#: ../../source/developer-docs/contrib_first_time.rst:8
+msgid "Welcome fellow contributor! We appreciate your help."
+msgstr ""
+
+# feac7eb012a841038cfec4c31f26db07
+#: ../../source/developer-docs/contrib_first_time.rst:10
+msgid ""
+"We typically label issues appropriate for new contributors as ``good "
+"first issue`` or ``help wanted``.  To start an issue, you may comment to "
+"let everyone know that you'll be working on it.  Our repos typically "
+"provide development installation instructions in each repo's "
+"``CONTRIBUTING.md`` or ``README.md``. **Should you find an issue with our"
+" development installation instructions please let us know in our "
+"issues.**  We want to ensure that our documentation for development "
+"installation is accurate.  Additionally, other contributors are often "
+"available to answer questions about fixing the issue on the issue number "
+"or on the repo's gitter channel."
+msgstr ""
+
+# ee56c9c218734eb89634ced64adc7089
+#: ../../source/developer-docs/contrib_first_time.rst:20
+msgid ""
+"We strive to have a inclusive, welcoming community.  Please read our "
+"`code of conduct "
+"<https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`__"
+" to learn more."
+msgstr ""
+
+# fd7a319af3e449b6861b2d74e4e1c8cb
+#: ../../source/developer-docs/contrib_first_time.rst:25
+msgid "Major Repos and Issue Types"
+msgstr ""
+
+# fa17d1bbc25c469c8aa8e05eeeef1cca
+#: ../../source/developer-docs/contrib_first_time.rst:28
+msgid "Python"
+msgstr ""
+
+# cd8ab1883a03446b91db2f5d1f7c13db
+#: ../../source/developer-docs/contrib_first_time.rst:30
+msgid ""
+"IPython, nbgrader, JupyterHub, repo2docker, and Binder are major repos "
+"written primarily in Python."
+msgstr ""
+
+# 13e25fb7dc4c4715abc0394881b6e0f7
+#: ../../source/developer-docs/contrib_first_time.rst:34
+msgid "`IPython <https://github.com/ipython/ipython>`__"
+msgstr ""
+
+# c2da4aae25e4412a911d495ddecf8495
+#: ../../source/developer-docs/contrib_first_time.rst:33
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/ipython/ipython/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__"
+msgstr ""
+
+# c5ee2f00454c418ab40ddb37f145b04f
+#: ../../source/developer-docs/contrib_first_time.rst:34
+msgid ""
+"`Development Installation <https://github.com/ipython/ipython"
+"#development-and-instant-running>`__"
+msgstr ""
+
+# d4df3d9d6a3a4a69b57ea417354f7e43
+#: ../../source/developer-docs/contrib_first_time.rst:35
+msgid "`Gitter Channel <https://gitter.im/ipython/ipython>`__"
+msgstr ""
+
+# eb0579bf78894f9dbf75c8786657adb2
+#: ../../source/developer-docs/contrib_first_time.rst:37
+msgid "`nbgrader <https://github.com/jupyter/nbgrader>`__"
+msgstr ""
+
+# 4dbe9d98a5b04f3c97d6e3fcb5ac9c95
+#: ../../source/developer-docs/contrib_first_time.rst:37
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyter/nbgrader/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__"
+msgstr ""
+
+# 831273b724474075be7ed229e8f7f7e0
+#: ../../source/developer-docs/contrib_first_time.rst:38
+msgid ""
+"`Development Installation "
+"<https://nbgrader.readthedocs.io/en/latest/contributor_guide/installation_developer.html>`__"
+msgstr ""
+
+# d97b92c244d243088ab12928e87d6df7
+#: ../../source/developer-docs/contrib_first_time.rst:41
+msgid "`JupyterHub <https://github.com/jupyterhub/jupyterhub>`__"
+msgstr ""
+
+# 387d54bdacca494fbb48fe045047ad3b
+#: ../../source/developer-docs/contrib_first_time.rst:40
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyterhub/jupyterhub/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__"
+msgstr ""
+
+# 103323470924458c96863a2956b18934
+#: ../../source/developer-docs/contrib_first_time.rst:41
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyterhub/jupyterhub#contributing>`__"
+msgstr ""
+
+# b060a9da9d1341a4b1bb023eb4a2a514
+# 971d63207aa04f5a8f60aefcf4af75fa
+#: ../../source/developer-docs/contrib_first_time.rst:42
+#: ../../source/developer-docs/contrib_first_time.rst:46
+msgid "`Gitter Channel <https://gitter.im/jupyterhub/jupyterhub>`__"
+msgstr ""
+
+# c587dbe34ebf447e8ff83ec285a05cc4
+#: ../../source/developer-docs/contrib_first_time.rst:45
+msgid "`repo2docker <https://github.com/jupyter/repo2docker>`__"
+msgstr ""
+
+# 52bedabdb3b040e895cb1ca8f80d6041
+#: ../../source/developer-docs/contrib_first_time.rst:44
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyter/repo2docker/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__"
+msgstr ""
+
+# 2f57686e120c44d695178d92b790da17
+#: ../../source/developer-docs/contrib_first_time.rst:45
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyter/repo2docker#installation>`__"
+msgstr ""
+
+# 8d289dfea18048199cea959342abb58c
+#: ../../source/developer-docs/contrib_first_time.rst:50
+msgid "`Binder <https://github.com/jupyterhub/binderhub>`__"
+msgstr ""
+
+# 5857637ca0fd49e9808958dd94156769
+#: ../../source/developer-docs/contrib_first_time.rst:48
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyterhub/binderhub/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22>`__"
+msgstr ""
+
+# 782632da47684ce8a213946114dc86ed
+#: ../../source/developer-docs/contrib_first_time.rst:49
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md>`__"
+msgstr ""
+
+# 92bddf6026f94077b2f368e02315c5f9
+#: ../../source/developer-docs/contrib_first_time.rst:50
+msgid "`Gitter Channel <https://gitter.im/jupyterhub/binder>`__"
+msgstr ""
+
+# 9b380cabc14b47179027d99a76fb7b8b
+#: ../../source/developer-docs/contrib_first_time.rst:53
+msgid "Documentation"
+msgstr ""
+
+# ad4855a98345426b8ff5b1012d31ccfe
+#: ../../source/developer-docs/contrib_first_time.rst:55
+msgid ""
+"All our repos have documentation issues that are relevant for new "
+"contributors. For example, the source for the documentation you are "
+"reading right now can be found in the `jupyter/jupyter repository on "
+"GitHub <https://github.com/jupyter/jupyter>`__."
+msgstr ""
+
+# fb1acce4f0464fb583a61010ade7e13f
+#: ../../source/developer-docs/contrib_first_time.rst:59
+msgid "JavaScript/TypeScript"
+msgstr ""
+
+# d17b947479924673b44d5e34dba895af
+#: ../../source/developer-docs/contrib_first_time.rst:61
+msgid ""
+"Jupyter Notebook, JupyterLab, and IPyWidgets use JavaScript and "
+"TypeScript."
+msgstr ""
+
+# e73febabcbe341d4ab5cd9062fe95128
+#: ../../source/developer-docs/contrib_first_time.rst:65
+msgid "`Jupyter Notebook <https://github.com/jupyter/notebook>`__"
+msgstr ""
+
+# f1a0b2f2975f459e8c85be7dfe502070
+#: ../../source/developer-docs/contrib_first_time.rst:64
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyter/notebook/issues?q=is%3Aissue+is%3Aopen+label%3A%22tag%3ANew+Contributor%22>`__"
+msgstr ""
+
+# 67ec729c38dd4eb4afc774c99aad3512
+#: ../../source/developer-docs/contrib_first_time.rst:65
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyter/notebook/blob/master/CONTRIBUTING.rst>`__"
+msgstr ""
+
+# eacc49d0d4e046309c208bceab13b8cc
+#: ../../source/developer-docs/contrib_first_time.rst:66
+msgid "`Gitter Channel <https://gitter.im/jupyter/notebook>`__"
+msgstr ""
+
+# 15087cd5dd224b8a882fad3d6db3085b
+#: ../../source/developer-docs/contrib_first_time.rst:69
+msgid "`JupyterLab <https://github.com/jupyterlab/jupyterlab>`__"
+msgstr ""
+
+# f7a939c12a42438796221b1b3216b85c
+#: ../../source/developer-docs/contrib_first_time.rst:68
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3AHelp+Wanted%22>`__"
+msgstr ""
+
+# 60727430accc47a59bdb9fd7c0dc9d10
+#: ../../source/developer-docs/contrib_first_time.rst:69
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`__"
+msgstr ""
+
+# 889f6bb437974cbf98d5bc40c912e0b4
+#: ../../source/developer-docs/contrib_first_time.rst:70
+msgid "`Gitter Channel <https://gitter.im/jupyterlab/jupyterlab>`__"
+msgstr ""
+
+# e810bd44e3374585a51bf791e155e821
+#: ../../source/developer-docs/contrib_first_time.rst:74
+msgid "`IPyWidgets <https://github.com/jupyter-widgets/ipywidgets>`__"
+msgstr ""
+
+# 27cd0846c54e44769e1ca07e09612753
+#: ../../source/developer-docs/contrib_first_time.rst:72
+#, python-format
+msgid ""
+"`Notable Issues <https://github.com/jupyter-"
+"widgets/ipywidgets/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__"
+msgstr ""
+
+# b2ed815f0f484e68a121c164065199df
+#: ../../source/developer-docs/contrib_first_time.rst:73
+msgid ""
+"`Development Instalation "
+"<https://ipywidgets.readthedocs.io/en/latest/dev_install.html>`__"
+msgstr ""
+
+# 72cbadaa4c3941bdb2196021192afe8c
+#: ../../source/developer-docs/contrib_first_time.rst:74
+msgid "`Gitter Channel <https://gitter.im/jupyter-widgets/Lobby>`__"
+msgstr ""
+
+# 540681780cc14e65925a8c0e9aad0405
+#: ../../source/developer-docs/contrib_first_time.rst:77
+msgid "DevOps"
+msgstr ""
+
+# 4b08f960f4e941e2b3aa717d7edca63b
+#: ../../source/developer-docs/contrib_first_time.rst:79
+msgid ""
+"JupyterHub, repo2docker, and Binder have many issues related to devops.  "
+"See the links above."
+msgstr ""
+
+# c0634775654042c2ad49c3d398f14230
+#: ../../source/developer-docs/contrib_first_time.rst:82
+msgid "Web Development"
+msgstr ""
+
+# 2920f2549f3c4ca5a27867664fd04def
+#: ../../source/developer-docs/contrib_first_time.rst:84
+msgid "We have issues related to the website."
+msgstr ""
+
+# 34830e753b7042d59da52a4bb2415161
+#: ../../source/developer-docs/contrib_first_time.rst:87
+msgid ""
+"`Project Jupyter's Website "
+"<https://github.com/jupyter/jupyter.github.io/>`__"
+msgstr ""
+
+# 2d035ecd6e9e40dfa1aa14533fd7e41c
+#: ../../source/developer-docs/contrib_first_time.rst:87
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyter/jupyter.github.io/issues?q=is%3Aissue+is%3Aopen+label"
+"%3Asprint-friendly>`__"
+msgstr ""
+
+# 2192a69a3d2f42008d5632996da49b7f
+#: ../../source/developer-docs/contrib_first_time.rst:88
+msgid ""
+"`Developer Installation <https://github.com/jupyter/jupyter.github.io"
+"#quick-local-testing>`__"
+msgstr ""
+
+# 0485183fb72344cf959bce1ba5420bd6
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:3
+msgid "Submitting a Bug"
+msgstr ""
+
+# af25f25c2cec41d8831b2e67c2a3e69c
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:4
+msgid ""
+"While using the Notebook, you might experience a bug that manifests "
+"itself in unexpected behavior.  If so, we encourage you  to open issues "
+"on GitHub. To make the navigating issues easier for both developers and "
+"users, we ask that you take the following steps before submitting an "
+"issue."
+msgstr ""
+
+# 139a72d8dfdb45cf90edf3e35aec0059
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:9
+msgid ""
+"Search through StackOverflow and existing GitHub issues to ensure that "
+"the issue has not already been reported by another user. If so, provide "
+"your input on the existing issue if you think it would be valuable."
+msgstr ""
+
+# cccad08769f44e52a04a90cbe76e2223
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:13
+msgid ""
+"Prepare a small, self-contained snippet of code that will allow others to"
+" reproduce the issue that you are experiencing."
+msgstr ""
+
+# c3a86b1233534248bb19fa1c1b09bd9d
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:16
+msgid ""
+"Prepare information about the environment that you are executing the code"
+" in, in order to aid in the debugging of the issue. You will need to "
+"provide information about the Python version, Jupyter version, operating "
+"system, and browser that you are using when submitting bugs. You can also"
+" use ``pip list`` or  ``conda list`` and ``grep`` in order to identify "
+"the versions of the libraries that are relevant to the issue that you are"
+" submitting."
+msgstr ""
+
+# b4302021c41448839eae6dca5b34a39e
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:24
+msgid ""
+"Prepare a simple test that outlines the expected behavior of the code or "
+"a description of the what the expected behavior should be."
+msgstr ""
+
+# 47c214b9890f43c599c9bf0b8c6e0582
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:27
+msgid ""
+"Prepare an explanation of why the current behavior is not desired and "
+"what it should be."
+msgstr ""
+
+# 971e73dd85a54bf9b588dad72b000207
+# fcc463f334c9426abb8e84b007b2f6cd
+#: ../../source/developer-docs/contrib_guide_code.rst:3
+#: ../../source/developer-docs/index.rst:5
+msgid "Developer Guide"
+msgstr ""
+
+# 7c5e21c9bdad4985aeab19c9c6a7af56
+#: ../../source/developer-docs/contrib_guide_code.rst:9
+msgid "A Note on Contributing to Open Source"
+msgstr ""
+
+# b4b9389d3154437ba7df6c08d95bffb4
+#: ../../source/developer-docs/contrib_guide_code.rst:11
+msgid ""
+"Contributing to open source can be a nerve-wrecking process, but don't "
+"worry everyone on the Jupyter team is dedicated to making sure that your "
+"open source experience is as fun as possible. At any time during the "
+"process described below, you can reach out to the Jupyter team on Gitter "
+"or the mailing list for assistance. If you are nervous about asking "
+"questions in public, you can also reach out to one of the Jupyter "
+"developers in private. You can use the public Gitter to find someone who "
+"has the best knowledge about the code you are working with and interact "
+"with the in a personal chat."
+msgstr ""
+
+# cc89b39165a446e5b87c4f9266495c26
+#: ../../source/developer-docs/contrib_guide_code.rst:20
+msgid ""
+"As you begin your open source journey, remember that it's OK if you don't"
+" understand something, it's OK to make mistakes, and it's OK to only "
+"contribute a small amount of the code necessary to fix the issue you are "
+"tackling. Any and all help is welcome and any and all people are "
+"encouraged to contribute."
+msgstr ""
+
+# 641608cfd0864941a223bf39b6a0b4ce
+#: ../../source/developer-docs/contrib_guide_code.rst:26
+msgid "How can I help?"
+msgstr ""
+
+# a37196b3fb6a4df1870786ea3235406a
+#: ../../source/developer-docs/contrib_guide_code.rst:28
+msgid ""
+"Individuals are welcome, and encouraged, to submit pull requests and "
+"contribute to the Jupyter source. If you are a first-time contributor "
+"looking to get involved with Jupyter, you can use the following query in "
+"a GitHub search to find beginner-friendly issues to tackle across the "
+"Jupyter codebase. This query is particularly useful because the Jupyter "
+"codebase is scattered across several repositories within the jupyter "
+"organization, as opposed to a single repository. You can click the link "
+"below to find sprint-friendly issues."
+msgstr ""
+
+# 1eee498a843146fab2ef3b1e9317a7b3
+#: ../../source/developer-docs/contrib_guide_code.rst:36
+msgid ""
+"`is:issue is:open is:sprint-friendly user:jupyter "
+"<https://github.com/search?q=is%3Aissue+is%3Aopen+is%3Asprint-"
+"friendly+user%3Ajupyter&type=Issues&ref=searchresults>`_"
+msgstr ""
+
+# e2e8942ce25f4d44a4dc7cc2e67730b5
+#: ../../source/developer-docs/contrib_guide_code.rst:39
+msgid ""
+"Once you've found an issue that you are eager to solve, you can use the "
+"guide below to get started. If you experience any problems while working "
+"on the issue, leave a comment on the issue page in GitHub and someone on "
+"the core team will be able to lend you assistance."
+msgstr ""
+
+# df6093a6a72247089f0024bcb798dcbc
+#: ../../source/developer-docs/contrib_guide_code.rst:44
+msgid ""
+"Please keep in mind that what follows are guidelines. If you work through"
+" the steps and have questions or run into time constraints, please submit"
+" what you already have worked on as a pull request and ask questions on "
+"it. Your effort, including partial or in-progress work, is appreciated."
+msgstr ""
+
+# b3e3eb75571744d1b15d0d7f1bec2c13
+#: ../../source/developer-docs/contrib_guide_code.rst:49
+msgid ""
+"Fork the repository associated with the issue you are addressing and "
+"clone it to a local directory on your machine."
+msgstr ""
+
+# d4a40f6de2d243dc8f4c188d4bccb987
+#: ../../source/developer-docs/contrib_guide_code.rst:52
+msgid ""
+"``cd`` into the directory and create a new branch using ``git checkout -b"
+" insert-branch-name-here``. Pick a branch name that gives some insight "
+"into what the issue you are fixing is. For example, if you are updating "
+"the text that is logged out by the program when a certain error happens "
+"you might name your branch `update-error-text`."
+msgstr ""
+
+# 022300380d634dca91632205f9c0c3b8
+#: ../../source/developer-docs/contrib_guide_code.rst:58
+msgid ""
+"Refer to the repository's README and documentation for details on "
+"configuring your system for development."
+msgstr ""
+
+# b294af0b7be547ae948f435194728ad6
+#: ../../source/developer-docs/contrib_guide_code.rst:61
+msgid ""
+"Identify the module or class where the code change you will make will "
+"reside and leave a comment in the file describing what issue you are "
+"trying to address."
+msgstr ""
+
+# 3da7f1d0ab7249f893554f57520c67e6
+#: ../../source/developer-docs/contrib_guide_code.rst:65
+msgid ""
+"Open a pull request to the repository with ``[WIP]`` appended to the "
+"front so that the core team is aware that you are actively pursuing the "
+"issue. When creating a pull request, make sure that the title clearly and"
+" concisely described what your code does. For example, we might use the "
+"title \"Updated error message on ExampleException\". In the body of the "
+"pull request, make sure that you include the phrase \"Closes #issue-"
+"number-here\", where the issue number is the issue number of the issue "
+"that you are addressing in this PR."
+msgstr ""
+
+# 8a1d4bda15d54f63b755268e0ee3f928
+#: ../../source/developer-docs/contrib_guide_code.rst:74
+msgid ""
+"Feel free to open a PR as early as possible. Getting early feedback on "
+"your approach will save you time and prevent the need for an extensive "
+"refactor later."
+msgstr ""
+
+# 933a91389b064d329ba443dc8b4aac48
+#: ../../source/developer-docs/contrib_guide_code.rst:78
+msgid ""
+"Run the test suite locally in order to ensure that everything is properly"
+" configured on your system. Refer to the repository's README for "
+"information on how to run the test suite. This will typically require "
+"that you run the ``nosetests`` command on the commandline. Alternatively,"
+" you may submit a pull request. Our Continuous Integration system will "
+"test your code and report test results."
+msgstr ""
+
+# 4940b5b766d34b728500b8ee01b00a2e
+#: ../../source/developer-docs/contrib_guide_code.rst:85
+msgid ""
+"Find the test file associated with the module that you will be changing. "
+"In the test file, add some tests that outline what you expect the "
+"behavior of the change should be. If we continue with our example of "
+"updating the text that is logged on error, we might write test cases that"
+" check to see if the exception raised when you induce the error contains "
+"the appropriate string. When writing test cases, make sure that you test "
+"for the following things."
+msgstr ""
+
+# 190f4f31714c4eebbb80f054ed3b9ede
+#: ../../source/developer-docs/contrib_guide_code.rst:93
+msgid "What is the simplest test case I can write for this issue?"
+msgstr ""
+
+# bf18ca96f21e40d0a07cfa24d3f83ebb
+#: ../../source/developer-docs/contrib_guide_code.rst:94
+msgid "What will happen if your code is given messy inputs?"
+msgstr ""
+
+# 5e238f0155c44fc198bbe03b5eb52072
+#: ../../source/developer-docs/contrib_guide_code.rst:95
+msgid "What will happen if your code is given no inputs?"
+msgstr ""
+
+# f642285810ad4b74996365fabf4a36bc
+#: ../../source/developer-docs/contrib_guide_code.rst:96
+msgid "What will happen if your code is given too few inputs?"
+msgstr ""
+
+# fc7c95470d5c47d1a1c642101f0f128a
+#: ../../source/developer-docs/contrib_guide_code.rst:97
+msgid "What will happen if your code is given too many inputs?"
+msgstr ""
+
+# 1512fa1ef2674eb7b4fd8e0cffb9ea34
+#: ../../source/developer-docs/contrib_guide_code.rst:99
+msgid ""
+"If you need assistance writing test cases, you can place a comment on the"
+" pull request that was opened earlier and one of the core team members "
+"will be able to help you."
+msgstr ""
+
+# 8ef9e5734a364dc2988978fbf5c1f717
+#: ../../source/developer-docs/contrib_guide_code.rst:103
+msgid ""
+"Go back to the file that you are updating and begin adding the code for "
+"your pull request."
+msgstr ""
+
+# 10fd03dbbce04657995fe36c868333db
+#: ../../source/developer-docs/contrib_guide_code.rst:106
+msgid ""
+"Run the test suite again to see if your changes have caused any of the "
+"test cases to pass. If any of the test cases have failed, go back to your"
+" code and make the updates necessary to have them pass."
+msgstr ""
+
+# c8d1e89343e246daa2cdc22cdeb2611d
+#: ../../source/developer-docs/contrib_guide_code.rst:110
+msgid ""
+"Once all of your test cases have passed, commit both the test cases and "
+"the updated module and push the updates to the branch on your forked "
+"repository."
+msgstr ""
+
+# 87111861fffe4a49a87827323e112ce7
+#: ../../source/developer-docs/contrib_guide_code.rst:113
+msgid ""
+"Once you are ready for your pull request to be reviewed, remove the [WIP]"
+" tag from the front of issue, a project reviewer will review your code "
+"for quality. You can expect the reviewer to check for the documentation "
+"provided in the changes you made, how thorough the test cases you "
+"provided are, and how efficient your code is. Your reviewer will provide "
+"feedback on your code and you will have the chance to edit your code and "
+"apply fixes."
+msgstr ""
+
+# 5f6e2c2d4cc74b1686fec2915006f366
+#: ../../source/developer-docs/contrib_guide_code.rst:120
+msgid ""
+"Once your PR is ready to become a part of the code base, it will be "
+"merged by a member of the core team."
+msgstr ""
+
+# 0b6fc432cbc7440aa4365d35fe0e7533
+#: ../../source/developer-docs/contrib_guide_code.rst:124
+msgid "Contribution Workflow"
+msgstr ""
+
+# 9869fb16c17e4a2dbe7e220f2099e7a4
+#: ../../source/developer-docs/contrib_guide_code.rst:130
+msgid "Core Developer Workflow"
+msgstr ""
+
+# d88b2538fa7c4b65a87600628a3190fa
+#: ../../source/developer-docs/contrib_guide_code.rst:132
+msgid ""
+"To help you understand our review process by core developers after you "
+"submit a pull request, here's a guide that outlines the general process "
+"(specifics may vary a bit across our repositories). Here is an example "
+"for Jupyter notebook 4.x:"
+msgstr ""
+
+# 6afb4060cab3492f8185187faada55b2
+#: ../../source/developer-docs/contrib_guide_code.rst:139
+msgid ""
+"In general, Pull Requests are against ``master`` unless they only affect "
+"a backport branch. If a PR affects master and should be backported, the "
+"general flow is:"
+msgstr ""
+
+# 3b5bfc37063a4062a301ee23411528c0
+#: ../../source/developer-docs/contrib_guide_code.rst:143
+msgid "mark the PR with milestone for the next backport release (4.3)"
+msgstr ""
+
+# c42e3f791f6d4cc38b4fb9ac0eec129a
+#: ../../source/developer-docs/contrib_guide_code.rst:144
+msgid "merge into master"
+msgstr ""
+
+# 018cd8318aef471484dc9184b43973c3
+#: ../../source/developer-docs/contrib_guide_code.rst:145
+msgid "backport to 4.x"
+msgstr ""
+
+# 7b28314df8154e5b8606b722f4d73856
+#: ../../source/developer-docs/contrib_guide_code.rst:146
+msgid "push updated 4.x branch"
+msgstr ""
+
+# 10d9ca0afcf8439aac13eba4c1f428db
+#: ../../source/developer-docs/contrib_guide_code.rst:148
+msgid ""
+"Backports can be done in a variety of ways, but we have `a script "
+"<https://github.com/ipython/ipython/blob/master/tools/backport_pr.py>`_ "
+"for automating the common process to:"
+msgstr ""
+
+# 370a6eafee694f6ca5d7753ca3ef1962
+#: ../../source/developer-docs/contrib_guide_code.rst:152
+msgid ""
+"download the patch ` e.g. <https://patch-"
+"diff.githubusercontent.com/raw/jupyter/notebook/pull/1645.patch>`"
+msgstr ""
+
+# 1964c880516c43f99cbf34dadca2bdf1
+#: ../../source/developer-docs/contrib_guide_code.rst:153
+msgid "checkout the 4.x branch"
+msgstr ""
+
+# 70cb7a619981417393a3e1be5e661492
+#: ../../source/developer-docs/contrib_guide_code.rst:154
+msgid "apply the patch"
+msgstr ""
+
+# 1d6c472ef4e34a87ba54dd61299b1607
+#: ../../source/developer-docs/contrib_guide_code.rst:155
+msgid "make a commit"
+msgstr ""
+
+# bcc8acbb2663447fb1abece94d18a145
+#: ../../source/developer-docs/contrib_guide_code.rst:157
+msgid "which works for simple cases, at least."
+msgstr ""
+
+# 481646fca06049c39c7ccc2c7dfb000d
+#: ../../source/developer-docs/contrib_guide_code.rst:159
+msgid "In this case, it would be:"
+msgstr ""
+
+# 871218e69ea840f6a710fffda0f59255
+#: ../../source/developer-docs/contrib_guide_code.rst:161
+msgid ""
+"python /path/to/ipython-repo/tools/backport_pr.py jupyter/notebook 4.x "
+"1645"
+msgstr ""
+
+# 59008b88919d4084b6e7278a762249be
+#: ../../source/developer-docs/contrib_guide_vuln.rst:3
+msgid "Reporting a Vulnerability"
+msgstr ""
+
+# a848ceabd5bb48f9ba9cd7741ffe2733
+#: ../../source/developer-docs/contrib_guide_vuln.rst:5
+msgid ""
+"If you believe you've found a security vulnerability in a Jupyter "
+"project, please report it to "
+"[security@ipython.org](mailto:security@ipython.org). If you prefer to "
+"encrypt your security reports, you can use [this PGP public key](https"
+"://jupyter-"
+"notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc)."
+msgstr ""
+
+# c52d228e243243108261b278ecd95e9b
+#: ../../source/developer-docs/index.rst:7
+msgid "**Contents**"
+msgstr ""
+
+# 1dc0b8ea396a43d29a89a7917b0c918c
+#: ../../source/developer-docs/index.rst:20
+msgid ""
+"Whether you are a new contributor or a seasoned developer, we're pleased "
+"that you are working on Jupyter. We hope you find the Developer Guide is "
+"useful. Please suggest changes or ask questions about the contents. "
+"Thanks!"
+msgstr ""
+
+# ab19140a7ecf4481a9c8de4115df0760
+#: ../../source/developer-docs/index.rst:24
+msgid ""
+"If you are interested in installing a specific project from source, each "
+"project has documentation on ReadTheDocs. For example, IPython "
+"documentation can be found on `ReadTheDocs "
+"<http://ipython.readthedocs.io/en/latest/install/install.html"
+"#installation-from-source>`_. Most of our packages can be installed from "
+"the source directory like any other Python package, by running:"
+msgstr ""
+
+# 9219dc1779c14cdc86b8897e89749812
+#: ../../source/developer-docs/index.rst:34
+msgid ""
+"The Jupyter notebook needs some extra pieces to build Javascript "
+"components; the information about that is in the `notebook contributor "
+"documentation <http://jupyter-"
+"notebook.readthedocs.io/en/latest/contributing.html#setting-up-a"
+"-development-environment>`_."
+msgstr ""
+
+# ba9cdf4e3c534e8aaf851f3dda9197fa
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:2
+msgid "Jupyter Enhancement Proposals"
+msgstr ""
+
+# ca6fb9c7ab5a4fa886eeafec23b5e9d7
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:5
+msgid "Submitting an Enhancement Proposal"
+msgstr ""
+
+# 7b963188c0664d0eb0db00c494527254
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:6
+msgid ""
+"While using the Notebook, you might discover opportunities for growth and"
+" ideas for useful new features. If so, feel free to submit an enhancement"
+" proposal. The process for submitting enhancements is as follows:"
+msgstr ""
+
+# 00dbb9daf8e847ae9582179a7c574667
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:10
+msgid ""
+"Identify the scope of the enhancement. Is it a change that affects only "
+"on part of the codebase? Is the enhancement, to the best of your "
+"knowledge, fairly trivial to implement? If the scope of the enhancement "
+"is small, it should be be submitted as an issue in the project's "
+"repository. If the scope of your enhancement is large, it should be "
+"submitted to the official `Jupyter Enhancement Proposals repository "
+"<https://GitHub.com/jupyter/enhancement-proposals>`_."
+msgstr ""
+
+# ce6afac33e824a67b47c41ac989e42fe
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:17
+msgid ""
+"Prepare a brief write-up of the problem that your enhancement will "
+"address."
+msgstr ""
+
+# b3c8157c7deb456cbfc628b50b9cb3e5
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:19
+msgid "Prepare a brief write-up of the proposed enhancement itself."
+msgstr ""
+
+# a3742f392e7d48269a6eb5ad6b3b29db
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:21
+msgid ""
+"If the scope of your enhancement (as defined in step 1) is large, then "
+"prepare a detailed write-up of how your enhancement can be potentially "
+"implemented."
+msgstr ""
+
+# 8b68a4fe91c741fa8ca70adea65993b3
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:24
+msgid ""
+"Identify a brief list of the pros and cons associated with implementing "
+"the enhancement that you propose."
+msgstr ""
+
+# 05d6c080c5694b76b055702502bba802
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:27
+msgid ""
+"Identify the individuals who might be interested in implementing the "
+"enhancement."
+msgstr ""
+
+# c2300fb3ceac4a66a45558b7967a8b69
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:29
+msgid ""
+"Depending on the scope of your enhancement, submit it either as an issue "
+"to the appropriate repository or as a Jupyter Enhancement Proposal."
+msgstr ""
+
+# 5229bf41eae2469e935b184e97efb92f
+#: ../../source/developer-docs/releasing.rst:5
+msgid "Basic template for releasing a Jupyter project"
+msgstr ""
+
+# cd861154d1f84d8ea5d16b605e863348
+#: ../../source/developer-docs/releasing.rst:7
+msgid ""
+"Jupyter consists of a bunch of small projects, and a few larger ones. "
+"This lays out the basic process of releasing a smaller project, which "
+"should also apply to larger projects, though they may have some added "
+"steps."
+msgstr ""
+
+# ee207b96ee4e491eb606356ff7070dfa
+#: ../../source/developer-docs/releasing.rst:14
+msgid "Milestones"
+msgstr ""
+
+# 2a00176ea8fb4fe794664c05e57dd8b5
+#: ../../source/developer-docs/releasing.rst:16
+msgid ""
+"Most Jupyter projects use a GitHub milestone system for marking issues "
+"and pull requests in releases. Each release should have a milestone "
+"associated with it. The first step in preparing for a release is to make "
+"sure that every issue and pull request has the right milestone."
+msgstr ""
+
+# 0c7eec680ceb4af9a72f8dab62c26656
+#: ../../source/developer-docs/releasing.rst:20
+msgid ""
+"Go through any **open** Issues and Pull Requests marked with the current "
+"milestone. If there are any, they need to be resolved or bumped to the "
+"next milestone. It's fine to bump issues - they are typically marked with"
+" the earliest feasible milestone, but many such optimistically marked "
+"tasks aren't complete when it's time to release. There's always next "
+"time!"
+msgstr ""
+
+# bb130aa7931f4847b76a34059a9c9d35
+#: ../../source/developer-docs/releasing.rst:25
+msgid ""
+"Check **closed** Issues and Pull Requests, using the milestone filter "
+"\"Issues with no milestone\". There should never be any closed issues or "
+"pull requests without a milestone. If you find any, go through and mark "
+"them with the current milestone or \"no action\" as appropriate."
+msgstr ""
+
+# 405918c188824db7a4ae6128c0016fb5
+#: ../../source/developer-docs/releasing.rst:31
+msgid ""
+"A release may be ready to go when it has zero open issues or pull "
+"requests."
+msgstr ""
+
+# 1e581bc70c1245fa87d458bb6cf9da6f
+#: ../../source/developer-docs/releasing.rst:35
+msgid "Release notes"
+msgstr ""
+
+# cee9ab2013764c5384b4744a1b53fc93
+#: ../../source/developer-docs/releasing.rst:37
+msgid ""
+"Once all of the issues and pull requests are dealt with, it's time to "
+"make release notes. The smaller projects generally have a "
+":file:`changelog.rst` in the docs directory, where you can add a section "
+"for the new release. Look through the pull requests merged for the "
+"current milestone (this is why we use milestones), and write a short "
+"summary of the highlights of the changes in this release. There should "
+"generally be a link to the milestone itself for more details."
+msgstr ""
+
+# 089a6812113341949f101391390ff914
+#: ../../source/developer-docs/releasing.rst:45
+msgid ""
+"Make a pull requests with these notes. It's a good idea to cc @willingc "
+"for review of this PR. Make sure to mark this PR with your release's "
+"milestone!"
+msgstr ""
+
+# cc10475d5ef64e6ba38860fd5de6746d
+#: ../../source/developer-docs/releasing.rst:51
+msgid "Making the release"
+msgstr ""
+
+# df383c7a5c5945838338679952e39cb2
+#: ../../source/developer-docs/releasing.rst:53
+msgid ""
+"Now that your changelog is merged, we can actually build and publish the "
+"release. We'll assume that ``V`` has been declared as a shell variable "
+"containing the release version::"
+msgstr ""
+
+# c3f810a58bec4ab593bd3cb5780a7800
+#: ../../source/developer-docs/releasing.rst:58
+msgid ""
+"Start by making sure you have a clean checkout of master, with no extra "
+"files::"
+msgstr ""
+
+# dfa0fb808869495cb344491a84a9bb95
+#: ../../source/developer-docs/releasing.rst:63
+msgid ""
+"First, update the version of the package, often in the file "
+":file:`<pkg>/_version.py` or similar."
+msgstr ""
+
+# 4bcd13891eac4bb0ba91bbebcf098767
+#: ../../source/developer-docs/releasing.rst:65
+msgid "Commit that change::"
+msgstr ""
+
+# 34263cae40c2473d9fba3a813758b95f
+#: ../../source/developer-docs/releasing.rst:71
+msgid ""
+"At this point, I like to run the tests just to be sure that setting the "
+"version didn't confuse anything."
+msgstr ""
+
+# 5a5e318fddd94e67a6ff324546cf6ea8
+#: ../../source/developer-docs/releasing.rst:74
+msgid "Build the distributions::"
+msgstr ""
+
+# f6f03aad7bdd4be79c7cb7d1d4fd0898
+#: ../../source/developer-docs/releasing.rst:79
+msgid "Tag the commit::"
+msgstr ""
+
+# 83952c3b04f449d8a88e05fdb304dd29
+#: ../../source/developer-docs/releasing.rst:83
+msgid ""
+"And finally, publish everything, to github and PyPI using `twine "
+"<https://github.com/pypa/twine>`_::"
+msgstr ""
+
+# 6aae441e50b747efa6796a94f1d11211
+#: ../../source/developer-docs/releasing.rst:89
+msgid ""
+"We have a release! You can now bump the version to the next '.dev' "
+"version, by editing :file:`<pkg>/_version.py` (or similar) again, and "
+"commit::"
+msgstr ""
+
+# c3cde896bc9041b49e4f3305ec5d2128
+#: ../../source/developer-docs/releasing.rst:97
+msgid ""
+"The pushes assume that `origin` points to the main jupyter/ipython repo. "
+"Depending how you use git, this could be `upstream` or something else."
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/development_guide.po
+++ b/docs/source/locale/en/LC_MESSAGES/development_guide.po
@@ -1,0 +1,3932 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 20:11-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 68594f7b5d5243178cc934fef0ff52ac
+#: ../../source/development_guide/boot2docker.rst:4
+msgid "Setup IPython development environment using boot2docker"
+msgstr ""
+
+# c58a4d9ce362416aa2daee3df0414ffb
+# e672e2de6d6449a29cc141b4ade2eeda
+# da64540a97524eae993335e681c87efe
+# df673bb406394df09796f62b181bc76c
+# c6ccec59d6b24b65b672d2b16e0cfbf3
+# a3791289050546b592649661277f5df9
+# c7c0ad0e79bb413b8d7956188294533b
+# 98a81ea5075b4ea7b5565d6bc0b86a03
+# 8443422c6ee045edbcd483ce2c654348
+# 0a17cb2a8248427c9980b12767b26bf5
+# 53507b55bf0d4779879707534702049f
+# e7da595236724a8c9c3f228d663e0a98
+# fcc87c9518d44372986a025fb70993b6
+# 914169504e1f479db9966697a9c327b4
+# abe35ed53e9544aaba2a10892e50c995
+# 75aa173cd6e349c38f5c305f6c1e8cf6
+#: ../../source/development_guide/boot2docker.rst:7
+#: ../../source/development_guide/closing_prs.rst:7
+#: ../../source/development_guide/coding_style.rst:7
+#: ../../source/development_guide/documenting_ipython.rst:7
+#: ../../source/development_guide/github_workflow.rst:7
+#: ../../source/development_guide/index.rst:7
+#: ../../source/development_guide/js_events.rst:7
+#: ../../source/development_guide/lab_meetings.rst:7
+#: ../../source/development_guide/less.rst:7
+#: ../../source/development_guide/pull_request.rst:7
+#: ../../source/development_guide/py3compat.rst:7
+#: ../../source/development_guide/releasing.rst:7
+#: ../../source/development_guide/rest_api.rst:7
+#: ../../source/development_guide/sphinx_directive.rst:7
+#: ../../source/development_guide/testing.rst:7
+#: ../../source/development_guide/testing_kernels.rst:7
+msgid ""
+"This is copied verbatim from the old IPython wiki and is currently under "
+"development. Much of the information in this part of the development "
+"guide is out of date."
+msgstr ""
+
+# 838ebaf9ef564b538433da5fc636f7f1
+#: ../../source/development_guide/boot2docker.rst:9
+msgid ""
+"The following are instructions on how to get an IPython development "
+"environment up and running without having to install anything on your "
+"host machine, other than ```boot2docker`` "
+"<https://github.com/boot2docker/boot2docker>`__ and ```docker`` "
+"<https://www.docker.com/>`__."
+msgstr ""
+
+# b68287e01b4e44feaa6874beb4f48e33
+#: ../../source/development_guide/boot2docker.rst:16
+msgid "Install ``boot2docker``"
+msgstr ""
+
+# 87465fdbf40840caa1d714143f237347
+#: ../../source/development_guide/boot2docker.rst:18
+msgid ""
+"Install `boot2docker <https://github.com/boot2docker/boot2docker>`__. "
+"There are multiple ways to install, depending on your environment. See "
+"the `boot2docker docs <https://github.com/boot2docker/boot2docker>`__."
+msgstr ""
+
+# 4b5576467cd04ab4addfaf7f2dbc9c8c
+#: ../../source/development_guide/boot2docker.rst:24
+msgid "Mac OS X"
+msgstr ""
+
+# c22634b884c6483ebe67c40611bc9805
+#: ../../source/development_guide/boot2docker.rst:26
+msgid "On a Mac OS X host with `Homebrew <http://brew.sh>`__ installed:"
+msgstr ""
+
+# db5a7fb63dbe455083f8e8e2caed7435
+#: ../../source/development_guide/boot2docker.rst:33
+msgid "Initialize ``boot2docker`` VM"
+msgstr ""
+
+# 54c6a6b598ac43b6aee4cd42e11a47b6
+#: ../../source/development_guide/boot2docker.rst:40
+msgid "Start VM"
+msgstr ""
+
+# 0f0d8f53a4ef40b590afdf1f1dcd8902
+#: ../../source/development_guide/boot2docker.rst:46
+msgid ""
+"The ``boot2docker`` CLI communicates with the docker daemon on the "
+"``boot2docker`` VM. To do this, we must set some environment variables, "
+"e.g. ``DOCKER_HOST``,"
+msgstr ""
+
+# cc1d31d1c4a247378bfcaaad4453050f
+#: ../../source/development_guide/boot2docker.rst:54
+msgid "To view the IP address of the VM:"
+msgstr ""
+
+# 3644c712c8d042deb536906e299d7302
+#: ../../source/development_guide/boot2docker.rst:62
+msgid "Install ``ipython`` from Development Branch"
+msgstr ""
+
+# fb26c1a1c9e64219a9569a2f09491a7c
+#: ../../source/development_guide/boot2docker.rst:69
+msgid "Build Docker Image"
+msgstr ""
+
+# 3186d34726d84139b077dd88cfcfb94a
+#: ../../source/development_guide/boot2docker.rst:71
+msgid ""
+"Use the Dockerfile in the cloned ``ipython`` directory to build a Docker "
+"image."
+msgstr ""
+
+# 07c715242d6d4a7fbf8b07eb27d00c5d
+#: ../../source/development_guide/boot2docker.rst:80
+msgid "Run Docker Container"
+msgstr ""
+
+# 1e5ff76a0da84a9d94587ef29a5ff8d4
+#: ../../source/development_guide/boot2docker.rst:82
+msgid ""
+"Run a container using the new image. We mount the entire ``ipython`` "
+"source tree on the host into the container at ``/srv/ipython`` to enable "
+"changes we make to the source on the host immediately reflected in the "
+"container."
+msgstr ""
+
+# 7169e25c6baf40b8889c6a22f710203e
+#: ../../source/development_guide/boot2docker.rst:93
+msgid "To list the running container from another shell on the host:"
+msgstr ""
+
+# 03945f9ceca44f629ddca27e5a97b97e
+#: ../../source/development_guide/boot2docker.rst:103
+msgid "Install IPython in Editable Mode"
+msgstr ""
+
+# 5a1104a612284812a3ae1bbe1c90fea6
+#: ../../source/development_guide/boot2docker.rst:105
+msgid ""
+"Once in the container, you'll need to uninstall the ``ipython`` package "
+"and re-install in editable mode to enable your dev changes to be "
+"reflected in your environment."
+msgstr ""
+
+# 5ff35ef88252440b9f9b3eb342580672
+#: ../../source/development_guide/boot2docker.rst:120
+msgid "Run Notebook Server"
+msgstr ""
+
+# 4e74c9cf2d184935a6c3a2b096d959b5
+#: ../../source/development_guide/boot2docker.rst:127
+msgid "Visit Notebook Server"
+msgstr ""
+
+# 1c7053580c414a5288a396b9ed7805f8
+#: ../../source/development_guide/boot2docker.rst:129
+msgid ""
+"On your host, run the following command to get the IP of the boot2docker "
+"VM if you forgot:"
+msgstr ""
+
+# 23da7928850040239ef807b7959c0cd9
+#: ../../source/development_guide/boot2docker.rst:138
+msgid "Then visit it in your browser:"
+msgstr ""
+
+# cef8292d861940009dfe37218ea8e00b
+#: ../../source/development_guide/boot2docker.rst:145
+msgid ""
+"As a shortcut on a Mac, you can run the following in a terminal window "
+"(or make it a bash alias):"
+msgstr ""
+
+# dbb1b7b037264b6aa1392abd9a3cc4e8
+#: ../../source/development_guide/closing_prs.rst:4
+msgid "Policy on Closing Pull Requests"
+msgstr ""
+
+# 4457e1e8c0744af2998ef6c8fda5393a
+#: ../../source/development_guide/closing_prs.rst:9
+msgid ""
+"IPython has the following policy on closing pull requests. The goal of "
+"this policy is to keep our pull request queue small and allow us to focus"
+" on code that is being actively developed and has a strong chance of "
+"being merged in master soon."
+msgstr ""
+
+# 6d8ef2f40c884f8485f2555032c90e65
+#: ../../source/development_guide/closing_prs.rst:14
+msgid "A pull request will be closed when:"
+msgstr ""
+
+# 5296d8b1e26d4920b014f007532f13c1
+#: ../../source/development_guide/closing_prs.rst:16
+msgid ""
+"It has been reviewed, but has sat for a month or more waiting for the "
+"submitter to commit more code to address the comments."
+msgstr ""
+
+# 1b189f41fadd4727b9518d4a36cea12e
+#: ../../source/development_guide/closing_prs.rst:18
+msgid ""
+"The review process has uncovered larger design or technical issues that "
+"extend beyond the details of the specific pull request."
+msgstr ""
+
+# 33f62e8f6d374379becff41a3411cfc3
+#: ../../source/development_guide/closing_prs.rst:21
+msgid ""
+"In particular, we do not accept whole large \"cleanup\" changes which do "
+"not address any specific bug. This includes trailing whitespace, PEP8, "
+"etc. One of the reasons is that such massive cleanup provide plenty of "
+"opportunities to introduce new and subtle bugs."
+msgstr ""
+
+# ff27543439ef4ff797a196a8a4e5aed6
+#: ../../source/development_guide/closing_prs.rst:27
+msgid ""
+"In general we will not close pull requests because of a lack of review. "
+"If a pull request has sat for a month or more without review, we need to "
+"kick ourselves and get to reviewing it."
+msgstr ""
+
+# 836a8c8dc6d44c04a337d673fb6fbff0
+#: ../../source/development_guide/closing_prs.rst:31
+msgid "When a pull request is closed we will do the following:"
+msgstr ""
+
+# 266b795ae71e43cc87cddb8286e40a03
+#: ../../source/development_guide/closing_prs.rst:33
+msgid ""
+"Post a github message to the pull request to confirm that everyone is "
+"fine with closing the pull request. This message should cite this policy."
+msgstr ""
+
+# 16ba3fb52f27430f90d7f61930398bb1
+#: ../../source/development_guide/closing_prs.rst:36
+msgid ""
+"Open an issue to track the pull request. This issue should describe what "
+"would be needed in order to reopen the pull request."
+msgstr ""
+
+# 0f58a1256caa4b7192796a5736a382fa
+#: ../../source/development_guide/closing_prs.rst:38
+msgid ""
+"Post a github message to the pull request encouraging the submitter to "
+"continue with the work and detail what issues need to be addressed in "
+"order for the pull request to be reopened."
+msgstr ""
+
+# e69ccb3b0acf4fd084506753d3c24d19
+#: ../../source/development_guide/closing_prs.rst:42
+msgid "This policy was discussed in the following thread:"
+msgstr ""
+
+# 1f3432526f934316b5cc8c24c79373d0
+#: ../../source/development_guide/closing_prs.rst:44
+msgid "https://mail.scipy.org/pipermail/ipython-dev/2012-August/010025.html"
+msgstr ""
+
+# ed7cad128706471b952c27bef1853163
+#: ../../source/development_guide/closing_prs.rst:47
+msgid "Example Message:"
+msgstr ""
+
+# 2ed6aa93ae254842abf6ac9840dcad6b
+#: ../../source/development_guide/coding_style.rst:4
+msgid "Coding Style"
+msgstr ""
+
+# 9dc8aa2c74864d179a5660cf9b835565
+#: ../../source/development_guide/coding_style.rst:9
+msgid ""
+"This document describes our coding style. Coding style refers to the "
+"following:"
+msgstr ""
+
+# 3b823c54355c4add8d1a262896faff88
+#: ../../source/development_guide/coding_style.rst:12
+msgid "How source code is formatted (indentation, spacing, etc.)"
+msgstr ""
+
+# 57c4f53e269a4abc99fb2f32b3c45fbe
+#: ../../source/development_guide/coding_style.rst:13
+msgid "How things are named (variables, functions, classes, modules, etc.)"
+msgstr ""
+
+# c110cd13183f48c3ba04055dc0fe3cd1
+#: ../../source/development_guide/coding_style.rst:16
+msgid "General coding conventions"
+msgstr ""
+
+# 919ed475296f42af850c26db1f5cf22d
+#: ../../source/development_guide/coding_style.rst:18
+msgid ""
+"In general, we follow the standard Python style conventions as described "
+"in Python's `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`__, the "
+"official Python Style Guide."
+msgstr ""
+
+# af906044ad2e45d59473fa93957caf11
+#: ../../source/development_guide/coding_style.rst:22
+msgid "Other general comments:"
+msgstr ""
+
+# a67babfcd44d4b78b92ae38338f1ae72
+#: ../../source/development_guide/coding_style.rst:24
+msgid ""
+"In a large file, top level classes and functions should be separated by 2"
+" lines to make it easier to separate them visually."
+msgstr ""
+
+# 93eb729f53834df789c27c571a413cf3
+#: ../../source/development_guide/coding_style.rst:27
+msgid "Use 4 spaces for indentation, **never** use hard tabs."
+msgstr ""
+
+# 7f266e5248eb4e03b2e6172a78a8192f
+#: ../../source/development_guide/coding_style.rst:29
+msgid ""
+"Keep the ordering of methods the same in classes that have the same "
+"methods. This is particularly true for classes that implement similar "
+"interfaces and for interfaces that are similar."
+msgstr ""
+
+# f0f19b61545e4b3494e24b82a6428eb8
+#: ../../source/development_guide/coding_style.rst:34
+msgid "Naming conventions"
+msgstr ""
+
+# 627a72694cf142f29149585571fe0f00
+#: ../../source/development_guide/coding_style.rst:36
+msgid ""
+"For naming conventions, we also follow the guidelines of `PEP 8 "
+"<https://www.python.org/dev/peps/pep-0008/>`__. Some of the existing code"
+" doesn't honor this perfectly, but for all new and refactored IPython "
+"code, we'll use:"
+msgstr ""
+
+# 01c1d05be01b4ebaa2925993cda05b5e
+#: ../../source/development_guide/coding_style.rst:41
+msgid ""
+"All ``lowercase`` module names. Long module names can have words "
+"separated by underscores (``really_long_module_name.py``), but this is "
+"not required. Try to use the convention of nearby files."
+msgstr ""
+
+# 735af590e2894b84a25c4e014f5668ac
+#: ../../source/development_guide/coding_style.rst:45
+msgid "``CamelCase`` for class names."
+msgstr ""
+
+# 79ba0d92752b4a81a3edd927e5bb04bb
+#: ../../source/development_guide/coding_style.rst:47
+msgid ""
+"``lowercase_with_underscores`` for methods, functions, variables and "
+"attributes."
+msgstr ""
+
+# 8bef511e37924748b1d2e276dbe87e14
+#: ../../source/development_guide/coding_style.rst:50
+msgid ""
+"Implementation-specific *private* methods will use "
+"``_single_underscore_prefix``. Names with a leading double underscore "
+"will *only* be used in special cases, as they makes subclassing difficult"
+" (such names are not easily seen by child classes)."
+msgstr ""
+
+# 91bbe7cbf0a94cfbbbd298eaa6a826eb
+#: ../../source/development_guide/coding_style.rst:55
+msgid ""
+"Occasionally some run-in lowercase names are used, but mostly for very "
+"short names or where we are implementing methods very similar to existing"
+" ones in a base class (like ``runlines()`` where ``runsource()`` and "
+"``runcode()`` had established precedent)."
+msgstr ""
+
+# 7c362e1e2fa444b49046b01386e4deb0
+#: ../../source/development_guide/coding_style.rst:60
+msgid ""
+"The old IPython codebase has a big mix of classes and modules prefixed "
+"with an explicit ``IP`` of ``ip``. This is not necessary and all new code"
+" should not use this prefix. The only case where this approach is "
+"justified is for classes or functions which are expected to be imported "
+"into external namespaces and a very generic name (like Shell) that is "
+"likely to clash with something else. However, if a prefix seems "
+"absolutely necessary the more specific ``IPY`` or ``ipy`` are preferred."
+msgstr ""
+
+# 726f417c6f4f4bd7848b5a4fb6335b48
+#: ../../source/development_guide/coding_style.rst:69
+msgid "All JavaScript code should follow these naming conventions as well."
+msgstr ""
+
+# 45e0d17e22f64edf9c68181820b2598c
+#: ../../source/development_guide/coding_style.rst:72
+msgid "Attribute declarations for objects"
+msgstr ""
+
+# beddc03b335a4e8fb4cd44d441db527b
+#: ../../source/development_guide/coding_style.rst:74
+msgid ""
+"In general, objects should declare, in their *class*, all attributes the "
+"object is meant to hold throughout its life. While Python allows you to "
+"add an attribute to an instance at any point in time, this makes the code"
+" harder to read and requires methods to constantly use checks with "
+"hasattr() or try/except calls. By declaring all attributes of the object "
+"in the class header, there is a single place one can refer to for "
+"understanding the object's data interface, where comments can explain the"
+" role of each variable and when possible, sensible deafaults can be "
+"assigned."
+msgstr ""
+
+# 37f87ca28453415582149435e73f1912
+#: ../../source/development_guide/coding_style.rst:84
+msgid ""
+"If an attribute is meant to contain a mutable object, it should be set to"
+" ``None`` in the class and its mutable value should be set in the "
+"object's constructor. Since class attributes are shared by all instances,"
+" failure to do this can lead to difficult to track bugs. But you should "
+"still set it in the class declaration so the interface specification is "
+"complete and documented in one place."
+msgstr ""
+
+# 608ec84f1ee642bb993c493b2b6c2e9e
+#: ../../source/development_guide/coding_style.rst:91
+msgid "A simple example:"
+msgstr ""
+
+# 5c20ddda84a14bce9bf606623cc93d5c
+#: ../../source/development_guide/coding_style.rst:108
+msgid "New files"
+msgstr ""
+
+# 1cb302a31307483e8d7cbbf0b518efef
+#: ../../source/development_guide/coding_style.rst:110
+msgid ""
+"When starting a new Python file for IPython, you can use the `following "
+"template <./template.py>`__ as a starting point that has a few common "
+"things pre-written for you."
+msgstr ""
+
+# 8dca628763ce406499eb008ec3428735
+#: ../../source/development_guide/documenting_ipython.rst:4
+msgid "Documenting IPython"
+msgstr ""
+
+# 84d33dde8447417eb9e358383a11690f
+#: ../../source/development_guide/documenting_ipython.rst:9
+msgid ""
+"When contributing code to IPython, you should strive for clarity and "
+"consistency, without falling prey to a style straitjacket. Basically, "
+"'document everything, try to be consistent, do what makes sense.'"
+msgstr ""
+
+# 7196603c3de542cea955a86758144197
+#: ../../source/development_guide/documenting_ipython.rst:13
+msgid ""
+"By and large we follow existing Python practices in major projects like "
+"Python itself or NumPy, this document provides some additional detail for"
+" IPython."
+msgstr ""
+
+# 219d53313b744213b12d81b83e8df5e1
+#: ../../source/development_guide/documenting_ipython.rst:18
+msgid "Standalone documentation"
+msgstr ""
+
+# 18573d3352f3414eac2f83f8e1e871b7
+#: ../../source/development_guide/documenting_ipython.rst:20
+msgid ""
+"All standalone documentation should be written in plain text (``.txt``) "
+"files using reStructuredText [reStructuredText]\\_ for markup and "
+"formatting. All such documentation should be placed in the directory "
+"docs/source of the IPython source tree. Or, when appropriate, a suitably "
+"named subdirectory should be used. The documentation in this location "
+"will serve as the main source for IPython documentation."
+msgstr ""
+
+# 5cd39db2efda4df4b349d060d6aa6fed
+#: ../../source/development_guide/documenting_ipython.rst:27
+msgid ""
+"The actual HTML and PDF docs are built using the Sphinx [Sphinx]\\_ "
+"documentation generation tool. Once you have Sphinx installed, you can "
+"build the html docs yourself by doing:"
+msgstr ""
+
+# e998f0d0a6c04b7b8c56c83b9a9f331d
+#: ../../source/development_guide/documenting_ipython.rst:36
+msgid ""
+"Our usage of Sphinx follows that of matplotlib [Matplotlib]\\_ closely. "
+"We are using a number of Sphinx tools and extensions written by the "
+"matplotlib team and will mostly follow their conventions, which are "
+"nicely spelled out in their documentation guide [MatplotlibDocGuide]\\_. "
+"What follows is thus a abridged version of the matplotlib documentation "
+"guide, taken with permission from the matplotlib team."
+msgstr ""
+
+# 8e666fd21967441ea266b6c67f7d3525
+#: ../../source/development_guide/documenting_ipython.rst:43
+msgid ""
+"If you are reading this in a web browser, you can click on the \"Show "
+"Source\" link to see the original reStricturedText for the following "
+"examples."
+msgstr ""
+
+# cc20bf2f388f4367b6ba15ad83d829a0
+#: ../../source/development_guide/documenting_ipython.rst:47
+msgid "A bit of Python code:"
+msgstr ""
+
+# 264cf7c13ba249b89ef7c49f385d7e84
+#: ../../source/development_guide/documenting_ipython.rst:55
+msgid "An interactive Python session:"
+msgstr ""
+
+# 786a003a590a47deb799b41de76c206d
+#: ../../source/development_guide/documenting_ipython.rst:63
+msgid "An IPython session:"
+msgstr ""
+
+# 6b24f490d8474cb2b37153c2af7ce628
+#: ../../source/development_guide/documenting_ipython.rst:75
+msgid "A bit of shell code:"
+msgstr ""
+
+# db00e5ea736140fb9f337702c96a4a8b
+#: ../../source/development_guide/documenting_ipython.rst:84
+msgid "Docstring format"
+msgstr ""
+
+# 4c0a416dddfd49c3a4dd057290418e1a
+#: ../../source/development_guide/documenting_ipython.rst:86
+msgid ""
+"Good docstrings are very important. Unfortunately, Python itself only "
+"provides a rather loose standard for docstrings [PEP257]\\_, and there is"
+" no universally accepted convention for all the different parts of a "
+"complete docstring. However, the NumPy project has established a very "
+"reasonable standard, and has developed some tools to support the smooth "
+"inclusion of such docstrings in Sphinx-generated manuals. Rather than "
+"inventing yet another pseudo-standard, IPython will be henceforth "
+"documented using the NumPy conventions; we carry copies of some of the "
+"NumPy support tools to remain self-contained, but share back upstream "
+"with NumPy any improvements or fixes we may make to the tools."
+msgstr ""
+
+# 55afdecbcdcf4655a4a1524d6a7dd4e8
+#: ../../source/development_guide/documenting_ipython.rst:97
+msgid ""
+"The NumPy documentation guidelines [NumPyDocGuide]\\_ contain detailed "
+"information on this standard, and for a quick overview, the NumPy example"
+" docstring [NumPyExampleDocstring]\\_ is a useful read."
+msgstr ""
+
+# 8b42aebb3a444d4d9b728e9ad4ddd161
+#: ../../source/development_guide/documenting_ipython.rst:101
+msgid ""
+"For user-facing APIs, we try to be fairly strict about following the "
+"above standards (even though they mean more verbose and detailed "
+"docstrings). Wherever you can reasonably expect people to do "
+"introspection with:"
+msgstr ""
+
+# eeec98ec0a6b460f840a0694f95d90ab
+#: ../../source/development_guide/documenting_ipython.rst:110
+msgid "the docstring should follow the NumPy style and be fairly detailed."
+msgstr ""
+
+# ff6b3e20f5bf45a791cbe212c899964c
+#: ../../source/development_guide/documenting_ipython.rst:112
+msgid ""
+"For purely internal methods that are only likely to be read by others "
+"extending IPython itself we are a bit more relaxed, especially for "
+"small/short methods and functions whose intent is reasonably obvious. We "
+"still expect docstrings to be written, but they can be simpler. For very "
+"short functions with a single-line docstring you can use something like:"
+msgstr ""
+
+# 356a512b00f64482a03af0ccb7086cf0
+#: ../../source/development_guide/documenting_ipython.rst:125
+msgid "and for longer multiline strings:"
+msgstr ""
+
+# 317dcb97e87a48df8a65ea5a29ce8171
+#: ../../source/development_guide/documenting_ipython.rst:136
+msgid ""
+"Here are two additional PEPs of interest regarding documentation of code."
+" While both of these were rejected, the ideas therein form much of the "
+"basis of docutils (the machinery to process reStructuredText):"
+msgstr ""
+
+# 3c9e0437ad854754bfefb01141704884
+#: ../../source/development_guide/documenting_ipython.rst:140
+msgid ""
+"`Docstring Processing System Framework "
+"<https://www.python.org/dev/peps/pep-0256/>`__"
+msgstr ""
+
+# 5693f929f2b34d5a8f7e870041bd26e3
+#: ../../source/development_guide/documenting_ipython.rst:142
+msgid ""
+"`Docutils Design Specification "
+"<https://www.python.org/dev/peps/pep-0258/>`__"
+msgstr ""
+
+# a429c37f728d49268eb32174328bbecc
+#: ../../source/development_guide/documenting_ipython.rst:145
+msgid "**note**"
+msgstr ""
+
+# 0115bc4e0feb41acb766d6359b30a749
+#: ../../source/development_guide/documenting_ipython.rst:147
+msgid ""
+"In the past IPython used epydoc so currently many docstrings still use "
+"epydoc conventions. We will update them as we go, but all new code should"
+" be documented using the NumPy standard."
+msgstr ""
+
+# 0a62190ea5ec408199bc8c8de14bb3d5
+#: ../../source/development_guide/documenting_ipython.rst:152
+msgid "Building and uploading"
+msgstr ""
+
+# e6d62b507602420ba1108675bd354123
+#: ../../source/development_guide/documenting_ipython.rst:154
+msgid ""
+"The built docs are stored in a separate repository. Through some github "
+"magic, they're automatically exposed as a website. It works like this:"
+msgstr ""
+
+# 033f18c19fd14b2d850eebfe9c5bff9c
+#: ../../source/development_guide/documenting_ipython.rst:157
+msgid ""
+"You will need to have sphinx and latex installed. In Ubuntu, install "
+"``texlive-latex-recommended texlive-latex-extra texlive-fonts-"
+"recommended``. Install the latest version of sphinx from PyPI (``pip "
+"install sphinx``)."
+msgstr ""
+
+# 76ad90067595421eb7515641ec908c1e
+#: ../../source/development_guide/documenting_ipython.rst:161
+msgid ""
+"Ensure that the development version of IPython is the first in your "
+"system path. You can either use a virtualenv, or modify your PYTHONPATH."
+msgstr ""
+
+# 9a38ef6f51434d2a89b0910cf9abab96
+#: ../../source/development_guide/documenting_ipython.rst:164
+msgid ""
+"Switch into the docs directory, and run ``make gh-pages``. This will "
+"build your updated docs as html and pdf, then automatically check out the"
+" latest version of the docs repository, copy the built docs into it, and "
+"commit your changes."
+msgstr ""
+
+# df5ab19592a5476285b9e7d8eb2afd48
+#: ../../source/development_guide/documenting_ipython.rst:168
+msgid "Open the built docs in a web browser, and check that they're as expected."
+msgstr ""
+
+# 18be1af497b341e2a51dc82023fc53be
+#: ../../source/development_guide/documenting_ipython.rst:170
+msgid ""
+"(When building the docs for a new tagged release, you will have to add "
+"its link to index.rst, then run ``python build_index.py`` to update "
+"index.html. Commit the change.)"
+msgstr ""
+
+# 8e1611ea31854e92a53e904775463bee
+#: ../../source/development_guide/documenting_ipython.rst:173
+msgid ""
+"Upload the docs with ``git push``. This only works if you have write "
+"access to the docs repository."
+msgstr ""
+
+# ec61477d7da4430a9b32d253523f183f
+#: ../../source/development_guide/documenting_ipython.rst:175
+msgid ""
+"If you are building a version that is not the current dev branch, nor a "
+"tagged release, then you must run gh-pages.py directly with ``python gh-"
+"pages.py <version>``, and *not* with ``make gh-pages``."
+msgstr ""
+
+# 1649b48861b04f75bf0ebb94efa60170
+#: ../../source/development_guide/github_workflow.rst:4
+msgid "IPython on GitHub"
+msgstr ""
+
+# 3585ed0c8e314d96a6bb14e72277340e
+#: ../../source/development_guide/github_workflow.rst:9
+msgid "Notes on working with GitHub"
+msgstr ""
+
+# 25cdba5ee7d847f0ac00fc8b042838d5
+#: ../../source/development_guide/github_workflow.rst:14
+msgid "Milestones"
+msgstr ""
+
+# 0f8c5c03390e4297aa264a525fa88975
+#: ../../source/development_guide/github_workflow.rst:16
+#, python-format
+msgid "100% of confirmed issues should have a milestone."
+msgstr ""
+
+# 962e8c858379422dbd3521984486885f
+#: ../../source/development_guide/github_workflow.rst:17
+msgid "An issue should never be closed without a milestone."
+msgstr ""
+
+# 083f524c4a424ba0872df779d2fdd5ac
+#: ../../source/development_guide/github_workflow.rst:18
+msgid "All pull requests should have a milestone."
+msgstr ""
+
+# bbfa916999bf40bf86ac1e57bf98442d
+#: ../../source/development_guide/github_workflow.rst:19
+msgid ""
+"All issues closed should be marked with the next release milestone, next "
+"backport milestone, or **no action**."
+msgstr ""
+
+# a47267eb8fa34a3c95b8d48c20f67475
+#: ../../source/development_guide/github_workflow.rst:21
+msgid "Open issues should only lack a milestone if:"
+msgstr ""
+
+# 2ade481e7b04485bbb5fa1e2edbcff5d
+#: ../../source/development_guide/github_workflow.rst:23
+msgid "more clarification is required (label: ``needs-info``)"
+msgstr ""
+
+# 25a12565438b42c4ade49360ba8d7f5c
+#: ../../source/development_guide/github_workflow.rst:25
+msgid "In general, there will be four milestones with open issues:"
+msgstr ""
+
+# 16bfe5662f274d3580492d27cc15f88c
+#: ../../source/development_guide/github_workflow.rst:27
+msgid ""
+"**next minor release**. This milestone contains issues that should be "
+"backported for the next minor release. See `below <#backporting>`__ for "
+"information on backporting."
+msgstr ""
+
+# 75539ed429124cefbb1a4ca005b58e98
+#: ../../source/development_guide/github_workflow.rst:30
+msgid ""
+"**next major release**. This should be the default milestone of all "
+"issues. As the release approaches, issues can be explicitly bumped to "
+"next release + 1."
+msgstr ""
+
+# e0269932529847bf80bbfb32ef1eb875
+#: ../../source/development_guide/github_workflow.rst:33
+msgid ""
+"**next major release + 1**. Only issues that we are confident will *not* "
+"be included in the next release go here. This milestone should be mostly "
+"empty until relatively close to release."
+msgstr ""
+
+# 03b9b3e660694f1c975ef87b6237cb54
+#: ../../source/development_guide/github_workflow.rst:36
+msgid ""
+"**wishlist**. This is the milestone for issues that we have no immediate "
+"plans to address."
+msgstr ""
+
+# 2d20a33c88384cbd9ac6d2b2853778fb
+#: ../../source/development_guide/github_workflow.rst:39
+msgid ""
+"The remaining milestone is **no action** for open or closed issues that "
+"require no action:"
+msgstr ""
+
+# ac39ba3996a54cdb84c3aabf70f2f42b
+#: ../../source/development_guide/github_workflow.rst:42
+msgid "Not actually an issue (e.g. questions, discussion, etc.)"
+msgstr ""
+
+# 4eb11b0ab81c4186af066494cbf6f880
+#: ../../source/development_guide/github_workflow.rst:43
+msgid "Duplicate of an existing Issue"
+msgstr ""
+
+# e910e40d62ae40ba92ebf2aad4f571f7
+#: ../../source/development_guide/github_workflow.rst:44
+msgid "Closed because we won't fix it"
+msgstr ""
+
+# f7fd1309dbb94e44816ac5f6d3412aae
+#: ../../source/development_guide/github_workflow.rst:45
+msgid ""
+"When an issue is closed with **no action**, it means that the issue will "
+"not be fixed, or it was not an issue at all."
+msgstr ""
+
+# 226b21806c0340128426c701cad68736
+#: ../../source/development_guide/github_workflow.rst:48
+msgid "When closing an issue, it should always have one of these milestones:"
+msgstr ""
+
+# 0b2befff4807419fbd6f84974b7f8c46
+#: ../../source/development_guide/github_workflow.rst:50
+msgid "**next minor release** because the issue has been addressed"
+msgstr ""
+
+# 146a5f43c2c440328ef41b0494c607b1
+#: ../../source/development_guide/github_workflow.rst:51
+msgid "**next major release** because the issue has been addressed"
+msgstr ""
+
+# 8043711c7ac7473390f1aef4d28b1d95
+#: ../../source/development_guide/github_workflow.rst:52
+msgid ""
+"**no action** because the issue *will not* be addressed, or it is a "
+"duplicate/non-issue."
+msgstr ""
+
+# 048050b4c6254852adc7aa6ba6bb05f6
+#: ../../source/development_guide/github_workflow.rst:55
+msgid ""
+"In general: When in doubt, mark with **next release**. We can always push"
+" back when we get closer to a given release."
+msgstr ""
+
+# fd9848b03ee84d5a9624e3483c251a69
+#: ../../source/development_guide/github_workflow.rst:59
+msgid "Labels and issues"
+msgstr ""
+
+# 9b8cd118660a40218ef73c550077249a
+#: ../../source/development_guide/github_workflow.rst:61
+msgid ""
+"Issues should always be labeled once they are confirmed (not necessary "
+"for issues that are still being clarified, or may be duplicates or not "
+"issues at all)."
+msgstr ""
+
+# dcacfa148b804c6db2f154268d88c844
+#: ../../source/development_guide/github_workflow.rst:65
+msgid "Some significant labels:"
+msgstr ""
+
+# 26d8c609c57b43c39115722f0ab20355
+#: ../../source/development_guide/github_workflow.rst:67
+msgid ""
+"``needs-info``: issue needs more information from submitter before "
+"progress can be made"
+msgstr ""
+
+# 6b80d1ff88f84142a5403d8b16fa0239
+#: ../../source/development_guide/github_workflow.rst:69
+msgid "``bug``: errors are raised, or unintended behavior occurs"
+msgstr ""
+
+# fb4b2da07e144e4e9a2a89ed6e2a8309
+#: ../../source/development_guide/github_workflow.rst:70
+msgid "``enhancement``: improvements that are not bugs"
+msgstr ""
+
+# 89c22fbe066c4b50bc24db7569adf9ad
+#: ../../source/development_guide/github_workflow.rst:77
+msgid ""
+"backport-X.Y.Z: Any fix for this issue should be backported to the "
+"maintenance branch. backports are expressed with milestones, starting "
+"with 2.1."
+msgstr ""
+
+# bea030babcf847d59f598000b057b061
+#: ../../source/development_guide/github_workflow.rst:80
+msgid ""
+"``prio-foo``: a priority level for ranking issues - nonessential, but "
+"prio-high/low are useful for explicitly promoting/demoting issues, "
+"particularly when nearing release."
+msgstr ""
+
+# 79d34ec383e549e9ad82a26201e9a3fe
+#: ../../source/development_guide/github_workflow.rst:83
+msgid ""
+"``ClosedPR``: This issue is a reminder for a PR that was closed for going"
+" stale."
+msgstr ""
+
+# ded670b7781b4ff38727ca5925f8fb91
+#: ../../source/development_guide/github_workflow.rst:85
+msgid "``sprint-friendly``: Obvious or easy fixes, where"
+msgstr ""
+
+# f44525ee35164c348398f65d3d5fef6e
+#: ../../source/development_guide/github_workflow.rst:87
+msgid ""
+"All confirmed issues should at least have a ``bug`` or ``enhancement`` "
+"label, and be marked with any affected components (e.g ``parallel``, "
+"``qtconsole``, ``htmlnotebook``), or particular sources of error (e.g. "
+"``py3k`` or ``unicode``) if we have appropriate labels."
+msgstr ""
+
+# 2ecbbea9359e4cffa85607c65b703502
+#: ../../source/development_guide/github_workflow.rst:92
+msgid ""
+"The ``sprint-friendly`` label is probably the best place for new "
+"contributors to start."
+msgstr ""
+
+# f3c4914e879d4e238f14c29a45205179
+#: ../../source/development_guide/github_workflow.rst:96
+msgid "Pull Requests"
+msgstr ""
+
+# 22e663debf3c4bfeacb413987ead6d04
+#: ../../source/development_guide/github_workflow.rst:98
+msgid "All work is submitted via Pull Requests."
+msgstr ""
+
+# 491be18ba00546098911880801ade3fa
+#: ../../source/development_guide/github_workflow.rst:99
+msgid ""
+"Pull Requests can be submitted as soon as there is code worth discussing."
+" Pull Requests track the branch, so you can continue to work after the PR"
+" is submitted. Review and discussion can begin well before the work is "
+"complete, and the more discussion the better. The worst case is that the "
+"PR is closed."
+msgstr ""
+
+# c83bf74d841c41ba803f8f931d0be52d
+#: ../../source/development_guide/github_workflow.rst:104
+msgid ""
+"Pull Requests that have stalled should be closed (see [[our policy on "
+"closing PRs\\|Dev: Closing Pull Requests]])"
+msgstr ""
+
+# 8c5762198389470d8bf22c565df0f764
+#: ../../source/development_guide/github_workflow.rst:106
+msgid ""
+"Pull Requests should always be made against master (backporting PRs is "
+"described below)."
+msgstr ""
+
+# 8ed220b836404a5ba572cd7705267e19
+#: ../../source/development_guide/github_workflow.rst:108
+msgid "Pull Requests should be tested, if feasible:"
+msgstr ""
+
+# c5c2a705421a41f1886242b0d6eefa96
+#: ../../source/development_guide/github_workflow.rst:110
+msgid "bugfixes should include regression tests"
+msgstr ""
+
+# 6cf267c40a434aafb57b42b651fafca1
+#: ../../source/development_guide/github_workflow.rst:111
+msgid "new behavior should at least get minimal exercise"
+msgstr ""
+
+# aefe7e6aeddf40a8a222bde3337d4026
+#: ../../source/development_guide/github_workflow.rst:113
+msgid ""
+"`Travis <https://travis-ci.org/ipython/ipython>`__ does a pretty good job"
+" testing IPython and Pull Requests, but it may make sense to manually "
+"perform tests (possibly with our ``test_pr`` script), particularly for "
+"PRs that affect ``IPython.parallel`` or Windows."
+msgstr ""
+
+# d75b67a07bec499e8881441fa03ce53e
+#: ../../source/development_guide/github_workflow.rst:119
+msgid "Opening an Issue"
+msgstr ""
+
+# 44bde95ec4a44a86a2238a3e3f7c8c2d
+#: ../../source/development_guide/github_workflow.rst:121
+msgid "When opening a new issue, please take the following steps:"
+msgstr ""
+
+# eadd0bf02cea48c49c11fdb30a92cc85
+#: ../../source/development_guide/github_workflow.rst:123
+msgid ""
+"Search GitHub and/or Google for your issue to avoid duplicate reports. "
+"Keyword searches for your error messages are most helpful."
+msgstr ""
+
+# 752323e4c9604015aaff8b37063830c2
+#: ../../source/development_guide/github_workflow.rst:125
+msgid ""
+"If possible, try updating to master and reproducing your issue, because "
+"we may have already fixed it."
+msgstr ""
+
+# b570bdae9b6b4579ac1941165f1f801a
+#: ../../source/development_guide/github_workflow.rst:127
+msgid "Try to include a minimal reproducible test case"
+msgstr ""
+
+# ed1554fe87da45d2a5c64dc0579d52b0
+#: ../../source/development_guide/github_workflow.rst:128
+msgid "Include relevant system information. Start with the output of:"
+msgstr ""
+
+# de41727a9280424c9fcd2c77ca6d7d3c
+#: ../../source/development_guide/github_workflow.rst:134
+msgid ""
+"And include any relevant package versions, depending on the issue, such "
+"as matplotlib, numpy, Qt, Qt bindings (PyQt/PySide), tornado, web "
+"browser, etc."
+msgstr ""
+
+# b69dac6d20d84f4da9aa176b1dca247d
+#: ../../source/development_guide/github_workflow.rst:139
+msgid "Backporting"
+msgstr ""
+
+# 6201a6ddc0724acc9f0aa6e2395950b0
+#: ../../source/development_guide/github_workflow.rst:141
+msgid ""
+"We should keep an ``A.x`` maintenance branch for backporting fixes from "
+"master."
+msgstr ""
+
+# bad96dd4bf104af59b483097f351f7cd
+#: ../../source/development_guide/github_workflow.rst:143
+msgid ""
+"That branch shall be called ``A.x``, e.g. ``2.x``, not ``2.1``. This way,"
+" there is only one maintenance branch per release series."
+msgstr ""
+
+# c8f4a678969e4923818596582284101b
+#: ../../source/development_guide/github_workflow.rst:145
+msgid ""
+"When an Issue is determined to be appropriate for backporting, it should "
+"be marked with the ``A.B`` milestone."
+msgstr ""
+
+# 7b66404e9301456dba12b13f438d61a3
+#: ../../source/development_guide/github_workflow.rst:147
+msgid ""
+"Any Pull Request which addresses a backport issue should also receive the"
+" same milestone."
+msgstr ""
+
+# 9c79bfa009914fafa0019f6e67f48dbf
+#: ../../source/development_guide/github_workflow.rst:149
+msgid ""
+"Patches are backported to the maintenance branch by applying the pull "
+"request patch to the maintenance branch (currently with the "
+"`backport\\_pr "
+"<https://github.com/ipython/ipython/blob/master/tools/backport_pr.py>`__ "
+"script)."
+msgstr ""
+
+# 2a7eba1900684fab9689312035a9dbdc
+#: ../../source/development_guide/index.rst:14
+msgid "Core Documents"
+msgstr ""
+
+# e80a134fe74c41b79acb0093738690ee
+#: ../../source/development_guide/index.rst:23
+msgid "Lab Meetings"
+msgstr ""
+
+# 5d68328888874591905ffd0a0dc08e60
+#: ../../source/development_guide/index.rst:29
+msgid "Development Policies"
+msgstr ""
+
+# 4b19b84c247c45fca67f4925c727048b
+#: ../../source/development_guide/index.rst:35
+msgid "Other Information"
+msgstr ""
+
+# 591c48743b9042228f7607d064abfbb1
+#: ../../source/development_guide/index.rst:4
+msgid "IPython Development Guide (source: old IPython wiki)"
+msgstr ""
+
+# 6289363304d44f5496a77e25f2bf8c1d
+#: ../../source/development_guide/index.rst:9
+msgid ""
+"IPython does all of its development using GitHub. All of our development "
+"information is hosted on this GitHub wiki. This page indexes all of that "
+"information. Developers interested in getting involved with IPython "
+"development should start here."
+msgstr ""
+
+# 12e4517c27a449f48e194515bcda319e
+#: ../../source/development_guide/index.rst:49
+msgid ""
+"A template for new Python files in IPython: `template.py "
+"<./template.py>`__"
+msgstr ""
+
+# 4081c049edfb42229114ea36feec288e
+#: ../../source/development_guide/js_events.rst:4
+msgid "JavaScript Events"
+msgstr ""
+
+# c61b275655c7434c93b6bb942d2ed50e
+#: ../../source/development_guide/js_events.rst:9
+msgid "(Note: this page is not currently consistent with IPython/Jupyter master)"
+msgstr ""
+
+# 47edbb5e6fb747099a83a04e95f7f67e
+#: ../../source/development_guide/js_events.rst:11
+msgid ""
+"Javascript events are used to notify unrelated parts of the notebook "
+"interface when something happens. For example, if the kernel is busy "
+"executing code, it may send an event announcing as such, which can then "
+"be picked up by other services, like the notification area. For details "
+"on how the events themselves work, see the `JQuery documentation "
+"<http://api.jquery.com/on/>`__."
+msgstr ""
+
+# 98fae31d7b944a1da58cc96e0d1a220b
+#: ../../source/development_guide/js_events.rst:18
+msgid ""
+"This page documents the core set of events, and explains when and why "
+"they are triggered."
+msgstr ""
+
+# e86a5f198ce441e9937343199282991b
+#: ../../source/development_guide/js_events.rst:22
+msgid "Cell-related events"
+msgstr ""
+
+# def2f5fa02a743ff9d48c421f82994b3
+#: ../../source/development_guide/js_events.rst:24
+msgid "`command\\_mode.Cell <#command_modecell>`__"
+msgstr ""
+
+# 3a4fd40f4b784920befbe4e8934de8b6
+#: ../../source/development_guide/js_events.rst:25
+msgid "`create.Cell <#createcell>`__"
+msgstr ""
+
+# a53e4f646d3a4c559b61693d04bdddb1
+#: ../../source/development_guide/js_events.rst:26
+msgid "`delete.Cell <#deletecell>`__"
+msgstr ""
+
+# 3d75746bb0c04b4e955c7e1d4dbbcf20
+#: ../../source/development_guide/js_events.rst:27
+msgid "`edit\\_mode.Cell <#edit_modecell>`__"
+msgstr ""
+
+# 0145fa086f07433695ab1dfece970b60
+#: ../../source/development_guide/js_events.rst:28
+msgid "`select.Cell <#selectcell>`__"
+msgstr ""
+
+# 24648c742e394165a105e4acba22fea8
+#: ../../source/development_guide/js_events.rst:29
+msgid "`output\\_appended.OutputArea <#output_appendedoutputarea>`__"
+msgstr ""
+
+# 40072d87d4004a328417903975367ee6
+#: ../../source/development_guide/js_events.rst:32
+msgid "CellToolbar-related events"
+msgstr ""
+
+# 366a5bb76dfb438db5d7533545658e2a
+#: ../../source/development_guide/js_events.rst:34
+msgid "`preset\\_activated.CellToolbar <#preset_activatedcelltoolbar>`__"
+msgstr ""
+
+# 0ad06e30020348f8a58b2db214d1f8b0
+#: ../../source/development_guide/js_events.rst:35
+msgid "`preset\\_added.CellToolbar <#preset_addedcelltoolbar>`__"
+msgstr ""
+
+# baf353e6b30e48d3bc81d5d881a9324a
+#: ../../source/development_guide/js_events.rst:38
+msgid "Dashboard-related events"
+msgstr ""
+
+# a436b7cbd47040b0bc344ad7412951bd
+#: ../../source/development_guide/js_events.rst:40
+msgid "`app\\_initialized.DashboardApp <#app_initializeddashboardapp>`__"
+msgstr ""
+
+# 94c8cba81b564a65b7050479ce437c58
+#: ../../source/development_guide/js_events.rst:41
+msgid "`sessions\\_loaded.Dashboard <#sessions_loadeddashboard>`__"
+msgstr ""
+
+# 7181c050bc5a411a92fb218852db8fe7
+#: ../../source/development_guide/js_events.rst:44
+msgid "app\\_initialized.DashboardApp"
+msgstr ""
+
+# 68fe58e26be54560a352829efd8b9dc8
+#: ../../source/development_guide/js_events.rst:46
+msgid ""
+"When the Jupyter Notebook browser window opens for the first time and "
+"initializes the Dashboard App. The Dashboard App lists the files and "
+"notebooks in the current directory. Additionally, it lets you create and "
+"open new Jupyter Notebooks."
+msgstr ""
+
+# b81706f287f048049876387fb9273ce3
+#: ../../source/development_guide/js_events.rst:52
+msgid "Kernel-related events"
+msgstr ""
+
+# b4874043cb84481095a16e4ccb23b3ed
+#: ../../source/development_guide/js_events.rst:54
+msgid "`execution\\_request.Kernel <#execution_requestkernel>`__"
+msgstr ""
+
+# 3ac81f6c2d4b40aabda9ee264ca363e2
+#: ../../source/development_guide/js_events.rst:55
+msgid "`input\\_reply.Kernel <#input_replykernel>`__"
+msgstr ""
+
+# 6f8eced167314851835ce91f934c2d11
+#: ../../source/development_guide/js_events.rst:56
+msgid "`kernel\\_autorestarting.Kernel <#kernel_autorestartingkernel>`__"
+msgstr ""
+
+# 47a691a1f6bd4f3baa34f121bec16585
+#: ../../source/development_guide/js_events.rst:57
+msgid "`kernel\\_busy.Kernel <#kernel_busykernel>`__"
+msgstr ""
+
+# 80c97c23fa2c40f09bfddee1110217b7
+#: ../../source/development_guide/js_events.rst:58
+msgid "`kernel\\_connected.Kernel <#kernel_connectedkernel>`__"
+msgstr ""
+
+# 70785bb0e881407e9b26806267abb5ee
+#: ../../source/development_guide/js_events.rst:59
+msgid "`kernel\\_connection\\_failed.Kernel <#kernel_connection_failedkernel>`__"
+msgstr ""
+
+# dae8b17088d34805ae776a6c9bc17640
+#: ../../source/development_guide/js_events.rst:60
+msgid "`kernel\\_created.Kernel <#kernel_createdkernel>`__"
+msgstr ""
+
+# 95e5ad5a50454661ac3c028a5896c504
+#: ../../source/development_guide/js_events.rst:61
+msgid "`kernel\\_created.Session <#kernel_createdsession>`__"
+msgstr ""
+
+# 321a1e2d289644f59c756f5095dc7e86
+#: ../../source/development_guide/js_events.rst:62
+msgid "`kernel\\_dead.Kernel <#kernel_deadkernel>`__"
+msgstr ""
+
+# 48e693465ecf4609b40ff7ec7b4c421b
+#: ../../source/development_guide/js_events.rst:63
+msgid "`kernel\\_dead.Session <#kernel_deadsession>`__"
+msgstr ""
+
+# e24e76bda50c4198a90a6b4cc9c7f41c
+#: ../../source/development_guide/js_events.rst:64
+msgid "`kernel\\_disconnected.Kernel <#kernel_disconnectedkernel>`__"
+msgstr ""
+
+# 791e73bc75a14f1d8efeb196576bdcca
+#: ../../source/development_guide/js_events.rst:65
+msgid "`kernel\\_idle.Kernel <#kernel_idlekernel>`__"
+msgstr ""
+
+# 870b93e3cf294b75b3788188a886f91b
+#: ../../source/development_guide/js_events.rst:66
+msgid "`kernel\\_interrupting.Kernel <#kernel_interruptingkernel>`__"
+msgstr ""
+
+# f026b24ce61844a0998a46cc46f712dd
+#: ../../source/development_guide/js_events.rst:67
+msgid "`kernel\\_killed.Kernel <#kernel_killedkernel>`__"
+msgstr ""
+
+# 8c243948993b422e9ce7979e67bf8806
+#: ../../source/development_guide/js_events.rst:68
+msgid "`kernel\\_killed.Session <#kernel_killedsession>`__"
+msgstr ""
+
+# 50229b3359a24ecdaca9c2121b0f7e8e
+#: ../../source/development_guide/js_events.rst:69
+msgid "`kernel\\_ready.Kernel <#kernel_readykernel>`__"
+msgstr ""
+
+# ab8223c68bbe48ee8271e0d69fe60c56
+#: ../../source/development_guide/js_events.rst:70
+msgid "`kernel\\_reconnecting.Kernel <#kernel_reconnectingkernel>`__"
+msgstr ""
+
+# fac3dd7af8514c258e0bf48ff3fea8c3
+#: ../../source/development_guide/js_events.rst:71
+msgid "`kernel\\_restarting.Kernel <#kernel_restartingkernel>`__"
+msgstr ""
+
+# 2a0189d15f2f4cb587ce28f32c98e471
+#: ../../source/development_guide/js_events.rst:72
+msgid "`kernel\\_starting.Kernel <#kernel_startingkernel>`__"
+msgstr ""
+
+# 790b63aed1b04fb0b44083b1531a8a10
+#: ../../source/development_guide/js_events.rst:73
+msgid "`send\\_input\\_reply.Kernel <#send_input_replykernel>`__"
+msgstr ""
+
+# bf0734bc1ee045d7beac313b9b15b5b7
+#: ../../source/development_guide/js_events.rst:74
+msgid "`shell\\_reply.Kernel <#shell_replykernel>`__"
+msgstr ""
+
+# 54b1c3618ccb47aa8e5439b65a594ffe
+#: ../../source/development_guide/js_events.rst:75
+msgid "`spec\\_changed.Kernel <#spec_changedkernel>`__"
+msgstr ""
+
+# a2877fd8d7ad42b28685938bc5f7c1be
+#: ../../source/development_guide/js_events.rst:78
+msgid "kernel\\_created.Kernel"
+msgstr ""
+
+# 3040632873c245529628ae604083e2e8
+#: ../../source/development_guide/js_events.rst:80
+msgid ""
+"The kernel has been successfully created or re-created through "
+"``/api/kernels``, but a connection to it has not necessarily been "
+"established yet."
+msgstr ""
+
+# 7816516d914c4c1eb141b2becc6478b5
+#: ../../source/development_guide/js_events.rst:85
+msgid "kernel\\_created.Session"
+msgstr ""
+
+# 0367845004434dbab781a2552639d4f4
+#: ../../source/development_guide/js_events.rst:87
+msgid ""
+"The kernel has been successfully created or re-created through "
+"``/api/sessions``, but a connection to it has not necessarily been "
+"established yet."
+msgstr ""
+
+# 72a7c504f85e448ca8fe72c0a32b2c4a
+#: ../../source/development_guide/js_events.rst:92
+msgid "kernel\\_reconnecting.Kernel"
+msgstr ""
+
+# 87126ef97bd34214865023e905e33d95
+#: ../../source/development_guide/js_events.rst:94
+msgid ""
+"An attempt is being made to reconnect (via websockets) to the kernel "
+"after having been disconnected."
+msgstr ""
+
+# 1ec32fcfb4ed408bac1e566e8b97aec0
+#: ../../source/development_guide/js_events.rst:98
+msgid "kernel\\_connected.Kernel"
+msgstr ""
+
+# 5acfc372f6f64cdc87c084c55679f892
+#: ../../source/development_guide/js_events.rst:100
+msgid ""
+"A connection has been established to the kernel. This is triggered as "
+"soon as all websockets (e.g. to the shell, iopub, and stdin channels) "
+"have been opened. This does not necessarily mean that the kernel is ready"
+" to do anything yet, though."
+msgstr ""
+
+# 29b6688f9bce412ebbb884ff886068f6
+#: ../../source/development_guide/js_events.rst:106
+msgid "kernel\\_starting.Kernel"
+msgstr ""
+
+# b70c01a2eefc4af2a57708d038debff0
+#: ../../source/development_guide/js_events.rst:108
+msgid ""
+"The kernel is starting. This is triggered once when the kernel process is"
+" starting up, and can be sent as a message by the kernel, or may be "
+"triggered by the frontend if it knows the kernel is starting (e.g., it "
+"created the kernel and is connected to it, but hasn't been able to "
+"communicate with it yet)."
+msgstr ""
+
+# ec64854942e54e16a0fc04bda832f976
+#: ../../source/development_guide/js_events.rst:115
+msgid "kernel\\_ready.Kernel"
+msgstr ""
+
+# b138893ce9964ff6b4347388855c5ade
+#: ../../source/development_guide/js_events.rst:117
+msgid ""
+"Like kernel\\_idle.Kernel, but triggered after the kernel has fully "
+"started up."
+msgstr ""
+
+# 3ad6f65bcbbb4e1ebd1bbd29c253aa85
+#: ../../source/development_guide/js_events.rst:121
+msgid "kernel\\_restarting.Kernel"
+msgstr ""
+
+# 5b6939501d04409d8860c0faf100b222
+#: ../../source/development_guide/js_events.rst:123
+msgid ""
+"The kernel is restarting. This is triggered at the beginning of an "
+"restart call to ``/api/kernels``."
+msgstr ""
+
+# 3bdabb293a8a4cdcb236b8349e518532
+#: ../../source/development_guide/js_events.rst:127
+msgid "kernel\\_autorestarting.Kernel"
+msgstr ""
+
+# a41bf1e6a4284693ba02b1d148163713
+#: ../../source/development_guide/js_events.rst:129
+msgid ""
+"The kernel is restarting on its own, which probably also means that "
+"something happened to cause the kernel to die. For example, running the "
+"following code in the notebook would cause the kernel to autorestart:"
+msgstr ""
+
+# fc34e9d75f1941b3ad2ed2530d2a04e7
+#: ../../source/development_guide/js_events.rst:139
+msgid "kernel\\_interrupting.Kernel"
+msgstr ""
+
+# ffc813b955594063b70bb592d70b548f
+#: ../../source/development_guide/js_events.rst:141
+msgid ""
+"The kernel is being interrupted. This is triggered at the beginning of a "
+"interrupt call to ``/api/kernels``."
+msgstr ""
+
+# ccf8af5eed16478796b627d55f104864
+#: ../../source/development_guide/js_events.rst:145
+msgid "kernel\\_disconnected.Kernel"
+msgstr ""
+
+# 3ab698370f4b46968370a25c425567e8
+#: ../../source/development_guide/js_events.rst:147
+msgid "The connection to the kernel has been lost."
+msgstr ""
+
+# 2802009fc67b490584fbd85d24b2882a
+#: ../../source/development_guide/js_events.rst:150
+msgid "kernel\\_connection\\_failed.Kernel"
+msgstr ""
+
+# 13c1dbef4b9349b0b838a4256d07143b
+#: ../../source/development_guide/js_events.rst:152
+msgid ""
+"Not only was the connection lost, but it was lost due to an error (i.e., "
+"we did not tell the websockets to close)."
+msgstr ""
+
+# ba8926d5bf55416e8aa6ab5ee053e637
+#: ../../source/development_guide/js_events.rst:156
+msgid "kernel\\_idle.Kernel"
+msgstr ""
+
+# d1f3c042055548dab598e2a4b494c115
+#: ../../source/development_guide/js_events.rst:158
+msgid "The kernel's execution state is 'idle'."
+msgstr ""
+
+# 12539ba4f1724ab5bef3dc6922eba206
+#: ../../source/development_guide/js_events.rst:161
+msgid "kernel\\_busy.Kernel"
+msgstr ""
+
+# 88b1443b9d7d4d9a9102d7014d36313a
+#: ../../source/development_guide/js_events.rst:163
+msgid "The kernel's execution state is 'busy'."
+msgstr ""
+
+# 9136374f3b774c08a9acfc0c33fd311a
+#: ../../source/development_guide/js_events.rst:166
+msgid "kernel\\_killed.Kernel"
+msgstr ""
+
+# 67232b97369b4224baec2481ad5f4dd0
+#: ../../source/development_guide/js_events.rst:168
+msgid "The kernel has been manually killed through ``/api/kernels``."
+msgstr ""
+
+# f79f7754a4a94c9ca64eaa9152f7b873
+#: ../../source/development_guide/js_events.rst:171
+msgid "kernel\\_killed.Session"
+msgstr ""
+
+# 2da99d85b9ad4167af4cbf22803c0d84
+#: ../../source/development_guide/js_events.rst:173
+msgid "The kernel has been manually killed through ``/api/sessions``."
+msgstr ""
+
+# b011fd6bcdef4824ac275758512959d7
+#: ../../source/development_guide/js_events.rst:176
+msgid "kernel\\_dead.Kernel"
+msgstr ""
+
+# 58190fd19f3843e7b01f0adedbc72a49
+#: ../../source/development_guide/js_events.rst:178
+msgid ""
+"This is triggered if the kernel dies, and the kernel manager attempts to "
+"restart it, but is unable to. For example, the following code run in the "
+"notebook will cause the kernel to die and for the kernel manager to be "
+"unable to restart it:"
+msgstr ""
+
+# a07a9dcaa9fa414a87e8bb387d584657
+#: ../../source/development_guide/js_events.rst:192
+msgid "kernel\\_dead.Session"
+msgstr ""
+
+# e50094f75e0e4779bdd5bd9cc231672b
+#: ../../source/development_guide/js_events.rst:194
+msgid ""
+"The kernel could not be started through ``/api/sessions``. This might be "
+"because the requested kernel type isn't installed. Another reason for "
+"this message is that the kernel died or was killed, but the session "
+"wasn't."
+msgstr ""
+
+# cdb10a3240634a88bcb5ab603db13223
+#: ../../source/development_guide/js_events.rst:200
+msgid "Notebook-related events"
+msgstr ""
+
+# ff5d6d331e274e01bf17ba723380972d
+#: ../../source/development_guide/js_events.rst:202
+msgid "`app\\_initialized.NotebookApp <#app_initializednotebookapp>`__"
+msgstr ""
+
+# c890a4f26e0743d28633290be51d4ccc
+#: ../../source/development_guide/js_events.rst:203
+msgid "`autosave\\_disabled.Notebook <#autosave_disablednotebook>`__"
+msgstr ""
+
+# 45c56970e40d4a27b4bd50085f013c61
+#: ../../source/development_guide/js_events.rst:204
+msgid "`autosave\\_enabled.Notebook <#autosave_enablednotebook>`__"
+msgstr ""
+
+# 787d5edb4c4e4666b0c1d0b5f194e13a
+#: ../../source/development_guide/js_events.rst:205
+msgid "`checkpoint\\_created.Notebook <#checkpoint_creatednotebook>`__"
+msgstr ""
+
+# 0f4a0e636e6e4b5fb64dc4c2cb14a538
+#: ../../source/development_guide/js_events.rst:206
+msgid ""
+"`checkpoint\\_delete\\_failed.Notebook "
+"<#checkpoint_delete_failednotebook>`__"
+msgstr ""
+
+# 15725ecac791496abcf4ac17f3d8a964
+#: ../../source/development_guide/js_events.rst:207
+msgid "`checkpoint\\_deleted.Notebook <#checkpoint_deletednotebook>`__"
+msgstr ""
+
+# 89e00e136b2f43b6ba5d6ded5606b27b
+#: ../../source/development_guide/js_events.rst:208
+msgid "`checkpoint\\_failed.Notebook <#checkpoint_failednotebook>`__"
+msgstr ""
+
+# 458ba96596ea4f3c8e8760f3ff1bff75
+#: ../../source/development_guide/js_events.rst:209
+msgid ""
+"`checkpoint\\_restore\\_failed.Notebook "
+"<#checkpoint_restore_failednotebook>`__"
+msgstr ""
+
+# 891d9244f3424af0bb816f2d35e8d3a3
+#: ../../source/development_guide/js_events.rst:210
+msgid "`checkpoint\\_restored.Notebook <#checkpoint_restorednotebook>`__"
+msgstr ""
+
+# a087cd1aa32546cdab0c1832cbb53ac2
+#: ../../source/development_guide/js_events.rst:211
+msgid "`checkpoints\\_listed.Notebook <#checkpoints_listednotebook>`__"
+msgstr ""
+
+# afc574cc44784feeba00a72f727b8cce
+#: ../../source/development_guide/js_events.rst:212
+msgid "`command\\_mode.Notebook <#command_modenotebook>`__"
+msgstr ""
+
+# 35231218e930429b84217ae364e1a881
+#: ../../source/development_guide/js_events.rst:213
+msgid "`edit\\_mode.Notebook <#edit_modenotebook>`__"
+msgstr ""
+
+# a4e3da5247db4bd9ac0ff46302355b8e
+#: ../../source/development_guide/js_events.rst:214
+msgid ""
+"`list\\_checkpoints\\_failed.Notebook "
+"<#list_checkpoints_failednotebook>`__"
+msgstr ""
+
+# d54d2621b1d848448d7f51b2c0c4abf9
+#: ../../source/development_guide/js_events.rst:215
+msgid "`notebook\\_load\\_failed.Notebook <#notebook_load_failednotebook>`__"
+msgstr ""
+
+# 297dd5a18c3e491abfbf2fc1d198a746
+#: ../../source/development_guide/js_events.rst:216
+msgid "`notebook\\_loaded.Notebook <#notebook_loadednotebook>`__"
+msgstr ""
+
+# abc6ecf1fc8b499fb2b212b8ec45139a
+#: ../../source/development_guide/js_events.rst:217
+msgid "`notebook\\_loading.Notebook <#notebook_loadingnotebook>`__"
+msgstr ""
+
+# 1ab9c46f713b4011ae03db3d1565aa99
+#: ../../source/development_guide/js_events.rst:218
+msgid "`notebook\\_rename\\_failed.Notebook <#notebook_rename_failednotebook>`__"
+msgstr ""
+
+# 705d0d6e532a47c8acf6a47bb07b3430
+#: ../../source/development_guide/js_events.rst:219
+msgid "`notebook\\_renamed.Notebook <#notebook_renamednotebook>`__"
+msgstr ""
+
+# 9630174248894aa0bb6b67091c37352a
+#: ../../source/development_guide/js_events.rst:220
+msgid "`notebook\\_restoring.Notebook <#notebook_restoringnotebook>`__"
+msgstr ""
+
+# 19d828a32334434482f103cea343d015
+#: ../../source/development_guide/js_events.rst:221
+msgid "`notebook\\_save\\_failed.Notebook <#notebook_save_failednotebook>`__"
+msgstr ""
+
+# d3fcdab1a0ae4813a968084486583389
+#: ../../source/development_guide/js_events.rst:222
+msgid "`notebook\\_saved.Notebook <#notebook_savednotebook>`__"
+msgstr ""
+
+# 1826b5fd328441cd9b281e97e21b8bfc
+#: ../../source/development_guide/js_events.rst:223
+msgid "`notebook\\_saving.Notebook <#notebook_savingnotebook>`__"
+msgstr ""
+
+# 14dc21e830634ecbb3120013d479d6a1
+#: ../../source/development_guide/js_events.rst:224
+msgid "`rename\\_notebook.Notebook <#rename_notebooknotebook>`__"
+msgstr ""
+
+# 545d212ebca44e1898c3d4906ae53fb9
+#: ../../source/development_guide/js_events.rst:225
+msgid ""
+"`selected\\_cell\\_type\\_changed.Notebook "
+"<#selected_cell_type_changednotebook>`__"
+msgstr ""
+
+# bd96bdc9213240ca9c347317afc1bb83
+#: ../../source/development_guide/js_events.rst:226
+msgid "`set\\_dirty.Notebook <#set_dirtynotebook>`__"
+msgstr ""
+
+# 8c289d8ea7d74ff5bd87d081e3c143b3
+#: ../../source/development_guide/js_events.rst:227
+msgid "`set\\_next\\_input.Notebook <#set_next_inputnotebook>`__"
+msgstr ""
+
+# d7f8269d162c425dbce0001d2a0bdffe
+#: ../../source/development_guide/js_events.rst:228
+msgid "`trust\\_changed.Notebook <#trust_changednotebook>`__"
+msgstr ""
+
+# 3be14fb7ddaa44f9898f33c9984781a6
+#: ../../source/development_guide/js_events.rst:231
+msgid "Other"
+msgstr ""
+
+# 28cfc866239f4bb0be2907f27c335b2c
+#: ../../source/development_guide/js_events.rst:233
+msgid "`open\\_with\\_text.Pager <#open_with_textpager>`__"
+msgstr ""
+
+# 9d0f63ac175a4e06b6060c1b5c0589b9
+#: ../../source/development_guide/js_events.rst:234
+msgid "`rebuild.QuickHelp <#rebuildquickhelp>`__"
+msgstr ""
+
+# 052142391c524dbd9cd3b11b73fbdcf4
+#: ../../source/development_guide/lab_meetings.rst:4
+msgid "Lab Meetings on Air"
+msgstr ""
+
+# 655db7d08bf94cb7b434583f46de9302
+#: ../../source/development_guide/lab_meetings.rst:9
+msgid ""
+"Academic labs have long had the tradition of the weekly lab meeting, "
+"where all topics of interest to the lab are discussed. IPython has strong"
+" roots in academia, but it is also an open source project that needs to "
+"engage an active international community. So while our goal with IPython "
+"is not to publish the next paper, we've been thinking about the value "
+"these regular discussions bring to how teams work on sustained efforts "
+"involving difficult problems, and wanted to bring that bit of academic "
+"practice into the open source workflow. So we have decided to conduct "
+"weekly \"lab meetings\" for IPython, that will be held publicly using a "
+"Google Hangout on Air."
+msgstr ""
+
+# b7e924ebaa1442abb4ce8579e7dfb513
+#: ../../source/development_guide/lab_meetings.rst:21
+msgid "Logistics"
+msgstr ""
+
+# 07e6cc2da96b4754b66212a9314e3eb2
+#: ../../source/development_guide/lab_meetings.rst:23
+msgid ""
+"We are trying to keep things simple and with a minimum of new moving "
+"parts:"
+msgstr ""
+
+# a6bfaf8f74724ff792320a67ceb36788
+#: ../../source/development_guide/lab_meetings.rst:26
+msgid ""
+"Meetings happen on Tuesdays at 10am California time (i.e. UTC-8 or -7 "
+"depending on the time of year)."
+msgstr ""
+
+# 2872a2e95c9c4eca8e795423ba1dbc40
+#: ../../source/development_guide/lab_meetings.rst:28
+msgid ""
+"We broadcast the meeting as it happens via G+ and leave the public "
+"YouTube link afterwards."
+msgstr ""
+
+# cb7960e779de46a393549f9b14437b25
+#: ../../source/development_guide/lab_meetings.rst:30
+msgid ""
+"During the meeting, all chat that needs to happen by typing can be done "
+"on our `Gitter chat room <https://gitter.im/ipython/ipython>`__."
+msgstr ""
+
+# 75e889a166a94bb3a0358a1465121a4b
+#: ../../source/development_guide/lab_meetings.rst:33
+msgid ""
+"We keep a running document with `minutes of the meeting on HackPad "
+"<https://ipython.hackpad.com/>`__ where we summarize main points. (`2015 "
+"part 1 <https://ipython.hackpad.com/3YJG5lv2Hws>`__)"
+msgstr ""
+
+# 7ee9bd48be064c18b6f1c952e070a66d
+#: ../../source/development_guide/lab_meetings.rst:37
+msgid ""
+"We welcome and encourage help from others in updating these minutes "
+"during the meeting, but we'll make no major effort in ensuring that they "
+"are a detailed and accurate record of the whole discussion. We simply "
+"don't have the time for that."
+msgstr ""
+
+# 425913e731c54469be844019d93a0581
+#: ../../source/development_guide/lab_meetings.rst:43
+msgid "Prior meetings"
+msgstr ""
+
+# 05fd7d7f121346c290fd8ce8550118bf
+#: ../../source/development_guide/lab_meetings.rst:45
+msgid ""
+"You can find a list of the videos on the `ipythondev YouTube user page "
+"<https://www.youtube.com/user/ipythondev>`__."
+msgstr ""
+
+# d512e27aff344444aae5dfaf62a1a9c2
+#: ../../source/development_guide/less.rst:4
+msgid "How to Compile .less Files"
+msgstr ""
+
+# ad2b306908b048c6bdec64929c3d6c15
+#: ../../source/development_guide/less.rst:9
+msgid ""
+"For testing your development work in CSS, you'll need to compile the "
+".less files to CSS. Make sure you have dependencies that LESS requires, "
+"including fabric, node, and lessc. Follow the below steps to compile the "
+".less files:"
+msgstr ""
+
+# 515ed293377b44b88d86fd11e6cb76f8
+#: ../../source/development_guide/less.rst:18
+msgid "Alternatively, you can:"
+msgstr ""
+
+# f66d911ce52644939f54e1c4cfa7cdd0
+#: ../../source/development_guide/pull_request.rst:4
+msgid "The Perfect Pull Request"
+msgstr ""
+
+# 89a81be294c9411c8f07631085687f58
+#: ../../source/development_guide/pull_request.rst:9
+msgid "A brief guide to making and reviewing pull requests."
+msgstr ""
+
+# 223a61361a9d42d19e8f544bbed9ede8
+#: ../../source/development_guide/pull_request.rst:12
+msgid "1. It works"
+msgstr ""
+
+# ee97d94a227d426a91e8cf8eb7fac5fd
+#: ../../source/development_guide/pull_request.rst:14
+msgid "The code does what it's supposed to!"
+msgstr ""
+
+# 7191fb41b3f446c2b047ca063a5e4356
+#: ../../source/development_guide/pull_request.rst:17
+msgid "2. It works on all of the platforms that IPython officially supports"
+msgstr ""
+
+# 88d94c97480c46a98e8ee9c20f7d521c
+#: ../../source/development_guide/pull_request.rst:19
+msgid "IPython has to work on:"
+msgstr ""
+
+# a330b995df754c6db1c6d675a7f71ec2
+#: ../../source/development_guide/pull_request.rst:21
+msgid "Linux of various kinds, Windows & Mac"
+msgstr ""
+
+# 0982b10a11ac4969ad699d4c552c26a2
+#: ../../source/development_guide/pull_request.rst:22
+msgid "Python 2 & 3"
+msgstr ""
+
+# dae2ad7446ea4d9daade79e4c60bc60a
+#: ../../source/development_guide/pull_request.rst:25
+msgid "3. Handles unicode issues properly"
+msgstr ""
+
+# fd066b3664f148a6b16e1cec798ad3ca
+#: ../../source/development_guide/pull_request.rst:27
+msgid ""
+"Much of our code base deals with strings and unicode. This needs to be "
+"done in a manner that is unicode aware and works on Python 2 and 3. [This"
+" article] (http://www.joelonsoftware.com/articles/Unicode.html) is a good"
+" intro to unicode."
+msgstr ""
+
+# 2e6a238797d34b35a2e3ccd7363775d8
+#: ../../source/development_guide/pull_request.rst:33
+msgid "4. Adheres to our coding style"
+msgstr ""
+
+# 6cf5f6068ddc420d91eef5c6aac49a51
+#: ../../source/development_guide/pull_request.rst:35
+msgid ""
+"Coding style refers to how source code is formatted and how variables, "
+"functions, methods and classes are named. Your code should follow our "
+"coding style, which is described [[here\\|Dev: Coding style]]."
+msgstr ""
+
+# 414e07fca966418d833f8e539fa75dd5
+#: ../../source/development_guide/pull_request.rst:40
+msgid "5. Clean & commented"
+msgstr ""
+
+# 3fd8703e90d14aff80b997e371af9e5b
+#: ../../source/development_guide/pull_request.rst:42
+msgid ""
+"The code should be well organized, and have inline comments where "
+"appropriate. When we look at the code, it should be clear what it's doing"
+" and why. It should not break abstractions that we have established in "
+"the project."
+msgstr ""
+
+# 755c8ba81fe34db1a85d015bb87412f2
+#: ../../source/development_guide/pull_request.rst:48
+msgid "6. Tested"
+msgstr ""
+
+# b74b1c16fc754989b663b171b313d43d
+#: ../../source/development_guide/pull_request.rst:50
+msgid ""
+"If it fixes a bug, the pull request should ideally add an automated test "
+"that fails without the fix, and passes with it. Normally it should be "
+"sufficient to copy an existing test and tweak it. New functionality "
+"should come with its own tests as well. Details about testing IPython can"
+" be found [[here\\|Dev: Testing]]."
+msgstr ""
+
+# 16f7363d77e5489f9ce488ca4a26f71d
+#: ../../source/development_guide/pull_request.rst:57
+msgid "7. Well documented"
+msgstr ""
+
+# ba75b92346094faa90b2e78c95c69a98
+#: ../../source/development_guide/pull_request.rst:59
+msgid ""
+"Don't forget to update docstrings, and any relevant parts of `the "
+"official documentation <https://ipython.readthedocs.io/en/stable/>`__. "
+"New features or significant changes warrant an entry in the *What's New* "
+"section too. Details about documenting IPython can be found [[here\\|Dev:"
+" Documenting IPython]]."
+msgstr ""
+
+# d854f6fc89a64ddcb42f0a9a55973b77
+#: ../../source/development_guide/py3compat.rst:4
+msgid "Python 3 Compatibility Module"
+msgstr ""
+
+# c004d43c8f534c84a82ec4fef2b5b1df
+#: ../../source/development_guide/py3compat.rst:9
+msgid ""
+"The ``IPython.utils.py3compat`` module provides a number of functions to "
+"make it easier to write code for Python 2 and 3. We also use 2to3 in the "
+"setup process to change syntax, and the ``io.open()`` function, which is "
+"essentially the built in open function from Python 3."
+msgstr ""
+
+# b192dadb5475442db1b2a0490e225483
+#: ../../source/development_guide/py3compat.rst:11
+msgid "The names provided are:"
+msgstr ""
+
+# 30de9621716043538db5664d131cb897
+#: ../../source/development_guide/py3compat.rst:13
+msgid "**PY3**: True in Python 3, False in Python 2."
+msgstr ""
+
+# 8f5c3e60ac0747f2b79902da7a2bdae3
+#: ../../source/development_guide/py3compat.rst:16
+msgid "Unicode related"
+msgstr ""
+
+# b6a2d35346a64709aa527b4abda7d7ee
+#: ../../source/development_guide/py3compat.rst:17
+msgid ""
+"**decode**, **encode**: Shortcuts to decode or encode strings, using "
+"``sys.stdin.encoding`` by default, and using replacement characters on "
+"errors."
+msgstr ""
+
+# 73ee89f9102a4788baa41e5b229a9562
+#: ../../source/development_guide/py3compat.rst:18
+msgid ""
+"**str_to_unicode**, **unicode_to_str**, **str_to_bytes**, "
+"**bytes_to_str**: Convert to/from the platform's standard ``str`` type "
+"(bytes in Python 2, unicode in Python 3). Each function is a no-op on one"
+" of the two platforms."
+msgstr ""
+
+# a1dee6dc1a2c46c8a5ec2956070e3a10
+#: ../../source/development_guide/py3compat.rst:19
+msgid ""
+"**cast_unicode**, **cast_bytes**: Accept unknown unicode or byte strings,"
+" and convert them accordingly."
+msgstr ""
+
+# 47bc77989e70427ba4a7cc1cafd7915b
+#: ../../source/development_guide/py3compat.rst:20
+msgid ""
+"**cast_bytes_py2**: Casts unicode to byte strings on Python 2, but "
+"doesn't do anything on Python 3."
+msgstr ""
+
+# 4e8dd403d59b46b9bdb3d5a502311b1b
+# 80822ca0571045df983fab67282f3c6d
+#: ../../source/development_guide/py3compat.rst:23
+#: ../../source/development_guide/rest_api.rst:20
+msgid "Miscellaneous"
+msgstr ""
+
+# cb19d92f73c243b89006254015d4035b
+#: ../../source/development_guide/py3compat.rst:24
+msgid ""
+"**input**: Refers to ``raw_input`` on Python 2, ``input`` on Python 3 "
+"(needed because 2to3 only converts calls to raw_input, not assignments to"
+" other names)."
+msgstr ""
+
+# f998ff129b49488897a174f56cf0a528
+#: ../../source/development_guide/py3compat.rst:25
+msgid ""
+"**builtin_mod_name**: The string name you import to get the builtins "
+"(``__builtin__`` --> ``builtins``)."
+msgstr ""
+
+# 59da6755c02d48118c18d89fce1aa672
+#: ../../source/development_guide/py3compat.rst:26
+msgid "**isidentifier**: Checks if a string is a valid Python identifier."
+msgstr ""
+
+# 871668c2bc504ea298b8e5b945f27fad
+#: ../../source/development_guide/py3compat.rst:27
+msgid ""
+"**open**: Simple wrapper for Python 3 unicode-enabled open. Similar to "
+"``codecs.open``, but allows universal newlines. The current "
+"implementation only supports the very simplest use."
+msgstr ""
+
+# 43c6fddb42a946f0b38d44892e529478
+#: ../../source/development_guide/py3compat.rst:28
+msgid ""
+"**MethodType**: ``types.MethodType`` from Python 3. Takes only two "
+"arguments: function, instance. The class argument for Python 2 is filled "
+"automatically."
+msgstr ""
+
+# d94ea732977d42438b860b989f2a313c
+#: ../../source/development_guide/py3compat.rst:29
+msgid ""
+"**doctest_refactor_print**: Can be called on a string or a function (or "
+"used as a decorator). In Python 3, it converts print statements in "
+"doctests to print() calls. 2to3 does this for real doctests, but we need "
+"it in several other places. It simply uses a regex, which is good enough "
+"for the current cases."
+msgstr ""
+
+# e25ce2b110e44536a7af4a448c4eaa6f
+#: ../../source/development_guide/py3compat.rst:30
+msgid ""
+"**u_format**: Where tests use the repr() of a unicode string, it should "
+"be written ``'{u}\"thestring\"'``, and fed to this function, which will "
+"produce ``'u\"thestring\"'`` for Python 2, and ``'\"thestring\"'`` for "
+"Python 3. Can also be used as a decorator, to work on a docstring."
+msgstr ""
+
+# 679faf609998417083db36b8e8a04382
+#: ../../source/development_guide/py3compat.rst:31
+msgid ""
+"**execfile**: Makes a return on Python 3 (where it's no longer a "
+"builtin), and upgraded to handle Unicode filenames on Python 2."
+msgstr ""
+
+# 6070e9e6628b4aa09ed6655604054931
+#: ../../source/development_guide/releasing.rst:4
+msgid "Steps for Releasing IPython"
+msgstr ""
+
+# 474fc1460c5b4777abee30aa86907ed6
+#: ../../source/development_guide/releasing.rst:9
+msgid ""
+"This document contains notes about the process that is used to release "
+"IPython. Our release process is currently not very formal and could be "
+"improved."
+msgstr ""
+
+# c1f41e0fa6da4994b9b19379eb2bc23f
+#: ../../source/development_guide/releasing.rst:13
+msgid ""
+"Most of the release process is automated by the ``release`` script in the"
+" ``tools`` directory of our main repository. This document is just a "
+"handy reminder for the release manager."
+msgstr ""
+
+# a9b95a6e657e46b28c6e52dbcc201a18
+#: ../../source/development_guide/releasing.rst:18
+msgid "0. Environment variables"
+msgstr ""
+
+# 8d5be193613e4256b862d9f8e07041fa
+#: ../../source/development_guide/releasing.rst:20
+msgid ""
+"You can set some env variables to note previous release tag and current "
+"release milestone, version, and git tag:"
+msgstr ""
+
+# de9c9247cc124e2893d9ec0f227a643d
+#: ../../source/development_guide/releasing.rst:31
+msgid ""
+"These will be used later if you want to copy/paste, or you can just type "
+"the appropriate command when the time comes. These variables are not used"
+" by scripts (hence no ``export``)."
+msgstr ""
+
+# 6c0a769309184688b2fb014ff2f8c796
+#: ../../source/development_guide/releasing.rst:36
+msgid "1. Finish release notes"
+msgstr ""
+
+# e869e1ec6f9742c8bf23bacb602a60b9
+#: ../../source/development_guide/releasing.rst:38
+msgid "If a major release:"
+msgstr ""
+
+# 666b2be953434d93bb878827050ab63d
+#: ../../source/development_guide/releasing.rst:40
+msgid "merge any pull request notes into what's new:"
+msgstr ""
+
+# 3724968cf84e4e99b20121379514a4e0
+#: ../../source/development_guide/releasing.rst:46
+msgid ""
+"update ``docs/source/whatsnew/development.rst``, to ensure it covers the "
+"major points."
+msgstr ""
+
+# 75183279a5dc4eba93af2a9c26039722
+#: ../../source/development_guide/releasing.rst:48
+msgid "move the contents of ``development.rst`` to ``versionX.rst``"
+msgstr ""
+
+# c24f0f091e7949f3bf48de122e6334af
+#: ../../source/development_guide/releasing.rst:49
+msgid "generate summary of GitHub contributions, which can be done with:"
+msgstr ""
+
+# 4b8b45a7487a4bd4b31ae0b9d16bd8d0
+#: ../../source/development_guide/releasing.rst:55
+msgid ""
+"which may need some manual cleanup. Add the cleaned up result and add it "
+"to ``docs/source/whatsnew/github-stats-X.rst`` (make a new file, or add "
+"it to the top, depending on whether it is a major release). You can use:"
+msgstr ""
+
+# 843c53e7f17142a09ae961e46c0cfa4d
+#: ../../source/development_guide/releasing.rst:63
+msgid ""
+"to find duplicates and update ``.mailmap``. Before generating the GitHub "
+"stats, verify that all closed issues and pull requests :ref:`have "
+"appropriate milestones <github_workflow_milestones>`. `This search "
+"<https://github.com/ipython/ipython/issues?q=is%3Aclosed+no%3Amilestone+is%3Aissue>`__"
+" should return no results."
+msgstr ""
+
+# 73753e8a58e34787817ed3238ed82716
+#: ../../source/development_guide/releasing.rst:71
+msgid "2. Run the ``tools/build_release`` script"
+msgstr ""
+
+# 16ac313a93e049638a7f863d317ce63f
+#: ../../source/development_guide/releasing.rst:73
+msgid ""
+"This does all the file checking and building that the real release script"
+" will do. This will let you do test installations, check that the build "
+"procedure runs OK, etc. You may want to also do a test build of the docs."
+msgstr ""
+
+# e7ffacc8c81a4834a14d0b314e17690b
+#: ../../source/development_guide/releasing.rst:79
+msgid "3. Create and push the new tag"
+msgstr ""
+
+# b8b0871867cd4fcc80b3e368e4d95844
+#: ../../source/development_guide/releasing.rst:81
+msgid "Edit ``IPython/core/release.py`` to have the current version."
+msgstr ""
+
+# 3c370bad39e746c39111430ccc936310
+#: ../../source/development_guide/releasing.rst:83
+msgid "Commit the changes to release.py and jsversion:"
+msgstr ""
+
+# 76be04383e184e9da329e3aa0d098a3c
+#: ../../source/development_guide/releasing.rst:90
+msgid "Create and push the tag:"
+msgstr ""
+
+# 507ccfbc828145e9b0d1d4dfee83d563
+#: ../../source/development_guide/releasing.rst:97
+msgid "Update release.py back to ``x.y-dev`` or ``x.y-maint``, and push:"
+msgstr ""
+
+# 4877cb8b2c564ce5bd36962492de8d10
+#: ../../source/development_guide/releasing.rst:105
+msgid "4. Get a fresh clone of the tag for building the release:"
+msgstr ""
+
+# f52cc49dec9346f1b0c98b00a01785d9
+#: ../../source/development_guide/releasing.rst:113
+msgid "5. Run the ``release`` script"
+msgstr ""
+
+# cec8d17770c84efca03630775ab98d9d
+#: ../../source/development_guide/releasing.rst:119
+msgid ""
+"This makes the tarballs, zipfiles, and wheels. It posts them to "
+"archive.ipython.org and registers the release with PyPI."
+msgstr ""
+
+# f1685ede7c474aac941535883e418b17
+#: ../../source/development_guide/releasing.rst:122
+msgid "This will require that you have current wheel, Python 3.4 and Python 2.7."
+msgstr ""
+
+# 9a7908665a6b48459d926aaf5bde37ef
+#: ../../source/development_guide/releasing.rst:126
+msgid "7. Update the IPython website"
+msgstr ""
+
+# 84184061981f4f93a42f63d827dc1374
+#: ../../source/development_guide/releasing.rst:128
+msgid "release announcement (news, announcements)"
+msgstr ""
+
+# 107c03099a624fa686299b8bd37f9f80
+#: ../../source/development_guide/releasing.rst:129
+msgid "update current version and download links"
+msgstr ""
+
+# ee281737c90c44458452d4dceae0f9ad
+#: ../../source/development_guide/releasing.rst:130
+msgid "(If major release) update links on the documentation page"
+msgstr ""
+
+# 7e0ab94df3f949269ccc4e70aa69f593
+#: ../../source/development_guide/releasing.rst:133
+msgid "8. Drafting a short release announcement"
+msgstr ""
+
+# 36d7bb70789c43c8b561212dfb878412
+#: ../../source/development_guide/releasing.rst:135
+msgid ""
+"This should include i) highlights and ii) a link to the html version of "
+"the *What's new* section of the documentation."
+msgstr ""
+
+# 8182a6c415a44cedb150dcf452395ea9
+#: ../../source/development_guide/releasing.rst:138
+msgid "Post to mailing list, and link from Twitter."
+msgstr ""
+
+# 5b55b0e918cc4d15a5f839aea3cb8a98
+#: ../../source/development_guide/releasing.rst:141
+msgid "9. Update milestones on GitHub"
+msgstr ""
+
+# 816cc83ee1b345a78effb459097dc99e
+#: ../../source/development_guide/releasing.rst:143
+msgid "close the milestone you just released"
+msgstr ""
+
+# 5f3da01008e84e7aaf469cda8e6b8899
+#: ../../source/development_guide/releasing.rst:144
+msgid "open new milestone for (x, y+1), if it doesn't exist already"
+msgstr ""
+
+# 00455207637744b5a45442f59ea981a9
+#: ../../source/development_guide/releasing.rst:147
+msgid "10. Celebrate!"
+msgstr ""
+
+# 8cfab3dcdbf94612acc47b332d1b3feb
+#: ../../source/development_guide/rest_api.rst:4
+msgid "Architecture of IPython notebook's Dashboard"
+msgstr ""
+
+# e1e8a4f3cb2e41ac8593e4fc18d62d01
+#: ../../source/development_guide/rest_api.rst:9
+msgid ""
+"The tables below show the current RESTful web service architecture "
+"implemented in IPython notebook. The listed URL's use the HTTP verbs to "
+"return representations of the desired resource."
+msgstr ""
+
+# 2bc47a02cbd945568fb33dc9224b0f07
+#: ../../source/development_guide/rest_api.rst:13
+msgid ""
+"We are in the process of creating a new dashboard architecture for the "
+"IPython notebook, which will allow the user to navigate through multiple "
+"directory files to find desired notebooks."
+msgstr ""
+
+# 4fdebc16479d422b8922fb8f9fce7cc5
+#: ../../source/development_guide/rest_api.rst:18
+msgid "Current Architecture"
+msgstr ""
+
+# fe498a404e0a4c30ae3e620b1d10cc34
+# 9ec2dc9f4138483bb35b689d665d6639
+# b3c5e3a8af40456783a930038b3c4809
+# 98e0a158be994fd88c0bedf17a6b36ae
+# 6e16b609a4ed40f7a2290b0eb520d729
+# fb83ef26d0b44c429af002716f4abdc7
+# 9b2ccd8da72441869fea8111af33760c
+# 96da17585dfd4826bffb704c0793263d
+#: ../../source/development_guide/rest_api.rst:23
+#: ../../source/development_guide/rest_api.rst:38
+#: ../../source/development_guide/rest_api.rst:112
+#: ../../source/development_guide/rest_api.rst:145
+#: ../../source/development_guide/rest_api.rst:169
+#: ../../source/development_guide/rest_api.rst:189
+#: ../../source/development_guide/rest_api.rst:212
+#: ../../source/development_guide/rest_api.rst:242
+msgid "HTTP verb"
+msgstr ""
+
+# e82c6c0b009d44669ddc88b336f64581
+# 7bd84f2c31bb407293fcfa5046887b9d
+# 96d32c89f5ca4ab8a563425ba6b8065e
+# 1fbabf44108c41ddb9ed1872f64855c7
+# 229067f6b1ff4d939c63260bd2e3fe20
+# 7ddac55fc7ea4abda4866b2bf48d8019
+# 74921be61dbf48f8a7c10d2ea8bfcdea
+#: ../../source/development_guide/rest_api.rst:23
+#: ../../source/development_guide/rest_api.rst:38
+#: ../../source/development_guide/rest_api.rst:145
+#: ../../source/development_guide/rest_api.rst:169
+#: ../../source/development_guide/rest_api.rst:189
+#: ../../source/development_guide/rest_api.rst:212
+#: ../../source/development_guide/rest_api.rst:242
+msgid "URL"
+msgstr ""
+
+# de2ab75d45694fb984403d78fddeaca2
+# deb3e95c78574322a84329ee678366dd
+# 9361819f0837429babf92f04c4595287
+# 7a06c5af6c6f4f8cb20893c23c5936f3
+# 32c8b21b1d474f68acf0742198d18634
+# f0d3556b5b834db28df348b1f153db64
+# b9924939f4d34b9eab2effd17d29121b
+# 2eb6a4f4943d48fea7dab628f14d222e
+#: ../../source/development_guide/rest_api.rst:23
+#: ../../source/development_guide/rest_api.rst:38
+#: ../../source/development_guide/rest_api.rst:112
+#: ../../source/development_guide/rest_api.rst:145
+#: ../../source/development_guide/rest_api.rst:169
+#: ../../source/development_guide/rest_api.rst:189
+#: ../../source/development_guide/rest_api.rst:212
+#: ../../source/development_guide/rest_api.rst:242
+msgid "Action"
+msgstr ""
+
+# 763401d3039247d79e58ce1ec12fd518
+# 5afcd411ddb747738c3352f5189e036e
+# 78df1bb43b284a90a495991bf9d3e890
+# ab0547f84b784914bedd133e870b0057
+# 6cecf55719c145c9ae0796cbb378ac92
+# 4c4b2d742a8e4ea19985b66a37bb67a7
+# d27bb38bd52b4a6593a520840121b7ac
+# 5d1afd0c0a934b6bbd21eb57e7e7cbc7
+# fe6be4c15d914e3bbbf61432eee841ad
+# c487a63b691042b59b1f83490001ce47
+# 14c8617aa9b3490ab38b80f37f3fcf4c
+# 08f7c8eb565445b180c2fd363fa0f054
+# 50663441342e4b959bceae65ee26c8f6
+# 741a15dfa12a4f38b3f93bfb536647fb
+# f1181df2b3154c76bc292c53aa05391e
+# 91931ae80d9f490c850685d2db412081
+# 6037f22576504cb3a6fc7c3010dc2192
+# bd10507b0d50427782417823e54cd3be
+# cb2f272b24ce45bc894c2946f1267dcc
+# 480cf3b73cc148d7ad7bf74c6c263c55
+# 23b5ee04c60745ddbdcdf2cfd2219e93
+# 73c5e9f321b34b6abd5421f2b40285a1
+# 51cbcb5b73ea4c19ab76aef565c16595
+# b488e84daab844beb51647a2057fc030
+# bf3bc78ec5ab439d9c8d693b0f0491f5
+# de5dc5031a1e4aa4be45a7414af059b0
+# be05eeb20901486d80386c7ee69aa827
+# 5e2686db0ed743cdba7ef66620ee9939
+# 657ece27d618456b8c1d6c33ddf1f800
+# 3428328645e242ea89296246917f99f4
+# b72e3436c8de4d38ae7000fabba5d221
+# 33784dfc6de24eea92bd419c1a486195
+# 5386f0dbdf2c4ec99c19ff3369bd4a78
+#: ../../source/development_guide/rest_api.rst:26
+#: ../../source/development_guide/rest_api.rst:28
+#: ../../source/development_guide/rest_api.rst:32
+#: ../../source/development_guide/rest_api.rst:41
+#: ../../source/development_guide/rest_api.rst:44
+#: ../../source/development_guide/rest_api.rst:48
+#: ../../source/development_guide/rest_api.rst:88
+#: ../../source/development_guide/rest_api.rst:115
+#: ../../source/development_guide/rest_api.rst:117
+#: ../../source/development_guide/rest_api.rst:134
+#: ../../source/development_guide/rest_api.rst:137
+#: ../../source/development_guide/rest_api.rst:148
+#: ../../source/development_guide/rest_api.rst:155
+#: ../../source/development_guide/rest_api.rst:172
+#: ../../source/development_guide/rest_api.rst:174
+#: ../../source/development_guide/rest_api.rst:192
+#: ../../source/development_guide/rest_api.rst:199
+#: ../../source/development_guide/rest_api.rst:215
+#: ../../source/development_guide/rest_api.rst:218
+#: ../../source/development_guide/rest_api.rst:220
+#: ../../source/development_guide/rest_api.rst:224
+#: ../../source/development_guide/rest_api.rst:227
+#: ../../source/development_guide/rest_api.rst:231
+#: ../../source/development_guide/rest_api.rst:235
+#: ../../source/development_guide/rest_api.rst:245
+#: ../../source/development_guide/rest_api.rst:248
+#: ../../source/development_guide/rest_api.rst:251
+#: ../../source/development_guide/rest_api.rst:255
+#: ../../source/development_guide/rest_api.rst:259
+#: ../../source/development_guide/rest_api.rst:263
+#: ../../source/development_guide/rest_api.rst:266
+#: ../../source/development_guide/rest_api.rst:268
+#: ../../source/development_guide/rest_api.rst:276
+msgid "``GET``"
+msgstr ""
+
+# dffd12ae712b43ce8d6cf80d826c8017
+#: ../../source/development_guide/rest_api.rst:26
+msgid "/.\\*/\\"
+msgstr ""
+
+# 5ce071fb24d14854b986d15e69e2114e
+#: ../../source/development_guide/rest_api.rst:26
+msgid "Strips trailing slashes."
+msgstr ""
+
+# 1a776f1e82e44612aa2fdec9644afe9e
+#: ../../source/development_guide/rest_api.rst:28
+msgid "\\/api\\"
+msgstr ""
+
+# cbed5e8bbde04a74aa860b0dbf7e4880
+#: ../../source/development_guide/rest_api.rst:28
+msgid "Returns api version information."
+msgstr ""
+
+# 486f00bc379041ddb7f6fcdbd9e95e7d
+#: ../../source/development_guide/rest_api.rst:30
+msgid "``*``"
+msgstr ""
+
+# feff0224746046688e5c25ff5c3c6171
+#: ../../source/development_guide/rest_api.rst:30
+msgid "\\/api/notebooks"
+msgstr ""
+
+# 01a8e34b3a694b098bb91525785b7e36
+#: ../../source/development_guide/rest_api.rst:30
+msgid "Deprecated: redirect to /api/contents"
+msgstr ""
+
+# d8dabd59231844c6ad324fc4d271e6af
+#: ../../source/development_guide/rest_api.rst:32
+msgid "\\/api/nbconvert"
+msgstr ""
+
+# dacbd2c6987f42409c2feb109d0dde44
+#: ../../source/development_guide/rest_api.rst:35
+msgid "Notebook contents API."
+msgstr ""
+
+# aef631b0aed447688207bd806340cd63
+#: ../../source/development_guide/rest_api.rst:41
+msgid "/api/contents"
+msgstr ""
+
+# f5cde97e47e548379614ab3affbdddf0
+#: ../../source/development_guide/rest_api.rst:41
+msgid "Return a model for the base directory. See /api/contents/<path>/<file>."
+msgstr ""
+
+# 1448b28828454b7d9d1ed2853bcaf819
+#: ../../source/development_guide/rest_api.rst:44
+msgid "/api/contents/ <file>"
+msgstr ""
+
+# 3c765646a94f4d75a4d7c5ad89e8fe42
+#: ../../source/development_guide/rest_api.rst:44
+msgid ""
+"Return a model for the given file in the base directory. See "
+"/api/contents/<path>/<file>."
+msgstr ""
+
+# a4605641dd4f4cfebfe87b0155e422b2
+# 1e7d59f407dd49099f7351c0553beac9
+# 712b8ef05e294ee0b1b61e14ac733a19
+# 13225189dbd94717a156bab23927b5a1
+# 1d9baa4d593b4548af6606a84a2d2731
+#: ../../source/development_guide/rest_api.rst:48
+#: ../../source/development_guide/rest_api.rst:53
+#: ../../source/development_guide/rest_api.rst:70
+#: ../../source/development_guide/rest_api.rst:73
+#: ../../source/development_guide/rest_api.rst:85
+msgid "/api/contents/ <path>/<file>"
+msgstr ""
+
+# ed7bc4dabc754ad697cb7d97b98947f9
+#: ../../source/development_guide/rest_api.rst:48
+msgid ""
+"Return a model for a file or directory. A directory model contains a list"
+" of models (without content) of the files and directories it contains."
+msgstr ""
+
+# dfd73d904a7d4864aacd914ec6e2d4a3
+# 6eed25236c154ee7af6ba6c83fb8edaf
+#: ../../source/development_guide/rest_api.rst:53
+#: ../../source/development_guide/rest_api.rst:202
+msgid "``PUT``"
+msgstr ""
+
+# eb1c17f460184abe9577e7513ecd048e
+#: ../../source/development_guide/rest_api.rst:53
+msgid ""
+"Saves the file in the location specified by name and path. PUT is very "
+"similar to POST, but the requester specifies the name, where as with "
+"POST, the server picks the name. PUT /api/contents/path/Name.ipynb Save "
+"notebook at ``path/Name.ipynb``. Notebook structure is specified in "
+"``content`` key of JSON request body. If content is not specified, create"
+" a new empty notebook. PUT /api/contents/path/Name.ipynb with JSON body "
+"{\"copy\\_from\" : \"[path/to/] OtherNotebook.ipynb\"} Copy OtherNotebook"
+" to Name"
+msgstr ""
+
+# ceb6808281824129852733d7c9e4eeb5
+# 5625ae0380c34bc090c776621551f97e
+#: ../../source/development_guide/rest_api.rst:70
+#: ../../source/development_guide/rest_api.rst:158
+msgid "``PATCH``"
+msgstr ""
+
+# 75933adea4084527b478230d805980a3
+#: ../../source/development_guide/rest_api.rst:70
+msgid "Renames a notebook without re-uploading content."
+msgstr ""
+
+# 17c634548eb74c01a0dc92e4f58f49b4
+# caf03f3932b148388a33c42c74810505
+# fa50085f68ac4687be99cc75d2422897
+# 9d82e240de48406fa0d56bf23cc5c36c
+# d10b01d8ba9242d28457c629dba7ab6a
+# aaced630d1a043d7aed4dcba55b355e1
+# db725a152cba4888803919aec39c9ec6
+# 1fae8fe1e28345118a5d9c21b4b17854
+# 9961f9c83d9d4eceb9c2d7c49f3dfe62
+#: ../../source/development_guide/rest_api.rst:73
+#: ../../source/development_guide/rest_api.rst:92
+#: ../../source/development_guide/rest_api.rst:96
+#: ../../source/development_guide/rest_api.rst:120
+#: ../../source/development_guide/rest_api.rst:126
+#: ../../source/development_guide/rest_api.rst:150
+#: ../../source/development_guide/rest_api.rst:177
+#: ../../source/development_guide/rest_api.rst:195
+#: ../../source/development_guide/rest_api.rst:271
+msgid "``POST``"
+msgstr ""
+
+# 0536f641b6934319af698bda9cedf4e7
+#: ../../source/development_guide/rest_api.rst:73
+msgid ""
+"Creates a new file or directory in the specified path. POST creates new "
+"files or directories. The server always decides on the name. POST "
+"/api/contents/path New untitled notebook in path. If content specified, "
+"upload a notebook, otherwise start empty. POST /api/contents/path with "
+"body {\"copy\\_from\":\"OtherNotebook.ipynb\"} New copy of OtherNotebook "
+"in path"
+msgstr ""
+
+# d44cc798e58e4cad9b54269ba21156ad
+# ef7cfa1704f143d092483ccd5da72212
+# 30b3b06e66a24d61a5b24a611ccc0230
+# 9e98d4862452477c8ce4249aac75162e
+# 6c47ab0a66b644d28ac57748a4937e45
+#: ../../source/development_guide/rest_api.rst:85
+#: ../../source/development_guide/rest_api.rst:102
+#: ../../source/development_guide/rest_api.rst:123
+#: ../../source/development_guide/rest_api.rst:162
+#: ../../source/development_guide/rest_api.rst:205
+msgid "``DELETE``"
+msgstr ""
+
+# 9ceef3bacd5340ad8d5aeec1466a076b
+#: ../../source/development_guide/rest_api.rst:85
+msgid "delete a file in the given path."
+msgstr ""
+
+# 202361a1c09e47c2ad83579b433f5f4f
+# 15dde1b4832b42e7ad20afa5bee4e930
+#: ../../source/development_guide/rest_api.rst:88
+#: ../../source/development_guide/rest_api.rst:92
+msgid "/api/contents/ <path>/<file> /checkpoints"
+msgstr ""
+
+# 05ec1d01737d4688a6567dbaa710c7c3
+#: ../../source/development_guide/rest_api.rst:88
+msgid "get lists checkpoint for a file."
+msgstr ""
+
+# ca6e8400ef244624b6839870077fd6e3
+#: ../../source/development_guide/rest_api.rst:92
+msgid "post creates a new checkpoint."
+msgstr ""
+
+# 992ccde95573448aa6f41302d413bb40
+# a8be10f1246244ed965f085222bf11ff
+#: ../../source/development_guide/rest_api.rst:96
+#: ../../source/development_guide/rest_api.rst:102
+msgid "/api/contents/ <path>/<file> /checkpoints/ <checkpoint\\_ id>"
+msgstr ""
+
+# 2cd3d316ad3441c7b0d552eb718b6d28
+#: ../../source/development_guide/rest_api.rst:96
+msgid "post restores a file from a checkpoint."
+msgstr ""
+
+# 5bfe5a66d89d446fb55eb87325c487f3
+#: ../../source/development_guide/rest_api.rst:102
+msgid "delete clears a checkpoint for a given file."
+msgstr ""
+
+# a15416a2e61a4aaab583905d4af0963f
+#: ../../source/development_guide/rest_api.rst:109
+msgid "Kernel API"
+msgstr ""
+
+# c83393dead364609ba046887ad58eda4
+#: ../../source/development_guide/rest_api.rst:112
+msgid "URI"
+msgstr ""
+
+# a22a8dde569a49fdaabee69c4c8a4922
+# 9ce37afd4749427b86a9bdb405154753
+#: ../../source/development_guide/rest_api.rst:115
+#: ../../source/development_guide/rest_api.rst:120
+msgid "/api/kernels"
+msgstr ""
+
+# 61ec1cbf32c64bbfb1ea3eaa0d19192c
+#: ../../source/development_guide/rest_api.rst:115
+msgid "Return a model of all kernels."
+msgstr ""
+
+# ef7ea762242943969ec5c1e7cea1eada
+# 31cfc33080984d38b979a875687f4a62
+#: ../../source/development_guide/rest_api.rst:117
+#: ../../source/development_guide/rest_api.rst:123
+msgid "/api/kernels /<kernel\\_id>"
+msgstr ""
+
+# 3547722485614d43b0f8342ef19860bd
+#: ../../source/development_guide/rest_api.rst:117
+msgid "Return a model of kernel with given kernel id."
+msgstr ""
+
+# 50a8cf2db9a44b2d8bd1229939621a61
+#: ../../source/development_guide/rest_api.rst:120
+msgid "Start a new kernel with default or given name."
+msgstr ""
+
+# 5e1f9fc90a784841ac614c10dc3516db
+#: ../../source/development_guide/rest_api.rst:123
+msgid "Shutdown the given kernel."
+msgstr ""
+
+# aba500823d0a4193996e93e699a48012
+#: ../../source/development_guide/rest_api.rst:126
+msgid "/api/kernels /<kernel\\_id> /<action>"
+msgstr ""
+
+# f15d513346c34e96b482db11c73ebe2f
+#: ../../source/development_guide/rest_api.rst:126
+msgid ""
+"Perform action on kernel with given kernel id. Actions can be "
+"\"interrupt\" or \"restart\"."
+msgstr ""
+
+# 60b68955ab9746548149c88070e09d1b
+#: ../../source/development_guide/rest_api.rst:130
+msgid "``WS``"
+msgstr ""
+
+# e8e11e0467134d0c9c7792aa498d65dd
+#: ../../source/development_guide/rest_api.rst:130
+msgid "/api/kernels /<kernel\\_id> /channels"
+msgstr ""
+
+# de4521b7a70a4a78987145e026a49607
+#: ../../source/development_guide/rest_api.rst:130
+msgid "Websocket stream"
+msgstr ""
+
+# 70afdc93b80448788de5ee906115a591
+#: ../../source/development_guide/rest_api.rst:134
+msgid "/api/kernel specs"
+msgstr ""
+
+# e18bed8d78d245a4a5c2973178a7528e
+#: ../../source/development_guide/rest_api.rst:134
+msgid "Return a spec model of all available kernels."
+msgstr ""
+
+# a611384ba3e146aab1d36ad045577752
+#: ../../source/development_guide/rest_api.rst:137
+msgid "/api/kernel specs/ <kernel\\_name>"
+msgstr ""
+
+# 7505bc902e344212856aab8a1be8f17a
+#: ../../source/development_guide/rest_api.rst:137
+msgid "Return a spec model of all available kernels with a given kernel name."
+msgstr ""
+
+# 81461b43739140fc8fc0ad640eb498d5
+#: ../../source/development_guide/rest_api.rst:142
+msgid "Sessions API"
+msgstr ""
+
+# 08e4e18abc2244ceb8abf296ca974619
+#: ../../source/development_guide/rest_api.rst:148
+msgid "/api/sesions"
+msgstr ""
+
+# 6a2b019dacde41fba26edae7451aa2e5
+#: ../../source/development_guide/rest_api.rst:148
+msgid "Return model of active sessions."
+msgstr ""
+
+# e56fef54527d48dc8ba3b121cd264e40
+#: ../../source/development_guide/rest_api.rst:150
+msgid "/api/sessions"
+msgstr ""
+
+# f76c7178430e4df4884d2e39182e9c8b
+#: ../../source/development_guide/rest_api.rst:150
+msgid ""
+"If session does not already exist, create a new session with given "
+"notebook name and path and given kernel name. Return active sesssion."
+msgstr ""
+
+# 5a4883c124374c5badd2612c1995b17e
+# 62a139f0726b4521b1217f734f0a7a3c
+# 58e922b4809b4ef6a9c622a81b6e8037
+#: ../../source/development_guide/rest_api.rst:155
+#: ../../source/development_guide/rest_api.rst:158
+#: ../../source/development_guide/rest_api.rst:162
+msgid "/api/sessions /<session\\_id>"
+msgstr ""
+
+# 1a7b5abb09a84f49a0fe343a7f667a61
+#: ../../source/development_guide/rest_api.rst:155
+msgid "Return model of active session with given session id."
+msgstr ""
+
+# b5c11a8bffec49dca8bfc9c581d9bf4f
+#: ../../source/development_guide/rest_api.rst:158
+msgid ""
+"Return model of active session with notebook name or path of session with"
+" given session id."
+msgstr ""
+
+# 83e67dff5c6c4c4282abc35a809886d6
+#: ../../source/development_guide/rest_api.rst:162
+msgid "Delete model of active session with given session id."
+msgstr ""
+
+# ce880e4d63aa4f60b1cde75c9f07ec78
+#: ../../source/development_guide/rest_api.rst:166
+msgid "Clusters API"
+msgstr ""
+
+# 57b49bd43c8946b885d05a550d10998b
+#: ../../source/development_guide/rest_api.rst:172
+msgid "/api/clusters"
+msgstr ""
+
+# d597dde5def54af390dfb8c068248ad8
+#: ../../source/development_guide/rest_api.rst:172
+msgid "Return model of clusters."
+msgstr ""
+
+# 8dcc8aa616184ff39f7509a2821ba18c
+#: ../../source/development_guide/rest_api.rst:174
+msgid "/api/clusters <cluster\\_id>"
+msgstr ""
+
+# b7c8e1591a6d4ffe8c6fccfd070ec56f
+#: ../../source/development_guide/rest_api.rst:174
+msgid "Return model of given cluster."
+msgstr ""
+
+# 67a870b779114a1e8b55bc3682417ea9
+#: ../../source/development_guide/rest_api.rst:177
+msgid "/api/clusters <cluster\\_id> <action>"
+msgstr ""
+
+# 985c28ae15c543afb7ad154db3b46f50
+#: ../../source/development_guide/rest_api.rst:177
+msgid ""
+"Perform action with given clusters. Valid actions are \"start\" and "
+"\"stop\""
+msgstr ""
+
+# 819cb4187e2d4cc6a0e7107dc259977b
+#: ../../source/development_guide/rest_api.rst:183
+msgid "Old Architecture"
+msgstr ""
+
+# b0cef61ad6954909ac7f0e849285224f
+#: ../../source/development_guide/rest_api.rst:185
+msgid ""
+"This chart shows the web-services in the single directory IPython "
+"notebook."
+msgstr ""
+
+# fdeb7827a6d343a9a6066a8165be18d4
+# c2ec6a32978841179b74bed14bbd3ea1
+#: ../../source/development_guide/rest_api.rst:192
+#: ../../source/development_guide/rest_api.rst:195
+msgid "/notebooks"
+msgstr ""
+
+# af756cf6dda9437e9945475459ef4e5f
+#: ../../source/development_guide/rest_api.rst:192
+msgid "return list of dicts with each notebook's info"
+msgstr ""
+
+# 944132b8c9934cab857e811235689f40
+#: ../../source/development_guide/rest_api.rst:195
+msgid ""
+"if sending a body, saving that body as a new notebook; if no body, create"
+" a a new notebook."
+msgstr ""
+
+# 903e8f3495274ef5bd24dafa8c5004dd
+# c6e1a714498f409eabce7a39a40568aa
+# e4621bb9f8c34d9ab8d60469bac19bd2
+#: ../../source/development_guide/rest_api.rst:199
+#: ../../source/development_guide/rest_api.rst:202
+#: ../../source/development_guide/rest_api.rst:205
+msgid "/notebooks /<notebook\\_id>"
+msgstr ""
+
+# fa3253b06f424c3fa9827596beeb038e
+#: ../../source/development_guide/rest_api.rst:199
+msgid "get JSON data for notebook"
+msgstr ""
+
+# 3ac66b01afa544639b6e56e520fcf336
+#: ../../source/development_guide/rest_api.rst:202
+msgid "saves an existing notebook with body data"
+msgstr ""
+
+# f2d62f8edd154a1694c266cb01d161da
+#: ../../source/development_guide/rest_api.rst:205
+msgid "deletes the notebook with the given ID"
+msgstr ""
+
+# 76792199079742d7ba728bfd36c6e12b
+#: ../../source/development_guide/rest_api.rst:209
+msgid "This chart shows the architecture for the IPython notebook website."
+msgstr ""
+
+# 4b327f0782284c11bffe95726ba3d093
+#: ../../source/development_guide/rest_api.rst:215
+msgid "/"
+msgstr ""
+
+# 8f2f602d40da4dc693e34cfbfdf8f3b7
+#: ../../source/development_guide/rest_api.rst:215
+msgid "navigates user to dashboard of notebooks and clusters."
+msgstr ""
+
+# 29f4821c5000491d8ff30a06d4a649b5
+#: ../../source/development_guide/rest_api.rst:218
+msgid "/<notebook\\_id>"
+msgstr ""
+
+# 6d09e8fe05b141529561184b06fe4678
+#: ../../source/development_guide/rest_api.rst:218
+msgid "go to wepage for that notebook"
+msgstr ""
+
+# 24836333d48d47d3986688ce667283a7
+#: ../../source/development_guide/rest_api.rst:220
+msgid "/new"
+msgstr ""
+
+# 4a85061aeca048fd9010b52afc06f83b
+#: ../../source/development_guide/rest_api.rst:220
+msgid ""
+"creates a new notebook with profile (or default, if no profile exists) "
+"setings"
+msgstr ""
+
+# ff97d5e191354ac49a2e70163427c4c2
+#: ../../source/development_guide/rest_api.rst:224
+msgid "/<notebook\\_id> /copy"
+msgstr ""
+
+# 0589cdc545964cf0926fa8eb459123b5
+#: ../../source/development_guide/rest_api.rst:224
+msgid "opens a duplicate copy or the notebook with the given ID in a new tab"
+msgstr ""
+
+# ff517ea185b049dfa1f37f0135487226
+#: ../../source/development_guide/rest_api.rst:227
+msgid "/<notebook\\_id> /print"
+msgstr ""
+
+# 70ade4f0505d436c949d0a14cea03ce6
+#: ../../source/development_guide/rest_api.rst:227
+msgid ""
+"prints the notebook with the given ID; if notebook doesn't exist, "
+"displays error message"
+msgstr ""
+
+# ef1e03a67e434bcebb694721b956c0a4
+#: ../../source/development_guide/rest_api.rst:231
+msgid "/login"
+msgstr ""
+
+# 54945e6f06af47a3948156bb62efe0f2
+#: ../../source/development_guide/rest_api.rst:231
+msgid ""
+"navigates to login page; if no user profile is defined, it navigates user"
+" to dashboard"
+msgstr ""
+
+# 7b8ee796640a4c1a86cd204b274f42d6
+#: ../../source/development_guide/rest_api.rst:235
+msgid "/logout"
+msgstr ""
+
+# 2f224f13e6a5446bb8683b23cf41436a
+#: ../../source/development_guide/rest_api.rst:235
+msgid "logs out of current profile, and navigates user to login page"
+msgstr ""
+
+# 461cac9f248140918942166ba0e0b01d
+#: ../../source/development_guide/rest_api.rst:239
+msgid "This chart shows the Web services that act on the kernels and clusters."
+msgstr ""
+
+# de02268e21c94de3a4759a55773c3ea2
+#: ../../source/development_guide/rest_api.rst:245
+msgid "/kernels"
+msgstr ""
+
+# d5845cac753b4c1abdc62104632c17c5
+#: ../../source/development_guide/rest_api.rst:245
+msgid "return the list of kernel IDs currently running"
+msgstr ""
+
+# 2bb5311d7d954a3f9c8f4ca85472bf76
+#: ../../source/development_guide/rest_api.rst:248
+msgid "/kernels /<kernel\\_id>"
+msgstr ""
+
+# 77fd3900942741b09303446a7004120a
+# c7c4420e0aa341a2af83c24a2d1767fe
+# 13d18f18fab7449d9f5a9ebbb3bd0724
+# f9521b40d2cc4a8caf50dc7788d4d135
+# 2a226c3f624349ae9a76a4adef40b2a8
+#: ../../source/development_guide/rest_api.rst:248
+#: ../../source/development_guide/rest_api.rst:255
+#: ../../source/development_guide/rest_api.rst:259
+#: ../../source/development_guide/rest_api.rst:263
+#: ../../source/development_guide/rest_api.rst:266
+msgid "---"
+msgstr ""
+
+# e136d989d52e439e8e6d924f02a1268b
+#: ../../source/development_guide/rest_api.rst:251
+msgid "/kernels /<kernel\\_id> <action>"
+msgstr ""
+
+# 59d771a7602d4cf0aba2314257cb6ac8
+#: ../../source/development_guide/rest_api.rst:251
+msgid "performs action (restart/kill) kernel with given ID"
+msgstr ""
+
+# e70044bc6b954eb5982a61f2d9f35fc4
+#: ../../source/development_guide/rest_api.rst:255
+msgid "/kernels /<kernel\\_id> /iopub"
+msgstr ""
+
+# 368154e364f94b5b9f449a21c01529e5
+#: ../../source/development_guide/rest_api.rst:259
+msgid "/kernels /<kernel\\_id> /shell"
+msgstr ""
+
+# 562e776b3fbb4f7e91b6208e783b6a15
+#: ../../source/development_guide/rest_api.rst:263
+msgid "/rstservice/ render"
+msgstr ""
+
+# 05a3c48c4b62422eb4d4079b522f3f99
+#: ../../source/development_guide/rest_api.rst:266
+msgid "/files/(.\\*)"
+msgstr ""
+
+# 569ac69c0a2c4b75b0e0de52468cbc7e
+#: ../../source/development_guide/rest_api.rst:268
+msgid "/clusters"
+msgstr ""
+
+# 84144edf06b64ad8bd71aa7cf35943f3
+#: ../../source/development_guide/rest_api.rst:268
+msgid "returns a list of dicts with each cluster's information"
+msgstr ""
+
+# 081da73e88514f32b9fbd6e610569422
+#: ../../source/development_guide/rest_api.rst:271
+msgid "/clusters /<profile\\_id> /<cluster\\_ action>"
+msgstr ""
+
+# ed0932c1d56548e598921efeeb5cc74b
+#: ../../source/development_guide/rest_api.rst:271
+msgid "performs action (start/stop) on cluster with given profile ID"
+msgstr ""
+
+# 4499cb69e075466ca0738fe9600eac8f
+#: ../../source/development_guide/rest_api.rst:276
+msgid "/clusters /<profile\\_id>"
+msgstr ""
+
+# 5144fcfdab6143b1975f8e8837e184db
+#: ../../source/development_guide/rest_api.rst:276
+msgid "returns the JSON data for cluster with given profile ID"
+msgstr ""
+
+# ecaf0b8eb09146c1990b346ac4c12ea8
+#: ../../source/development_guide/sphinx_directive.rst:4
+msgid "IPython Sphinx Directive"
+msgstr ""
+
+# 1a6af3d02129462689efcf761c98db39
+#: ../../source/development_guide/sphinx_directive.rst:9
+msgid ""
+"The ipython directive is a stateful ipython shell for embedding in sphinx"
+" documents.  It knows about standard ipython prompts, and extracts the "
+"input and output lines.  These prompts will be renumbered starting at "
+"``1``.  The inputs will be fed to an embedded ipython interpreter and the"
+" outputs from that interpreter will be inserted as well.  For example, "
+"code blocks like the following::"
+msgstr ""
+
+# be1f1c5ba2854ae9abcec8403c98b857
+#: ../../source/development_guide/sphinx_directive.rst:23
+msgid "will be rendered as"
+msgstr ""
+
+# 95d3f01bb5da46e7b1fc259b1f68fd9b
+#: ../../source/development_guide/sphinx_directive.rst:34
+msgid ""
+"This tutorial should be read side-by-side with the Sphinx source for this"
+" document because otherwise you will see only the rendered output and not"
+" the code that generated it.  Excepting the example above, we will not in"
+" general be showing the literal ReST in this document that generates the "
+"rendered output."
+msgstr ""
+
+# 7a9bcf56e253423cbc1c6256b5c4501e
+#: ../../source/development_guide/sphinx_directive.rst:41
+msgid ""
+"The state from previous sessions is stored, and standard error is "
+"trapped. At doc build time, ipython's output and std err will be "
+"inserted, and prompts will be renumbered. So the prompt below should be "
+"renumbered in the rendered docs, and pick up where the block above left "
+"off."
+msgstr ""
+
+# 8661fbdc92ab401b81044a193e9cdead
+#: ../../source/development_guide/sphinx_directive.rst:66
+msgid ""
+"The embedded interpreter supports some limited markup.  For example, you "
+"can put comments in your ipython sessions, which are reported verbatim.  "
+"There are some handy \"pseudo-decorators\" that let you doctest the "
+"output.  The inputs are fed to an embedded ipython session and the "
+"outputs from the ipython session are inserted into your doc.  If the "
+"output in your doc and in the ipython session don't match on a doctest "
+"assertion, an error will be"
+msgstr ""
+
+# 3f187933d2ca4ee8a3754fca19ba9c27
+#: ../../source/development_guide/sphinx_directive.rst:92
+msgid "Multi-line input is supported."
+msgstr ""
+
+# 2f404b366a7c4e33a08ad3536a33b782
+#: ../../source/development_guide/sphinx_directive.rst:103
+msgid ""
+"You can do doctesting on multi-line output as well.  Just be careful when"
+" using non-deterministic inputs like random numbers in the ipython "
+"directive, because your inputs are ruin through a live interpreter, so if"
+" you are doctesting random output you will get an error.  Here we "
+"\"seed\" the random number generator for deterministic output, and we "
+"suppress the seed line so it doesn't show up in the rendered output"
+msgstr ""
+
+# cd769347eca441e6ae41012cbd6c3368
+#: ../../source/development_guide/sphinx_directive.rst:132
+msgid "Another demonstration of multi-line input and output"
+msgstr ""
+
+# e25d68950302401aab1b4a8efbca2b28
+#: ../../source/development_guide/sphinx_directive.rst:156
+msgid ""
+"Most of the \"pseudo-decorators\" can be used an options to ipython mode."
+"  For example, to setup matplotlib pylab but suppress the output, you can"
+" do.  When using the matplotlib ``use`` directive, it should occur before"
+" any import of pylab.  This will not show up in the rendered docs, but "
+"the commands will be executed in the embedded interpreter and subsequent "
+"line numbers will be incremented to reflect the inputs::"
+msgstr ""
+
+# d512e1317bf34899ba98769e96504ffc
+#: ../../source/development_guide/sphinx_directive.rst:177
+msgid ""
+"Likewise, you can set ``:doctest:`` or ``:verbatim:`` to apply these "
+"settings to the entire block.  For example,"
+msgstr ""
+
+# 750e9c6085cb47f494525d6d700016eb
+#: ../../source/development_guide/sphinx_directive.rst:211
+msgid ""
+"You can create one or more pyplot plots and insert them with the "
+"``@savefig`` decorator."
+msgstr ""
+
+# 7e0cba55af2c4726b80908fc11bd87d4
+#: ../../source/development_guide/sphinx_directive.rst:223
+msgid ""
+"In a subsequent session, we can update the current figure with some text,"
+" and then resave"
+msgstr ""
+
+# 26224a89dd6b4104993adddc105e30d2
+#: ../../source/development_guide/sphinx_directive.rst:236
+msgid "You can also have function definitions included in the source."
+msgstr ""
+
+# 4fee5a90c5924503a796fe31c61836cd
+#: ../../source/development_guide/sphinx_directive.rst:250
+msgid "Then call it from a subsequent section."
+msgstr ""
+
+# 40f4c170c68d465ebd0facc61091d74c
+#: ../../source/development_guide/sphinx_directive.rst:262
+msgid "Writing Pure Python Code"
+msgstr ""
+
+# 27b06e32117148dd9ac27196ea17cff7
+#: ../../source/development_guide/sphinx_directive.rst:264
+msgid ""
+"Pure python code is supported by the optional argument `python`. In this "
+"pure python syntax you do not include the output from the python "
+"interpreter. The following markup::"
+msgstr ""
+
+# 9bfc9399e7344f47aeee6b108d4c80c8
+#: ../../source/development_guide/sphinx_directive.rst:275
+msgid "Renders as"
+msgstr ""
+
+# 143dfd8c90d640d1ae379cff861c53fc
+#: ../../source/development_guide/sphinx_directive.rst:284
+msgid ""
+"We can even plot from python, using the savefig decorator, as well as, "
+"suppress output with a semicolon"
+msgstr ""
+
+# 4e5f8f65f700433da3aa7c77aff0b8e8
+#: ../../source/development_guide/sphinx_directive.rst:292
+msgid "Similarly, std err is inserted"
+msgstr ""
+
+# be359198a34747a2a02d4ec1202f60f7
+#: ../../source/development_guide/sphinx_directive.rst:299
+msgid "Comments are handled and state is preserved"
+msgstr ""
+
+# 26da84518202409ebcf6b00f0d273bb8
+#: ../../source/development_guide/sphinx_directive.rst:306
+msgid "If you don't see the next code block then the options work."
+msgstr ""
+
+# 9e1cb6242761493abd5e4b9f305f73c6
+#: ../../source/development_guide/sphinx_directive.rst:313
+msgid "Multi-line input is handled."
+msgstr ""
+
+# 91f37105015c41d79b3605f85c3c69f5
+#: ../../source/development_guide/sphinx_directive.rst:323
+msgid "Functions definitions are correctly parsed"
+msgstr ""
+
+# 09192d72a72842c1af4869ff794d0c94
+#: ../../source/development_guide/sphinx_directive.rst:336
+msgid "And persist across sessions"
+msgstr ""
+
+# 8df88447cc244a0e98ada814e7bb2c75
+#: ../../source/development_guide/sphinx_directive.rst:343
+msgid ""
+"Pretty much anything you can do with the ipython code, you can do with a "
+"simple python script. Obviously, though it doesn't make sense to use the "
+"doctest option."
+msgstr ""
+
+# 078e5ad91f7e496e8f8551f9d8447521
+#: ../../source/development_guide/sphinx_directive.rst:348
+msgid "Pseudo-Decorators"
+msgstr ""
+
+# 8496e2e10f8249f8a0889c63bc0bdc01
+#: ../../source/development_guide/sphinx_directive.rst:350
+msgid ""
+"Here are the supported decorators, and any optional arguments they take."
+"  Some of the decorators can be used as options to the entire block (eg "
+"``verbatim`` and ``suppress``), and some only apply to the line just "
+"below them (eg ``savefig``)."
+msgstr ""
+
+# 46581c1b4489455a9401ef030eb19f7e
+#: ../../source/development_guide/sphinx_directive.rst:355
+msgid "@suppress"
+msgstr ""
+
+# 78c15d5d9d2148f1b24d668c8bbf3a12
+#: ../../source/development_guide/sphinx_directive.rst:357
+msgid ""
+"execute the ipython input block, but suppress the input and output block "
+"from the rendered output.  Also, can be applied to the entire "
+"``..ipython`` block as a directive option with ``:suppress:``."
+msgstr ""
+
+# f80914b7f9d84a0cb2269c32131f57c5
+#: ../../source/development_guide/sphinx_directive.rst:361
+msgid "@verbatim"
+msgstr ""
+
+# 7581a6ec4f3340009ea650860d1a4e87
+#: ../../source/development_guide/sphinx_directive.rst:363
+msgid ""
+"insert the input and output block in verbatim, but auto-increment the "
+"line numbers. Internally, the interpreter will be fed an empty string, so"
+" it is a no-op that keeps line numbering consistent. Also, can be applied"
+" to the entire ``..ipython`` block as a directive option with "
+"``:verbatim:``."
+msgstr ""
+
+# 5c4589b166cc4f8bbfc0ac493852cbba
+#: ../../source/development_guide/sphinx_directive.rst:369
+msgid "@savefig OUTFILE [IMAGE_OPTIONS]"
+msgstr ""
+
+# 3527e86c071e4a66b28c3634d27c12f7
+#: ../../source/development_guide/sphinx_directive.rst:371
+msgid ""
+"save the figure to the static directory and insert it into the document, "
+"possibly binding it into a minipage and/or putting code/figure "
+"label/references to associate the code and the figure. Takes args to pass"
+" to the image directive (*scale*, *width*, etc can be kwargs); see `image"
+" options "
+"<http://docutils.sourceforge.net/docs/ref/rst/directives.html#image>`_ "
+"for details."
+msgstr ""
+
+# 9bb837c64a9f47b09c9e6cdd748149cc
+#: ../../source/development_guide/sphinx_directive.rst:379
+msgid "@doctest"
+msgstr ""
+
+# a7c37652b27f49259655b5e77a94f2f1
+#: ../../source/development_guide/sphinx_directive.rst:381
+msgid ""
+"Compare the pasted in output in the ipython block with the output "
+"generated at doc build time, and raise errors if they donâ€™t match. "
+"Also, can be applied to the entire ``..ipython`` block as a directive "
+"option with ``:doctest:``."
+msgstr ""
+
+# 981a1d3bd1774d75893718ec6fc08f09
+#: ../../source/development_guide/sphinx_directive.rst:387
+msgid "Configuration Options"
+msgstr ""
+
+# 3df1f28cd6bf45acade20f5d1517e6f6
+#: ../../source/development_guide/sphinx_directive.rst:389
+msgid "ipython_savefig_dir"
+msgstr ""
+
+# 792602678601404a8d3ac21aa40be6b1
+#: ../../source/development_guide/sphinx_directive.rst:391
+msgid ""
+"The directory in which to save the figures. This is relative to the "
+"Sphinx source directory. The default is `html_static_path`."
+msgstr ""
+
+# 140a2c7a2b9d402cad12d5a024cb3e60
+#: ../../source/development_guide/sphinx_directive.rst:394
+msgid "ipython_rgxin"
+msgstr ""
+
+# bd034db7665a47e8b4d9368ff619aafa
+#: ../../source/development_guide/sphinx_directive.rst:396
+msgid ""
+"The compiled regular expression to denote the start of IPython input "
+"lines. The default is re.compile('In \\[(\\d+)\\]:\\s?(.*)\\s*'). You "
+"shouldn't need to change this."
+msgstr ""
+
+# f7c5465041ba48c2850106f6e9e94697
+#: ../../source/development_guide/sphinx_directive.rst:400
+msgid "ipython_rgxout"
+msgstr ""
+
+# 77908add9c29480690fd25915d879634
+#: ../../source/development_guide/sphinx_directive.rst:402
+msgid ""
+"The compiled regular expression to denote the start of IPython output "
+"lines. The default is re.compile('Out\\[(\\d+)\\]:\\s?(.*)\\s*'). You "
+"shouldn't need to change this."
+msgstr ""
+
+# 3201a8e59323478684c80a3454c2f8df
+#: ../../source/development_guide/sphinx_directive.rst:407
+msgid "ipython_promptin"
+msgstr ""
+
+# d057091b1f274838b754082ae5624619
+#: ../../source/development_guide/sphinx_directive.rst:409
+#, python-format
+msgid ""
+"The string to represent the IPython input prompt in the generated ReST. "
+"The default is 'In [%d]:'. This expects that the line numbers are used in"
+" the prompt."
+msgstr ""
+
+# 7b8b46b701f441eabf3e9e4bd61d6ff1
+#: ../../source/development_guide/sphinx_directive.rst:413
+msgid "ipython_promptout"
+msgstr ""
+
+# 890612f5be0b41c4aa95fbf2df2106b7
+#: ../../source/development_guide/sphinx_directive.rst:415
+#, python-format
+msgid ""
+"The string to represent the IPython prompt in the generated ReST. The "
+"default is 'Out [%d]:'. This expects that the line numbers are used in "
+"the prompt."
+msgstr ""
+
+# 27a6f000767e4d5ca50192bbba9a45cb
+#: ../../source/development_guide/testing.rst:4
+msgid "Testing IPython for users and developers"
+msgstr ""
+
+# e1c007bdd68b49d897c585eb20430783
+#: ../../source/development_guide/testing.rst:10
+msgid "Overview"
+msgstr ""
+
+# 844d10e3be9a4277aa773c204884291a
+#: ../../source/development_guide/testing.rst:12
+msgid ""
+"It is extremely important that all code contributed to IPython has tests."
+" Tests should be written as unittests, doctests or other entities that "
+"the IPython test system can detect. See below for more details on this."
+msgstr ""
+
+# 821bcb831c114683b15276dc6ec5899f
+#: ../../source/development_guide/testing.rst:17
+msgid ""
+"Each subpackage in IPython should have its own ``tests`` directory that "
+"contains all of the tests for that subpackage. All of the files in the "
+"``tests`` directory should have the word \"tests\" in them to enable the "
+"testing framework to find them."
+msgstr ""
+
+# 570ccbdb6bbf4d93bca65ee6004cbf20
+#: ../../source/development_guide/testing.rst:22
+msgid ""
+"In docstrings, examples (either using IPython prompts like ``In [1]:`` or"
+" 'classic' python ``>>>`` ones) can and should be included. The testing "
+"system will detect them as doctests and will run them; it offers control "
+"to skip parts or all of a specific doctest if the example is meant to be "
+"informative but shows non-reproducible information (like filesystem "
+"data)."
+msgstr ""
+
+# eb5ea7f7c4bd4149b910b6e7fdc90548
+#: ../../source/development_guide/testing.rst:29
+msgid ""
+"If a subpackage has any dependencies beyond the Python standard library, "
+"the tests for that subpackage should be skipped if the dependencies are "
+"not found. This is very important so users don't get tests failing simply"
+" because they don't have dependencies."
+msgstr ""
+
+# 1bae5608051d4014aaf1bdd3fea06df1
+#: ../../source/development_guide/testing.rst:34
+msgid ""
+"The testing system we use is an extension of the `nose "
+"<https://code.google.com/archive/p/python-nose>`__ test runner. In "
+"particular we've developed a nose plugin that allows us to paste verbatim"
+" IPython sessions and test them as doctests, which is extremely important"
+" for us."
+msgstr ""
+
+# f197bc1384eb4e908a7315e7a18894cd
+#: ../../source/development_guide/testing.rst:41
+msgid "Running the test suite"
+msgstr ""
+
+# d4eb05e8dab545a8bc155c101920e037
+#: ../../source/development_guide/testing.rst:43
+msgid ""
+"You can run IPython from the source download directory without even "
+"installing it system-wide or having configure anything, by typing at the "
+"terminal:"
+msgstr ""
+
+# 8aff3ac30add49aa91a752e8b3ae02b8
+#: ../../source/development_guide/testing.rst:51
+msgid "To start the webbased notebook you can use:"
+msgstr ""
+
+# 5786563b0bdd48439fa3dc0295306ac5
+#: ../../source/development_guide/testing.rst:57
+msgid ""
+"In order to run the test suite, you must at least be able to import "
+"IPython, even if you haven't fully installed the user-facing scripts yet "
+"(common in a development environment). You can then run the tests with:"
+msgstr ""
+
+# 14fb987065c2432dba155af720fe2bb1
+#: ../../source/development_guide/testing.rst:65
+msgid "Once you have installed IPython either via a full install or using:"
+msgstr ""
+
+# 71ac67c588434e1590c51a6eb7173c8a
+#: ../../source/development_guide/testing.rst:71
+msgid ""
+"you will have available a system-wide script called ``iptest`` that runs "
+"the full test suite. You can then run the suite with:"
+msgstr ""
+
+# 4f379e62ed0a48ebb0b34290233f8743
+#: ../../source/development_guide/testing.rst:78
+msgid ""
+"By default, this excludes the relatively slow tests for "
+"``IPython.parallel``. To run these, use ``iptest --all``."
+msgstr ""
+
+# b953130e61dd46fea865b2f3db368b9e
+#: ../../source/development_guide/testing.rst:81
+msgid ""
+"Please note that the iptest tool will run tests against the code imported"
+" by the Python interpreter. If the command ``python setup.py symlink`` "
+"has been previously run then this will always be the test code in the "
+"local directory via a symlink. However, if this command has not been run "
+"for the version of Python being tested, there is the possibility that "
+"iptest will run the tests against an installed version of IPython."
+msgstr ""
+
+# 9710816ba7b2484ea640d3a6b1b99c31
+#: ../../source/development_guide/testing.rst:89
+msgid ""
+"Regardless of how you run things, you should eventually see something "
+"like:"
+msgstr ""
+
+# 614b34f2ec5b4490a5e840f9d501ba70
+#: ../../source/development_guide/testing.rst:114
+msgid ""
+"If not, there will be a message indicating which test group failed and "
+"how to rerun that group individually. For example, this tests the "
+"``IPython.utils`` subpackage, the ``-v`` option shows progress "
+"indicators:"
+msgstr ""
+
+# 472241ea528a4474bf852a4a2b3192bf
+#: ../../source/development_guide/testing.rst:129
+msgid ""
+"Because the IPython test machinery is based on nose, you can use all nose"
+" syntax. Options after ``--`` are passed to nose. For example, this lets "
+"you run the specific test ``test_rehashx`` inside the ``test_magic`` "
+"module:"
+msgstr ""
+
+# a8b75c70816c4171995e1b3d69bc62af
+#: ../../source/development_guide/testing.rst:145
+msgid ""
+"When developing, the ``--pdb`` and ``--pdb-failures`` of nose are "
+"particularly useful, these drop you into an interactive pdb session at "
+"the point of the error or failure respectively: ``iptest mymodule -- "
+"--pdb``."
+msgstr ""
+
+# cc865cad5eff4c63bde73d0e5ed83c27
+#: ../../source/development_guide/testing.rst:150
+msgid ""
+"The system information summary printed above is accessible from the top "
+"level package. If you encounter a problem with IPython, it's useful to "
+"include this information when reporting on the mailing list; use::"
+msgstr ""
+
+# 89f6b6f7135644de883cfe881958da37
+#: ../../source/development_guide/testing.rst:156
+msgid "from IPython import sys_info print sys_info()"
+msgstr ""
+
+# 1ad64a55fae24664865a1daa9546bc92
+#: ../../source/development_guide/testing.rst:159
+msgid "and include the resulting information in your query."
+msgstr ""
+
+# 5c0493f32ba34c32a7f7a26b75a45b3c
+#: ../../source/development_guide/testing.rst:162
+msgid "Testing pull requests"
+msgstr ""
+
+# 56dccf1edc7d42ba97235fc0909a286b
+#: ../../source/development_guide/testing.rst:164
+msgid ""
+"We have a script that fetches a pull request from Github, merges it with "
+"master, and runs the test suite on different versions of Python. This "
+"uses a separate copy of the repository, so you can keep working on the "
+"code while it runs. To run it:"
+msgstr ""
+
+# 5f6f81a06a5548aa92e363c518a23423
+#: ../../source/development_guide/testing.rst:173
+msgid ""
+"The number is the pull request number from Github; the ``-p`` flag makes "
+"it post the results to a comment on the pull request. Any further "
+"arguments are passed to ``iptest``."
+msgstr ""
+
+# e9bf9d2d0d9e464d8c84e83b6ecea186
+#: ../../source/development_guide/testing.rst:177
+msgid ""
+"This requires the `requests <https://pypi.python.org/pypi/requests>`__ "
+"and `keyring <https://pypi.python.org/pypi/keyring>`__ packages."
+msgstr ""
+
+# cb70af2a41f444c19d09ba4052f15034
+#: ../../source/development_guide/testing.rst:181
+msgid "For developers: writing tests"
+msgstr ""
+
+# 94aeb6cea2674d37b05d9ec68916a4c7
+#: ../../source/development_guide/testing.rst:183
+msgid ""
+"By now IPython has a reasonable test suite, so the best way to see what's"
+" available is to look at the ``tests`` directory in most subpackages. But"
+" here are a few pointers to make the process easier."
+msgstr ""
+
+# d5cf58b941044fde967b425c2e2952a2
+#: ../../source/development_guide/testing.rst:188
+msgid "Main tools: ``IPython.testing``"
+msgstr ""
+
+# 473653eaf4104a50a6472b679f60cc7a
+#: ../../source/development_guide/testing.rst:190
+msgid ""
+"The ``IPython.testing`` package is where all of the machinery to test "
+"IPython (rather than the tests for its various parts) lives. In "
+"particular, the ``iptest`` module in there has all the smarts to control "
+"the test process. In there, the ``make_exclude`` function is used to "
+"build a blacklist of exclusions, these are modules that do not get even "
+"imported for tests. This is important so that things that would fail to "
+"even import because of missing dependencies don't give errors to end "
+"users, as we stated above."
+msgstr ""
+
+# 40dbcdef36d64128ad582781f05c660b
+#: ../../source/development_guide/testing.rst:199
+msgid ""
+"The ``decorators`` module contains a lot of useful decorators, especially"
+" useful to mark individual tests that should be skipped under certain "
+"conditions (rather than blacklisting the package altogether because of a "
+"missing major dependency)."
+msgstr ""
+
+# 8c1c005edf93476a8ae62b269d4404a6
+#: ../../source/development_guide/testing.rst:205
+msgid "Our nose plugin for doctests"
+msgstr ""
+
+# bfb15655ad094c51b4473555ba6ceb28
+#: ../../source/development_guide/testing.rst:207
+msgid ""
+"The ``plugin`` subpackage in testing contains a nose plugin called "
+"``ipdoctest`` that teaches nose about IPython syntax, so you can write "
+"doctests with IPython prompts. You can also mark doctest output with ``# "
+"random`` for the output corresponding to a single input to be ignored "
+"(stronger than using ellipsis and useful to keep it as an example). If "
+"you want the entire docstring to be executed but none of the output from "
+"any input to be checked, you can use the ``# all-random`` marker. The "
+"``IPython.testing.plugin.dtexample`` module contains examples of how to "
+"use these; for reference here is how to use ``# random``:"
+msgstr ""
+
+# 1292a78c838b4a9caeca2665510d1b04
+#: ../../source/development_guide/testing.rst:249
+msgid "and an example of ``# all-random``:"
+msgstr ""
+
+# 2d557c51b55e49a693c25acd171eb9bc
+#: ../../source/development_guide/testing.rst:279
+msgid ""
+"When writing docstrings, you can use the ``@skip_doctest`` decorator to "
+"indicate that a docstring should *not* be treated as a doctest at all. "
+"The difference between ``# all-random`` and ``@skip_doctest`` is that the"
+" former executes the example but ignores output, while the latter doesn't"
+" execute any code. ``@skip_doctest`` should be used for docstrings whose "
+"examples are purely informational."
+msgstr ""
+
+# 70efd2988ecf430f99d724409ed8cec0
+#: ../../source/development_guide/testing.rst:286
+msgid ""
+"If a given docstring fails under certain conditions but otherwise is a "
+"good doctest, you can use code like the following, that relies on the "
+"'null' decorator to leave the docstring intact where it works as a test:"
+msgstr ""
+
+# 3878be7f250c4ca5ba17f9028f5309a5
+#: ../../source/development_guide/testing.rst:304
+msgid ""
+"With our nose plugin that understands IPython syntax, an extremely "
+"effective way to write tests is to simply copy and paste an interactive "
+"session into a docstring. You can writing this type of test, where your "
+"docstring is meant *only* as a test, by prefixing the function name with "
+"``doctest_`` and leaving its body *absolutely empty* other than the "
+"docstring. In ``IPython.core.tests.test_magic`` you can find several "
+"examples of this, but for completeness sake, your code should look like "
+"this (a simple case):"
+msgstr ""
+
+# f2323f599c37435999518cd691eb254f
+#: ../../source/development_guide/testing.rst:322
+msgid ""
+"This function is only analyzed for its docstring but it is not considered"
+" a separate test, which is why its body should be empty."
+msgstr ""
+
+# a1a31cd900144f6498b312df387bf326
+#: ../../source/development_guide/testing.rst:326
+msgid "JavaScript Tests"
+msgstr ""
+
+# 55e925644bbf42f18fea76e793e5f7ea
+#: ../../source/development_guide/testing.rst:328
+msgid ""
+"We currently use `casperjs <http://casperjs.org/>`__ for testing the "
+"notebook javascript user interface."
+msgstr ""
+
+# 86ed51fe4d284284812995f9c2aa800d
+#: ../../source/development_guide/testing.rst:331
+msgid ""
+"To run the JS test suite by itself, you can either use ``iptest js``, "
+"which will start up a new notebook server and test against it, or you can"
+" open up a notebook server yourself, and then:"
+msgstr ""
+
+# 10ef19ece8954410aa7023ae524cfe0e
+#: ../../source/development_guide/testing.rst:340
+msgid ""
+"If your testing notebook server uses something other than the default "
+"port (8888), you will have to pass that as a parameter to the test suite "
+"as well."
+msgstr ""
+
+# d4dd9155cfc741168d07245a00e7449e
+#: ../../source/development_guide/testing.rst:349
+msgid "Running individual tests"
+msgstr ""
+
+# 27e768bba3f64ba7b12e8e7225779467
+#: ../../source/development_guide/testing.rst:351
+msgid ""
+"To speed up development, you usually are working on getting one test "
+"passing at a time. To do this, just pass the filename directly to the "
+"``casperjs test`` command like so:"
+msgstr ""
+
+# 11f7653601b84925a2ec145e210d7da0
+#: ../../source/development_guide/testing.rst:360
+msgid "Wrapping your head around the javascript within javascript:"
+msgstr ""
+
+# ed4f3f26b8dc4b3eaba4975661c195c3
+#: ../../source/development_guide/testing.rst:362
+msgid ""
+"CasperJS is a browser that's written in javascript, so we write "
+"javascript code to drive it. The Casper browser itself also has a "
+"javascript implementation (like the ones that come with Firefox and "
+"Chrome), and in the test suite we get access to those using "
+"``this.evaluate``, and it's cousins (``this.theEvaluate``, etc). "
+"Additionally, because of the asynchronous / callback nature of "
+"everything, there are plenty of ``this.then`` calls which define steps in"
+" test suite. Part of the reason for this is that each step has a timeout "
+"(default of 5 or 10 seconds). Additionally, there are already convenience"
+" functions in ``util.js`` to help you wait for output in a given cell, "
+"etc. In our javascript tests, if you see functions which "
+"``look_like_pep8_naming_convention``, those are probably coming from "
+"``util.js``, whereas functions that come with casper "
+"``haveCamelCaseNamingConvention``"
+msgstr ""
+
+# b834615955564a74a7c34b4071190cdc
+#: ../../source/development_guide/testing.rst:377
+msgid ""
+"Each file in ``test_cases`` looks something like this (this is "
+"``test_cases/check_interrupt.js``):"
+msgstr ""
+
+# 52615ee776ef4a71bf05c26f46670d28
+#: ../../source/development_guide/testing.rst:419
+msgid ""
+"For an example of how to pass parameters to the client-side javascript "
+"from casper test suite, see the ``casper.wait_for_output`` implementation"
+" in ``IPython/html/tests/casperjs/util.js``"
+msgstr ""
+
+# fae96465d4094630ac562426a0003dbc
+#: ../../source/development_guide/testing.rst:424
+msgid "Testing system design notes"
+msgstr ""
+
+# 58335def9eaa4f669f9521490ecbaa26
+#: ../../source/development_guide/testing.rst:426
+msgid ""
+"This section is a set of notes on the key points of the IPython testing "
+"needs, that were used when writing the system and should be kept for "
+"reference as it eveolves."
+msgstr ""
+
+# 4b0a9eccc5924a96aae6703bb568a450
+#: ../../source/development_guide/testing.rst:430
+msgid ""
+"Testing IPython in full requires modifications to the default behavior of"
+" nose and doctest, because the IPython prompt is not recognized to "
+"determine Python input, and because IPython admits user input that is not"
+" valid Python (things like ``%magics`` and ``!system commands``."
+msgstr ""
+
+# 800dc52e25ed4b7c91a299d5226f21ef
+#: ../../source/development_guide/testing.rst:435
+msgid "We basically need to be able to test the following types of code:"
+msgstr ""
+
+# b91ada24535c4452b163e02c66844461
+#: ../../source/development_guide/testing.rst:439
+msgid ""
+"Pure Python files containing normal tests. These are not a problem, since"
+" Nose will pick them up as long as they conform to the (flexible) "
+"conventions used by nose to recognize tests."
+msgstr ""
+
+# 62b8a60a8b14443ebfc3ca1dba0de170
+#: ../../source/development_guide/testing.rst:445
+msgid "Python files containing doctests. Here, we have two possibilities:"
+msgstr ""
+
+# 6324a400853c4860abf99f4cbd08a59c
+#: ../../source/development_guide/testing.rst:448
+msgid "The prompts are the usual ``>>>`` and the input is pure Python."
+msgstr ""
+
+# 65fa6dd816c24f4e9b84f6d0920c5756
+#: ../../source/development_guide/testing.rst:449
+msgid ""
+"The prompts are of the form ``In [1]:`` and the input can contain "
+"extended IPython expressions."
+msgstr ""
+
+# 9ad1cecfc10347bfac60314688c8dba6
+#: ../../source/development_guide/testing.rst:452
+msgid ""
+"In the first case, Nose will recognize the doctests as long as it is "
+"called with the ``--with-doctest`` flag. But the second case will likely "
+"require modifications or the writing of a new doctest plugin for Nose "
+"that is IPython-aware."
+msgstr ""
+
+# 200c3b0361b1483fabdf8735413bdd04
+#: ../../source/development_guide/testing.rst:459
+msgid ""
+"ReStructuredText files that contain code blocks. For this type of file, "
+"we have three distinct possibilities for the code blocks:"
+msgstr ""
+
+# 1886e7b95147471b9c70104d4bb51db6
+#: ../../source/development_guide/testing.rst:462
+msgid "They use ``>>>`` prompts."
+msgstr ""
+
+# 09bac740954c4fdca7173fafa7ff0716
+#: ../../source/development_guide/testing.rst:463
+msgid "They use ``In [1]:`` prompts."
+msgstr ""
+
+# 4b346c61197a47b2b1be0d95b8afa113
+#: ../../source/development_guide/testing.rst:464
+msgid "They are standalone blocks of pure Python code without any prompts."
+msgstr ""
+
+# 15b043cc6fa14b5687221a1c8176794e
+#: ../../source/development_guide/testing.rst:466
+msgid ""
+"The first two cases are similar to the situation #2 above, except that in"
+" this case the doctests must be extracted from input code blocks using "
+"docutils instead of from the Python docstrings."
+msgstr ""
+
+# 66f66893cec8416fbf35c58a4d7a6a28
+#: ../../source/development_guide/testing.rst:470
+msgid ""
+"In the third case, we must have a convention for distinguishing code "
+"blocks that are meant for execution from others that may be snippets of "
+"shell code or other examples not meant to be run. One possibility is to "
+"assume that all indented code blocks are meant for execution, but to have"
+" a special docutils directive for input that should not be executed."
+msgstr ""
+
+# 31b72bf0802e45aabd969ed1ee4de26f
+#: ../../source/development_guide/testing.rst:476
+msgid ""
+"For those code blocks that we will execute, the convention used will "
+"simply be that they get called and are considered successful if they run "
+"to completion without raising errors. This is similar to what Nose does "
+"for standalone test functions, and by putting asserts or other forms of "
+"exception-raising statements it becomes possible to have literate "
+"examples that double as lightweight tests."
+msgstr ""
+
+# 4656af2388f0464ba9945c046148ce4c
+#: ../../source/development_guide/testing.rst:485
+msgid ""
+"Extension modules with doctests in function and method docstrings. "
+"Currently Nose simply can't find these docstrings correctly, because the "
+"underlying doctest DocTestFinder object fails there. Similarly to #2 "
+"above, the docstrings could have either pure python or IPython prompts."
+msgstr ""
+
+# b81efc4dc4b94b3bbb7f5d2ec96ce033
+#: ../../source/development_guide/testing.rst:491
+msgid ""
+"Of these, only 3-c (reST with standalone code blocks) is not implemented "
+"at this point."
+msgstr ""
+
+# f838da91fa8045d89293ced7d8692fc2
+#: ../../source/development_guide/testing_kernels.rst:4
+msgid "Testing Kernels"
+msgstr ""
+
+# ac92e155007c43bc80418b77b9a0cf88
+#: ../../source/development_guide/testing_kernels.rst:9
+msgid ""
+"IPython makes it very easy to create wrapper kernels using its kernel "
+"framework. It requires extending the Kernel class and implementing a set "
+"of methods for the core functions like execute, history etc. Its also "
+"possible to write a full blown kernel in a language of your choice "
+"implementing listeners for all the zmq ports."
+msgstr ""
+
+# f736b303e5ac4f49bbc8a3f25e509692
+#: ../../source/development_guide/testing_kernels.rst:15
+msgid ""
+"The key problem for any kernel implemented by these methods is to ensure "
+"that it meets the message specification. The kerneltest command is a "
+"means to test the installed kernel against the message spec and validate "
+"the results."
+msgstr ""
+
+# 91370782e52f4012abf6b8acf0a5bc16
+#: ../../source/development_guide/testing_kernels.rst:21
+msgid "The kerneltest tool"
+msgstr ""
+
+# 0e98a93a5d064fdabde647dc8406ff87
+#: ../../source/development_guide/testing_kernels.rst:23
+msgid ""
+"The kerneltest tool is part of IPython.testing and is also included in "
+"the scripts similar to iptest. This takes 2 parameters - the name of the "
+"kernel to test and the test script file. The test script file should be "
+"in json format as described in the next section."
+msgstr ""
+
+# 3ce7cd1696494c4eae12a69ea3b741ee
+#: ../../source/development_guide/testing_kernels.rst:32
+msgid ""
+"You can also pass in an optional message spec version to the command. At "
+"the moment only the version 5 is supported, but as newer versions are "
+"released this can be used to test the kernel against a specific version "
+"of the kernel."
+msgstr ""
+
+# d2b4dcfce0e84905b4c9bfc15f589e93
+#: ../../source/development_guide/testing_kernels.rst:41
+msgid ""
+"The kernel to be tested needs to be installed and the kernelspec "
+"available in the user IPython directory. The tool will instantiate the "
+"kernel and send the commands over ZMQ. For each command executed on the "
+"kernel, the tool will validate the reply to ensure that it matches the "
+"message specification. In some cases the output is also checked, but the "
+"reply is always returned and printed out on the console. This can be used"
+" to validate that apart from meeting the message spec the kernel also "
+"produced the correct output."
+msgstr ""
+
+# 810f483237f74986bf01858b41067f9a
+#: ../../source/development_guide/testing_kernels.rst:51
+msgid "The test script file"
+msgstr ""
+
+# a645935aa17a44a3924eac56c4b49160
+#: ../../source/development_guide/testing_kernels.rst:53
+msgid ""
+"The test script file is a simple json file that specifies the command to "
+"execute and the test code to execute for the command."
+msgstr ""
+
+# 1d1a27261190419b852cc9ddc37c4615
+#: ../../source/development_guide/testing_kernels.rst:64
+msgid ""
+"For some commands in the message specification like kernel\\_info there "
+"is no need to specify the test\\_code parameter. The tool validates if it"
+" has all the inputs needed to execute the command and will print out an "
+"error to the console if it finds a missing parameter. Since the "
+"validation is built in, and only required parameters are passed, it is "
+"possible to add additional fields in the json file for test "
+"documentation."
+msgstr ""
+
+# ecab2837ce3b434db96892386181204c
+#: ../../source/development_guide/testing_kernels.rst:82
+msgid "A sample test script for the redis kernel will look like this"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/glossary.po
+++ b/docs/source/locale/en/LC_MESSAGES/glossary.po
@@ -1,0 +1,145 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 938cb2236c5e4a24a0d1cd9f80149b27
+#: ../../source/glossary.rst:5
+msgid "Glossary"
+msgstr ""
+
+# 9d41e58ffa16468b8e023a9712b29b3b
+#: ../../source/glossary.rst:8
+msgid "command line"
+msgstr ""
+
+# 5f6a8ec0ea1d4dad93821e3a29a9e5a5
+#: ../../source/glossary.rst:10
+msgid "The terminal or console window where you type commands."
+msgstr ""
+
+# a9505efde187467c88289d5b5c57bc92
+#: ../../source/glossary.rst:11
+msgid "Command Prompt"
+msgstr ""
+
+# fb1bf6539f8d4152a96bbfff01ede6bb
+#: ../../source/glossary.rst:13
+msgid ""
+"On Windows, this is the application where commands are typed into a "
+"window for execution."
+msgstr ""
+
+# a53402578c0c4ec4aef323352f576b9c
+#: ../../source/glossary.rst:15
+msgid "conda"
+msgstr ""
+
+# 48aea7fb60ea46b48b9d5cecc6b7c9f6
+#: ../../source/glossary.rst:17
+msgid "The package manager for Anaconda."
+msgstr ""
+
+# 9144299b6c03438697d2df100f252f0c
+#: ../../source/glossary.rst:18
+msgid "config"
+msgstr ""
+
+# af39f4ba81f8473f919ef55fefc8023c
+#: ../../source/glossary.rst:20
+msgid "Refers to the configuration files and process."
+msgstr ""
+
+# 7621f3badf974780adee77534f946e48
+#: ../../source/glossary.rst:21
+msgid "kernel"
+msgstr ""
+
+# ac15ce043620490d8fc7a9d46fc5d4ae
+#: ../../source/glossary.rst:23
+msgid ""
+"A kernel provides programming language support in Jupyter. IPython is the"
+" default kernel. Additional kernels include R, Julia, and many more."
+msgstr ""
+
+# 6c87a739094e41f5b1ab517a786e0376
+#: ../../source/glossary.rst:25
+msgid "Notebook Dashboard"
+msgstr ""
+
+# f5dc136dc22c4ea5bf8f382048d69acd
+#: ../../source/glossary.rst:27
+msgid ""
+"The notebook user interface which shows a list of the notebooks, files, "
+"and subdirectories in the directory where the notebook server is started."
+msgstr ""
+
+# 9d4b3fafd38844b3913fef20c976aea2
+#: ../../source/glossary.rst:30
+msgid "pip"
+msgstr ""
+
+# dde7ae79c1cd4295989a3d816c0d9106
+#: ../../source/glossary.rst:32
+msgid "Python package manager."
+msgstr ""
+
+# 025167dfb0b849158f1433aafcc4b7c3
+#: ../../source/glossary.rst:33
+msgid "profiles"
+msgstr ""
+
+# 4f1bce8c1652475c9e8c7313bdcc0155
+#: ../../source/glossary.rst:35
+msgid ""
+"Not available in Jupyter. In IPython 3, profiles are collections of "
+"configuration and runtime files."
+msgstr ""
+
+# 98ba4c37a4704f0a84921a8a7f14b8cb
+#: ../../source/glossary.rst:37
+msgid "REPL"
+msgstr ""
+
+# 1127a9c1dee04fc18f0af7e6d4087e5b
+#: ../../source/glossary.rst:39
+msgid "read-eval-print-loop."
+msgstr ""
+
+# dbf08896a556455faf46a74c9049cdc4
+#: ../../source/glossary.rst:40
+msgid "terminal"
+msgstr ""
+
+# fb3383cb17244feba592bcdc60f6bdeb
+#: ../../source/glossary.rst:42
+msgid "A window used to type in commands to be executed (Linux and OS X)."
+msgstr ""
+
+# ec11c3cf781043bcb094685869a6fd12
+#: ../../source/glossary.rst:43
+msgid "widget"
+msgstr ""
+
+# 204b394a671c4318ad854b78304049d8
+#: ../../source/glossary.rst:45
+msgid ""
+"A user interface component, similar to a plugin, that allows customized "
+"input, such as a slider."
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/install-kernel.po
+++ b/docs/source/locale/en/LC_MESSAGES/install-kernel.po
@@ -1,0 +1,108 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# efdc3f834e74419fa6a4b57c74ee4fcd
+#: ../../source/install-kernel.rst:3
+msgid "*Optional:* Installing Kernels"
+msgstr ""
+
+# a8453d1a49ac44b1a666c35084a9ae4d
+#: ../../source/install-kernel.rst:7
+msgid "Contents"
+msgstr ""
+
+# da930aecf67d4103b678a613f2b8f9ae
+#: ../../source/install-kernel.rst:9
+msgid ""
+"This information gives a high-level view of using Jupyter Notebook with "
+"different programming languages (kernels)."
+msgstr ""
+
+# 0b4e24aa51dd400782dfff162b605bb3
+#: ../../source/install-kernel.rst:13
+msgid "Are any languages pre-installed?"
+msgstr ""
+
+# ea86f10aa988483fbc44ed6fc2ed5c1c
+#: ../../source/install-kernel.rst:15
+msgid ""
+"Yes, installing the Jupyter Notebook will also install the `IPython "
+"<https://ipython.readthedocs.io/en/latest/>`_ :term:`kernel`. This allows"
+" working on notebooks using the Python programming language."
+msgstr ""
+
+# 94ea0ff4960049e8bffc34755b0c57d0
+#: ../../source/install-kernel.rst:20
+msgid "How do I install Python 2 and Python 3?"
+msgstr ""
+
+# 9e28ab95796d4facb934d8a06dbaf56c
+#: ../../source/install-kernel.rst:22
+msgid ""
+"To install an additional version of Python, i.e. to have both Python 2 "
+"and 3 available, see the IPython docs on `installing kernels "
+"<https://ipython.readthedocs.io/en/latest/install/kernel_install.html>`_."
+msgstr ""
+
+# fc0d1726d8ff4504922a6164a4841b27
+#: ../../source/install-kernel.rst:27
+msgid "How do I install other languages like R or Julia?"
+msgstr ""
+
+# 3eff7ec0dacb45dc9198c7dc21af8e4e
+#: ../../source/install-kernel.rst:29
+msgid ""
+"To run notebooks in languages other than Python, such as R or Julia, you "
+"will need to install additional kernels. For more information, see the "
+"full `list of available kernels`_."
+msgstr ""
+
+# a15c5c1d7def408f8bf85bb8b39608f6
+#: ../../source/install-kernel.rst:37
+msgid ":ref:`Jupyter Projects <subprojects>`"
+msgstr ""
+
+# 8a2af66f6aa14ac2ae3d77f3214ed281
+#: ../../source/install-kernel.rst:36
+msgid ""
+"Detailed installation instructions for individual Jupyter or IPython "
+"projects."
+msgstr ""
+
+# ea589c0dbe5d4f7a8f61edf4c78fa86b
+#: ../../source/install-kernel.rst:40
+msgid ":ref:`Kernels <kernels-langs>`"
+msgstr ""
+
+# 0bd2cf28af6e4107a801fb8e3d0e0ac3
+#: ../../source/install-kernel.rst:40
+msgid "Information about additional programming language kernels."
+msgstr ""
+
+# 8ce58b34c6cb4505ae83e5359e506a04
+#: ../../source/install-kernel.rst:42
+msgid ":ref:`Kernels documentation for Jupyter client <kernels>`"
+msgstr ""
+
+# 9d06f59e323b40d497adf08f5a3c677f
+#: ../../source/install-kernel.rst:43
+msgid "Technical information about kernels."
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/install.po
+++ b/docs/source/locale/en/LC_MESSAGES/install.po
@@ -1,0 +1,145 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# ffbb37b4a6064c4293bd70b5fddb96e4
+#: ../../source/install.rst:5
+msgid "Installing Jupyter Notebook"
+msgstr ""
+
+# 7ab1cb39403041899fd89e70ec072c36
+#: ../../source/install.rst:9
+msgid "Contents"
+msgstr ""
+
+# 24944b561f924ddd911096f48f136f64
+#: ../../source/install.rst:11
+msgid ""
+"This information explains how to install the Jupyter Notebook and the "
+"IPython kernel."
+msgstr ""
+
+# 9adca524080f4c91b4eb73369181cac7
+#: ../../source/install.rst:15
+msgid "Prerequisite: Python"
+msgstr ""
+
+# d169910c38f948b7ac2952e799e585d5
+#: ../../source/install.rst:17
+msgid ""
+"While Jupyter runs code in many programming languages, **Python** is a "
+"requirement (Python 3.3 or greater, or Python 2.7) for installing the "
+"Jupyter Notebook."
+msgstr ""
+
+# 085979bf68e84b0e9b15d137d1234a8b
+#: ../../source/install.rst:21
+msgid ""
+"We recommend using the `Anaconda <https://www.anaconda.com/download>`_ "
+"distribution to install Python and Jupyter. We'll go through its "
+"installation in the next section."
+msgstr ""
+
+# 16c5366b626b4d39b19b501cccb27142
+#: ../../source/install.rst:28
+msgid "Installing Jupyter using Anaconda and conda"
+msgstr ""
+
+# 767eb05028794e92bc704d599083862d
+#: ../../source/install.rst:30
+msgid ""
+"For new users, we **highly recommend** `installing Anaconda "
+"<https://www.anaconda.com/download>`_. Anaconda conveniently installs "
+"Python, the Jupyter Notebook, and other commonly used packages for "
+"scientific computing and data science."
+msgstr ""
+
+# 05c5808a5e0148158765958378b90b6f
+#: ../../source/install.rst:35
+msgid "Use the following installation steps:"
+msgstr ""
+
+# 54686805017a467b9a216e0a7704ce74
+#: ../../source/install.rst:37
+msgid ""
+"Download `Anaconda <https://www.anaconda.com/download>`_. We recommend "
+"downloading Anaconda's latest Python 3 version (currently Python 3.5)."
+msgstr ""
+
+# 4a21fbaf720541fda995cb60551befb4
+#: ../../source/install.rst:40
+msgid ""
+"Install the version of Anaconda which you downloaded, following the "
+"instructions on the download page."
+msgstr ""
+
+# d5a47880420642eaba90590b54097b26
+#: ../../source/install.rst:43
+msgid "Congratulations, you have installed Jupyter Notebook. To run the notebook:"
+msgstr ""
+
+# 6227c09c5e6b4a59be669bfb1c4c2fdc
+#: ../../source/install.rst:49
+msgid "See :ref:`Running the Notebook <running>` for more details."
+msgstr ""
+
+# a57622d290e3435084627a34b100ce79
+#: ../../source/install.rst:54
+msgid "*Alternative for experienced Python users:* Installing Jupyter with pip"
+msgstr ""
+
+# 4ff159ed555344a5b35b67086a401fda
+#: ../../source/install.rst:58
+msgid ""
+"Jupyter installation requires Python 3.3 or greater, or Python 2.7. "
+"IPython 1.x, which included the parts that later became Jupyter, was the "
+"last version to support Python 3.2 and 2.6."
+msgstr ""
+
+# dbff8577777040db8c06790617420c29
+#: ../../source/install.rst:62
+msgid ""
+"As an existing Python user, you may wish to install Jupyter using "
+"Python's package manager, :term:`pip`, instead of Anaconda."
+msgstr ""
+
+# ef9257faebfd4ba4bbf41fda5f195413
+#: ../../source/install.rst:67
+msgid ""
+"First, ensure that you have the latest pip; older versions may have "
+"trouble with some dependencies:"
+msgstr ""
+
+# bc2ec7faaa854a36bd339cbebc78741c
+#: ../../source/install.rst:74
+msgid "Then install the Jupyter Notebook using:"
+msgstr ""
+
+# cc79a3bf6e1a46b4bb1ab37da05e643d
+#: ../../source/install.rst:80
+msgid "(Use ``pip`` if using legacy Python 2.)"
+msgstr ""
+
+# bedb9ecab9554259ae2a7d28ea48e972
+#: ../../source/install.rst:82
+msgid ""
+"Congratulations. You have installed Jupyter Notebook. See :ref:`Running "
+"the Notebook <running>` for more details."
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/ipython.po
+++ b/docs/source/locale/en/LC_MESSAGES/ipython.po
@@ -1,0 +1,87 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# e06aa197a71b41eeaf94dfe9f0caaca2
+#: ../../source/ipython/content-ipython.rst:2
+msgid "IPython"
+msgstr ""
+
+# 93415afba3654a1c904000d9a30c7b04
+#: ../../source/ipython/content-ipython.rst:5
+msgid "Contents"
+msgstr ""
+
+# 0fb8abaae6d6439eb2d541d1cc83182b
+#: ../../source/ipython/content-ipython.rst:13
+msgid "Description"
+msgstr ""
+
+# 0ffa752b43e04a8f84cf0772fdeeda3b
+#: ../../source/ipython/content-ipython.rst:15
+msgid "IPython provides a rich architecture for interactive computing with:"
+msgstr ""
+
+# c81ecc03613b4623a05ae0b069bfc6a8
+#: ../../source/ipython/content-ipython.rst:17
+msgid "A powerful interactive shell."
+msgstr ""
+
+# cfe69331de214e0f9492f7cdde2deeff
+#: ../../source/ipython/content-ipython.rst:18
+msgid "A kernel for Jupyter."
+msgstr ""
+
+# 405d110fdb06459f97fd470b08f9b45a
+#: ../../source/ipython/content-ipython.rst:19
+msgid "Support for interactive data visualization and use of GUI toolkits."
+msgstr ""
+
+# 198111746308470bb460f4eff0187c9c
+#: ../../source/ipython/content-ipython.rst:20
+msgid "Flexible, embeddable interpreters to load into your own projects."
+msgstr ""
+
+# cc784dedd7924d66b116dc0cee97b0ca
+#: ../../source/ipython/content-ipython.rst:21
+msgid "Easy to use, high performance tools for parallel computing."
+msgstr ""
+
+# 2807f7be8ea5430caabaadf467ac3d28
+#: ../../source/ipython/content-ipython.rst:24
+msgid "Background"
+msgstr ""
+
+# 3735a8ce15d6486f90b2e6150041cf39
+#: ../../source/ipython/content-ipython.rst:26
+msgid ""
+"IPython is a growing project, with increasingly language-agnostic "
+"components. IPython 3.x was the last monolithic release of IPython, "
+"containing the notebook server, qtconsole, etc. As of IPython 4.0, the "
+"language-agnostic parts of the project: the notebook format, message "
+"protocol, qtconsole, notebook web application, etc. have moved to new "
+"projects under the name Jupyter. IPython itself is focused on interactive"
+" Python, part of which is providing a Python kernel for Jupyter."
+msgstr ""
+
+# a902c3e9aab34a9bb26248bf4ebffc1b
+#: ../../source/ipython/content-ipython.rst:35
+msgid "Resources"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/migrating.po
+++ b/docs/source/locale/en/LC_MESSAGES/migrating.po
@@ -1,0 +1,562 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 8f5cd3c486474d4b8a13ff41c24e3e75
+#: ../../source/migrating.rst:5
+msgid "Migrating from IPython Notebook"
+msgstr ""
+
+# a0bf9b469b3d41b486c705edbe1a32d3
+#: ../../source/migrating.rst:8
+msgid "Contents"
+msgstr ""
+
+# 661d74638f8e402c8844e1dae8178361
+#: ../../source/migrating.rst:11
+msgid "Abstract"
+msgstr ""
+
+# 7b16ca89f25647868cf204d88a1e4d29
+#: ../../source/migrating.rst:13
+msgid ""
+"`The Big Split <https://blog.jupyter.org/the-big-split-9d7b88a031a7>`__ "
+"moved IPython's various language-agnostic components under the Jupyter "
+"umbrella. Going forward, Jupyter will contain the language-agnostic "
+"projects that serve many languages. IPython will continue to focus on "
+"Python and its use with Jupyter."
+msgstr ""
+
+# 06bf34e702fa456e9ce4f7b616eb546e
+#: ../../source/migrating.rst:19
+msgid ""
+"This document describes what has changed, and how you may need to modify "
+"your code or configuration when migrating from IPython version 3 to "
+"Jupyter."
+msgstr ""
+
+# 3b23232adf694c6cb4998078211d9109
+#: ../../source/migrating.rst:24
+msgid "Understanding the Migration Process"
+msgstr ""
+
+# aa9fcadf57d549aa8a6d3f4126d60ca4
+#: ../../source/migrating.rst:27
+msgid "Automatic migration of files"
+msgstr ""
+
+# f5ec35e6c2494acbac3e543734ba12f2
+#: ../../source/migrating.rst:29
+msgid ""
+"The first time you run any ``jupyter`` command, it will perform an "
+"automatic migration of files. The automatic migration process **copies** "
+"files, instead of moving files, leaving the originals in place and the "
+"copies in the Jupyter file locations. You can re-run the migration, if "
+"needed, by calling ``jupyter migrate``. Your custom configuration will be"
+" migrated automatically and should work with Jupyter without further "
+"editing. When you update or modify your configuration in the future, "
+"please keep in mind that the file locations may have changed."
+msgstr ""
+
+# 2284d903d20c49b7acf289fede63d7e7
+#: ../../source/migrating.rst:39
+msgid "Where have my configuration files gone?"
+msgstr ""
+
+# 14350789ee634cb3a07a1f7564d87294
+#: ../../source/migrating.rst:41
+msgid "Also known as: \"Why isn't my configuration having any effect anymore?\""
+msgstr ""
+
+# 07d5f3408f704edfb54df3fd57924e6e
+#: ../../source/migrating.rst:43
+msgid ""
+"Jupyter splitting out from IPython means that the locations of some files"
+" have moved, and Jupyter projects have not inherited everything from how "
+"IPython did it."
+msgstr ""
+
+# cec706b3328f4024bf9b8cac2bd78686
+#: ../../source/migrating.rst:47
+msgid ""
+"When you start your first Jupyter application, the relevant configuration"
+" files are automatically copied to their new Jupyter locations. The "
+"original configuration files in the IPython locations have no effect on "
+"Jupyter's execution. If you accidentally edit your original IPython "
+"config file, you may not see the desired effect with Jupyter now. You "
+"should check that you are editing Jupyter's configuration file, and you "
+"should see the expected effect after restarting the Jupyter server."
+msgstr ""
+
+# 35761bdec57845c5956afcbd2518fcb2
+#: ../../source/migrating.rst:56
+msgid "Finding the Location of Important Files"
+msgstr ""
+
+# 0e91703834714ff8a450c3e1f4e19183
+#: ../../source/migrating.rst:58
+msgid ""
+"This section provides quick reference for common locations of IPython 3 "
+"files and the migrated Jupyter files."
+msgstr ""
+
+# b3066e3c9a824483918e9feabfddd439
+#: ../../source/migrating.rst:62
+msgid "Configuration files"
+msgstr ""
+
+# d1be8dd7d028443bab89581071668b40
+#: ../../source/migrating.rst:64
+msgid ""
+"Configuration files customize Jupyter to the user's preferences. The "
+"migrated files should all be **automatically copied** to their new "
+"Jupyter locations. Here are the location changes:"
+msgstr ""
+
+# e5dc4b2fb1b2448a9fa739dddd5fdfdc
+#: ../../source/migrating.rst:69
+msgid "IPython location"
+msgstr ""
+
+# 716d92fb1fa94db28397bdfddd9c29f0
+#: ../../source/migrating.rst:69
+msgid "Jupyter location"
+msgstr ""
+
+# 9678737a7e6342c7bb833a2c8242b625
+#: ../../source/migrating.rst:71
+msgid ":file:`~/.ipython/profile_default/static/custom`"
+msgstr ""
+
+# 1008e78186164ff2adcc4c0a92dae223
+# 72fe30c2d0404ee59bde125a2de1e38f
+# d91efb208eae4ad7b4965599aa9fb65e
+# a7a49c506f0e42f19e6f5d03cdbc5096
+# af9332d2f5a34982a36a9bb2cdcd0473
+# e8415a6ea7a14ab9bdc8dd7fbab6d67d
+# 9e046db52de3436fa30a19e5d1d9b045
+# e853fee326ff469da5a56f61d7a961a8
+# 56b6aa8cb49b41c19612910e3afb2563
+# c1d9598dce504f2380373045dfdc7625
+# 128040d623434edb9bbeda55c9507f00
+# 1fe82a47a7eb4b06a73d941d6d5ee283
+#: ../../source/migrating.rst:71 ../../source/migrating.rst:72
+#: ../../source/migrating.rst:73 ../../source/migrating.rst:74
+#: ../../source/migrating.rst:75 ../../source/migrating.rst:241
+#: ../../source/migrating.rst:242 ../../source/migrating.rst:243
+#: ../../source/migrating.rst:244 ../../source/migrating.rst:245
+#: ../../source/migrating.rst:246 ../../source/migrating.rst:247
+msgid "→"
+msgstr ""
+
+# 3305847c2b3c4dd597ec3b649ca0feb4
+#: ../../source/migrating.rst:71
+msgid ":file:`~/.jupyter/custom`"
+msgstr ""
+
+# 8a5dbaf9bbb24302b7f8c44d5c70d748
+#: ../../source/migrating.rst:72
+msgid ":file:`~/.ipython/profile_default/ipython_notebook_config.py`"
+msgstr ""
+
+# 44d5bf8302184c91ab5ea2642ff4b0af
+#: ../../source/migrating.rst:72
+msgid ":file:`~/.jupyter/jupyter_notebook_config.py`"
+msgstr ""
+
+# f17f8f9f52884c2bbc2fce452120161a
+#: ../../source/migrating.rst:73
+msgid ":file:`~/.ipython/profile_default/ipython_nbconvert_config.py`"
+msgstr ""
+
+# 6e8948fba80a4d329cf88b88e14f34a3
+#: ../../source/migrating.rst:73
+msgid ":file:`~/.jupyter/jupyter_nbconvert_config.py`"
+msgstr ""
+
+# 3e89a17fc5b24bdb8db5e054e654b496
+#: ../../source/migrating.rst:74
+msgid ":file:`~/.ipython/profile_default/ipython_qtconsole_config.py`"
+msgstr ""
+
+# 272ac1f228084a03ac2d2114a6412072
+#: ../../source/migrating.rst:74
+msgid ":file:`~/.jupyter/jupyter_qtconsole_config.py`"
+msgstr ""
+
+# 2e3a6302c7924ba29ba73e7c4a68be2f
+#: ../../source/migrating.rst:75
+msgid ":file:`~/.ipython/profile_default/ipython_console_config.py`"
+msgstr ""
+
+# 2ecee964e7b24a10bef99b7524da7344
+#: ../../source/migrating.rst:75
+msgid ":file:`~/.jupyter/jupyter_console_config.py`"
+msgstr ""
+
+# 4d628b8f2fd64ed883e979d8ba54112c
+#: ../../source/migrating.rst:78
+msgid ""
+"To choose a directory location other than the default :file:`~/.jupyter`,"
+" set the ``JUPYTER_CONFIG_DIR`` environment variable. You may need to run"
+" ``jupyter migrate`` after setting the environment variable for files to "
+"be copied to the desired directory."
+msgstr ""
+
+# 6441364aeb0d4174b78105a74f688c16
+#: ../../source/migrating.rst:84
+msgid "Data files: kernelspecs and notebook extensions"
+msgstr ""
+
+# e2924a8235fd431b9f9fd56ae0f39d23
+#: ../../source/migrating.rst:86
+msgid ""
+"Data files include files, other than configuration files, which are user "
+"installed. Examples include kernelspecs and notebook extensions. Like the"
+" configuration files, data files are also **automatically migrated** to "
+"their new Jupyter locations."
+msgstr ""
+
+# ec6e2b0e388b4bafbefdc42d92b69ab1
+#: ../../source/migrating.rst:91
+msgid "In **IPython 3**, data files lived in ``~/.ipython``."
+msgstr ""
+
+# db9667c61df04f03b389007dde80592b
+#: ../../source/migrating.rst:93
+msgid "In **Jupyter**, data files use platform-appropriate locations:"
+msgstr ""
+
+# 6ec16f9359924bcaad831b990915ac81
+#: ../../source/migrating.rst:95
+msgid "OS X: ``~/Library/Jupyter``"
+msgstr ""
+
+# 06b69be6aab34415a18b114a688ef046
+#: ../../source/migrating.rst:96
+msgid "Windows: the location specified in ``%APPDATA%`` environment variable"
+msgstr ""
+
+# b8aa64d12c084a09a9caf7f0997b9694
+#: ../../source/migrating.rst:97
+msgid ""
+"Elsewhere, ``$XDG_DATA_HOME`` is respected, with the default of "
+"``~/.local/share/jupyter``"
+msgstr ""
+
+# bcf6cf06fa7849d5adb27a36bb68475a
+#: ../../source/migrating.rst:100
+msgid ""
+"In all cases, the ``JUPYTER_DATA_DIR`` environment variable can be used "
+"to set a location explicitly."
+msgstr ""
+
+# 5ff8200b58f0422aab90ae5013d1bc60
+#: ../../source/migrating.rst:103
+msgid ""
+"Data files installed system-wide (e.g. in ``/usr/local/share/jupyter``) "
+"have not changed. Per-user installation of data files has changed "
+"location from ``.ipython`` to the platform-appropriate Jupyter location."
+msgstr ""
+
+# 8fc50bfd17e74c08aaee715d4df0aa28
+#: ../../source/migrating.rst:108
+msgid "Since Jupyter does not have profiles, how do I customize it?"
+msgstr ""
+
+# f21e1f21ab634dfeae67d57a810af7e8
+#: ../../source/migrating.rst:110
+msgid ""
+"While IPython has the concept of :term:`profiles`, **Jupyter does not "
+"have profiles**."
+msgstr ""
+
+# fbab5d83e70641b58ba8d8c25a1b5505
+#: ../../source/migrating.rst:113
+msgid ""
+"In IPython, profiles are collections of configuration and runtime files. "
+"Inside the IPython directory (``~/.ipython``), there are directories with"
+" names like ``profile_default`` or ``profile_demo``. In each of these are"
+" configuration files (``ipython_config.py``, "
+"``ipython_notebook_config.py``) and runtime files (``history.sqlite``, "
+"``security/kernel-*.json``). Profiles could be used to switch between "
+"configurations of IPython."
+msgstr ""
+
+# df3baa2e23de4665a1ba0a95d9bd1d53
+#: ../../source/migrating.rst:120
+msgid ""
+"Previously, people could use commands like ``ipython notebook --profile "
+"demo`` to set the profile for *both* the notebook server and the IPython "
+"kernel. This is no longer possible in one go with Jupyter, just like it "
+"wasn't possible in IPython 3 for any other kernels."
+msgstr ""
+
+# 900e8e17d08548eabeaa79549d4aa98b
+#: ../../source/migrating.rst:126
+msgid "Changing the Jupyter notebook configuration directory"
+msgstr ""
+
+# 6e7aba03567842fdb5bcd279d8cf35dd
+#: ../../source/migrating.rst:128
+msgid ""
+"If you want to change the notebook configuration, you can set the "
+"``JUPYTER_CONFIG_DIR``:"
+msgstr ""
+
+# b29b24c9af764ad4a280ddc011a49965
+#: ../../source/migrating.rst:137
+msgid "Changing the Jupyter notebook configuration file"
+msgstr ""
+
+# a7614ee085ba47d488cafe7699656792
+#: ../../source/migrating.rst:139
+msgid "If you just want to change the config file, you can do:"
+msgstr ""
+
+# a6aac6dd2d4943659e18520f5d392cf9
+#: ../../source/migrating.rst:146
+msgid "Changing IPython's profile using custom kernelspecs"
+msgstr ""
+
+# 9563bde765c14e3690a51f73d7c92cf7
+#: ../../source/migrating.rst:148
+msgid ""
+"If you do want to change the IPython kernel's profile, you can't do this "
+"at the server command-line anymore. Kernel arguments must be changed by "
+"modifying the kernelspec. You can do this without relaunching the server."
+" Kernelspec changes take effect every time you start a new kernel. "
+"However, there isn't a great way to modify the kernelspecs. One approach "
+"uses ``jupyter kernelspec list`` to find the ``kernel.json`` file and "
+"then modifies it, e.g. ``kernels/python3/kernel.json``, by hand. "
+"Alternatively, `a2km <https://github.com/minrk/a2km>`__ is an "
+"experimental project that tries to make these things easier."
+msgstr ""
+
+# 45d3b19664bd49fea20a62ec0e77c3ad
+#: ../../source/migrating.rst:158
+msgid ""
+"For example, add the ``--profile`` option to a custom kernelspec under "
+"``kernels/mycustom/kernel.json`` (see the Jupyter kernelspec directions "
+"`here <https://jupyter-client.readthedocs.io/en/latest/kernels.html"
+"#kernel-specs>`__):"
+msgstr ""
+
+# 2a98d819b7e04e5bbfc60ef439b635e2
+#: ../../source/migrating.rst:172
+msgid ""
+"You can then run Jupyter with the ``--kernel=mycustom`` command-line "
+"option and IPython will find the appropriate profile."
+msgstr ""
+
+# df14211cf90e4c57a5fa18626c872c72
+#: ../../source/migrating.rst:176
+msgid "Understanding Installation Changes"
+msgstr ""
+
+# b8d826a3ba3345abbedf16171c095d5c
+#: ../../source/migrating.rst:178
+msgid ""
+"See the :ref:`install` page for more information about installing "
+"Jupyter. Jupyter automatically migrates some things, like Notebook "
+"extensions and kernels."
+msgstr ""
+
+# fa33a2f4f8f94829a7c473d7071b0f43
+#: ../../source/migrating.rst:183
+msgid "Notebook extensions"
+msgstr ""
+
+# 51d5f0d804f442a9a97c7655e580e79b
+#: ../../source/migrating.rst:185
+msgid ""
+"Any IPython notebook extensions should be **automatically migrated** as "
+"part of the data files migration."
+msgstr ""
+
+# 5fd92d1027fb4b85ae426a42c82fe947
+#: ../../source/migrating.rst:188
+msgid "Notebook extensions were installed with:"
+msgstr ""
+
+# 91ab0eeefe084c70a44650fbd51644b7
+#: ../../source/migrating.rst:194
+msgid "Now, extensions are installed with:"
+msgstr ""
+
+# 5b197ef97efc43b5bbd741f814a6ee64
+#: ../../source/migrating.rst:200
+msgid ""
+"The notebook extensions will be installed in a system-wide location (e.g."
+" ``/usr/local/share/jupyter/nbextensions``). If doing a ``--user`` "
+"install, the notebook extensions will go in the ``JUPYTER_DATA_DIR`` "
+"location. Installation **SHOULD NOT** be done manually by guessing where "
+"the files should go."
+msgstr ""
+
+# 8f205aaaf5ee46de8e9d0522c240dc83
+#: ../../source/migrating.rst:207
+msgid "Kernels"
+msgstr ""
+
+# 6835584aca814c54909e4f5519afbf77
+#: ../../source/migrating.rst:209
+msgid ""
+"Kernels are installed in much the same way as notebook extensions. They "
+"will also be **automatically migrated**."
+msgstr ""
+
+# 221543b8255b44c6a970364430b396b9
+#: ../../source/migrating.rst:212
+msgid "Kernel specs used to be installed with:"
+msgstr ""
+
+# 7c691c23e0594313a3eade3815aa8c3f
+#: ../../source/migrating.rst:218
+msgid "They are now installed with:"
+msgstr ""
+
+# 7300ff40baec4daa85964d98a508f28c
+#: ../../source/migrating.rst:224
+msgid ""
+"By default, kernel specs will go in a system-wide location (e.g. "
+"``/usr/local/share/jupyter/kernels``). If doing a ``--user`` install, the"
+" kernel specs will go in the ``JUPYTER_DATA_DIR`` location. Installation "
+"**SHOULD NOT** be done manually by guessing where the files should go."
+msgstr ""
+
+# 7347a7230ab645599d5be543b3b019d0
+#: ../../source/migrating.rst:230
+msgid "Understanding Changes in imports"
+msgstr ""
+
+# e84b04296df74f698d561ee40d3355cc
+#: ../../source/migrating.rst:232
+msgid ""
+"IPython 4.0 includes shims to manage dependencies; so, all imports that "
+"work on IPython 3 should continue to work on IPython 4. If you find any "
+"differences, please `let us know "
+"<https://github.com/ipython/ipython/issues>`__."
+msgstr ""
+
+# 56813b80163249d3b2a3e603b904015d
+#: ../../source/migrating.rst:236
+msgid "Some changes include:"
+msgstr ""
+
+# 4f027d18d7bd44c7a354068d322e7b32
+#: ../../source/migrating.rst:239
+msgid "IPython 3"
+msgstr ""
+
+# 126977d37c5a49c09790822aabadb9fe
+#: ../../source/migrating.rst:239
+msgid "Jupyter and IPython 4.0"
+msgstr ""
+
+# 4243295b32bd48229e2f24ac3feb22c2
+#: ../../source/migrating.rst:241
+msgid "``IPython.html``"
+msgstr ""
+
+# 07dcd5f404274ab0b1593a89a10eda12
+#: ../../source/migrating.rst:241
+msgid "``notebook``"
+msgstr ""
+
+# eb1f964c367445f19d1aebc8b52fa46a
+#: ../../source/migrating.rst:242
+msgid "``IPython.html.widgets``"
+msgstr ""
+
+# 75653597f60c4e2facecc6342d4ee141
+#: ../../source/migrating.rst:242
+msgid "``ipywidgets``"
+msgstr ""
+
+# 2e80aada7b9b4fbfbd8bc21f683b5a33
+#: ../../source/migrating.rst:243
+msgid "``IPython.kernel``"
+msgstr ""
+
+# ee6c0d3100a0430887bc2ec59c836066
+#: ../../source/migrating.rst:243
+msgid "``jupyter_client``, ``ipykernel``"
+msgstr ""
+
+# 6ef0dd165dd9439b869e08965c69222a
+#: ../../source/migrating.rst:244
+msgid "``IPython.parallel``"
+msgstr ""
+
+# 282f79d57dc84378a575ad9037ceda9f
+#: ../../source/migrating.rst:244
+msgid "``ipyparallel``"
+msgstr ""
+
+# 0d2d805e0ebc4d1ca6e714416e5ba544
+#: ../../source/migrating.rst:245
+msgid "``IPython.qt.console``"
+msgstr ""
+
+# 3d9ae3c27ca949228f137c7099ff4dac
+#: ../../source/migrating.rst:245
+msgid "``qtconsole``"
+msgstr ""
+
+# d7fbddb811bc4e4ba54deb111b3f0a87
+#: ../../source/migrating.rst:246
+msgid "``IPython.utils.traitlets``"
+msgstr ""
+
+# e051da2ba487485eb14be36b1cbc0c02
+#: ../../source/migrating.rst:246
+msgid "``traitlets``"
+msgstr ""
+
+# 417499484a6241a5ba01fa609cf782f2
+#: ../../source/migrating.rst:247
+msgid "``IPython.config``"
+msgstr ""
+
+# 5686f8ec952f403bb20dad55c84bd2e7
+#: ../../source/migrating.rst:247
+msgid "``traitlets.config``"
+msgstr ""
+
+# 1069489e11e54f5683906ef69dd939f4
+#: ../../source/migrating.rst:252
+msgid "The ``IPython.kernel`` Split"
+msgstr ""
+
+# b3e32d27b5ec43d8b46b37ab774c3713
+#: ../../source/migrating.rst:254
+msgid "``IPython.kernel`` became two packages:"
+msgstr ""
+
+# 37e65f7a48a049849c032d103355c88c
+#: ../../source/migrating.rst:256
+msgid "``jupyter_client`` for the Jupyter client-side APIs."
+msgstr ""
+
+# daef865437274272bfbf0f835bab4a68
+#: ../../source/migrating.rst:257
+msgid "``ipykernel`` for Jupyter's IPython kernel"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/projects.po
+++ b/docs/source/locale/en/LC_MESSAGES/projects.po
@@ -1,0 +1,1285 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 92339a9a41b542e298b60cdb6f6cbf61
+#: ../../source/projects/config.rst:4
+msgid "Jupyter's Common Configuration Approach"
+msgstr ""
+
+# 90da53f4dfa74557a08b864016016453
+# e79e0aed79164105ba0c59db1e7cc25f
+# f3a563b080c148449967e4dfb0c0c397
+# 4670de024ca342e0ae42d85db75b0b47
+# d8a293acd5814a1d8797cdf904961a54
+# bb604039b6df48aeb10f4bfd47611399
+# 79fb4da0ecf7403f8bdf26c7e5200dea
+#: ../../source/projects/config.rst:7
+#: ../../source/projects/doc-proj-categories.rst:6
+#: ../../source/projects/incubator.rst:5
+#: ../../source/projects/ipython_projects.rst:5
+#: ../../source/projects/jupyter-directories.rst:7
+#: ../../source/projects/subprojects.rst:8
+#: ../../source/projects/upgrade-notebook.rst:5
+msgid "Contents"
+msgstr ""
+
+# 50ef143cd1864073a32ebb2bebdb1498
+# 4e98dda3ce1c4ddb8e35780e8e7651a6
+#: ../../source/projects/config.rst:10
+#: ../../source/projects/jupyter-directories.rst:100
+msgid "Summary"
+msgstr ""
+
+# 67c9b078874340d2a7434509d80b1dcb
+#: ../../source/projects/config.rst:12
+msgid ""
+"**Common Jupyter configuration system** The Jupyter applications have a "
+"common config system, and a common :ref:`config directory <config_dir>`. "
+"By default, this directory is :file:`~/.jupyter`."
+msgstr ""
+
+# 631c35d8d9ea49129b1a252a853e4683
+#: ../../source/projects/config.rst:17
+msgid ""
+"**Kernel configuration directories** If kernels use config files, these "
+"will normally be organised in separate directories for each kernel. For "
+"instance, the IPython kernel looks for files in the :ref:`IPython "
+"directory <ipythondir>` instead of the default Jupyter directory "
+":file:`~/.jupyter`."
+msgstr ""
+
+# c275e83d19c14b30a5fed2db4d317a77
+#: ../../source/projects/config.rst:24
+msgid "The Python config file"
+msgstr ""
+
+# 883c3694cddb4a79b753d056967b392f
+#: ../../source/projects/config.rst:26
+msgid "To create a default config file, run:"
+msgstr ""
+
+# 249e9606296f42fd9d3d746ce2e2e818
+#: ../../source/projects/config.rst:32
+msgid "The generated file will be named :file:`jupyter_{application}_config.py`."
+msgstr ""
+
+# 5885d077ef0c4a399da2fd455a465fca
+#: ../../source/projects/config.rst:34
+msgid ""
+"By editing the :file:`jupyter_{application}_config.py` file, you can "
+"configure class attributes like this::"
+msgstr ""
+
+# 5b49864fb34346d38f53ab5c5cc396dc
+#: ../../source/projects/config.rst:39
+msgid ""
+"Be careful with spelling. Incorrect names will simply be ignored, with no"
+" error message."
+msgstr ""
+
+# ab038bbb09b648e59a1f74f6d2a58d7a
+#: ../../source/projects/config.rst:42
+msgid ""
+"To add to a collection which may have already been defined elsewhere, you"
+" can use methods like those found on lists, dicts and sets: ``append``, "
+"``extend``, :meth:`~traitlets.config.LazyConfigValue.prepend` (like "
+"extend, but at the front), ``add``, and ``update`` (which works both for "
+"dicts and sets)::"
+msgstr ""
+
+# ee2b6c90ccd04fe4b948fcc54a29816f
+#: ../../source/projects/config.rst:52
+msgid "Command line options for configuration"
+msgstr ""
+
+# e9fa04aaf42e49cbb4d8262ce23da43d
+#: ../../source/projects/config.rst:54
+msgid ""
+"Every configurable value can also be set from the command line and passed"
+" as an argument, using this syntax:"
+msgstr ""
+
+# 4ab9825a5d064abb8181c8eecc58c8aa
+#: ../../source/projects/config.rst:61
+msgid ""
+"Frequently used options will also have short aliases and flags, such as "
+"``--port 8754`` or ``--no-browser``."
+msgstr ""
+
+# b4439d388ac44302a41c3f75677822ef
+#: ../../source/projects/config.rst:64
+msgid ""
+"To see the abbreviated options, pass ``--help`` or ``--help-all`` as "
+"follows:"
+msgstr ""
+
+# 2029a2c8cf304fc1a83b1903b362fe7e
+#: ../../source/projects/config.rst:72
+msgid ""
+"Command line options **will override** options set within a configuration"
+" file."
+msgstr ""
+
+# 36415b5e588946969565a4a22179fb99
+#: ../../source/projects/config.rst:77
+msgid ":mod:`traitlets:traitlets.config`"
+msgstr ""
+
+# ae0cd4a04e9e4835a145e80ea304ec17
+#: ../../source/projects/config.rst:78
+msgid "The low-level architecture of this config system."
+msgstr ""
+
+# 97d7c73abdeb4f0389a7e650d037fc10
+#: ../../source/projects/content-projects.rst:4
+msgid "Installation, Configuration, and Usage"
+msgstr ""
+
+# b3daae6ac8b8407d9311cebd6b0cd982
+#: ../../source/projects/content-projects.rst:7
+msgid "Installation"
+msgstr ""
+
+# 25e5f9f40ad84a3183e46a0701c5d083
+#: ../../source/projects/content-projects.rst:17
+msgid "How do I decide which packages I need?"
+msgstr ""
+
+# c96ce8e348c543bfbb7beb3622bd7d3b
+#: ../../source/projects/content-projects.rst:136
+msgid "Configuration"
+msgstr ""
+
+# 54d90121c5e24975be1c0cb3350e3a0b
+#: ../../source/projects/content-projects.rst:146
+msgid "Usage and Projects"
+msgstr ""
+
+# 878b87f3b5334557964db57fe6ecfc00
+#: ../../source/projects/doc-proj-categories.rst:3
+msgid "Project Documentation"
+msgstr ""
+
+# da1412ca76794532b4409e1da1d6a9c6
+#: ../../source/projects/doc-proj-categories.rst:8
+msgid ""
+"Links to **information on usage, configuration and development** hosted "
+"on Read The Docs or in the GitHub project repo."
+msgstr ""
+
+# 05e0c934a6004550a2bbc836a9f8241e
+# fc0cfc8377c448dd87f57ad3d7faf590
+#: ../../source/projects/doc-proj-categories.rst:12
+#: ../../source/projects/subprojects.rst:14
+msgid "Jupyter User Interfaces"
+msgstr ""
+
+# 67a117c7d3874a8b9183c9c321d6a4a0
+#: ../../source/projects/doc-proj-categories.rst:13
+msgid "`Jupyter Notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# f0f7ba9f5be24319a67f3822fdca4e63
+#: ../../source/projects/doc-proj-categories.rst:14
+msgid "`jupyter_console <http://jupyter-console.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# d11bac142e77476e8ed00dbc47d8cca4
+#: ../../source/projects/doc-proj-categories.rst:15
+msgid "`qtconsole <https://qtconsole.readthedocs.io/en/stable/>`_"
+msgstr ""
+
+# 2c1b9d78c1164045b7e3ee67011405cb
+#: ../../source/projects/doc-proj-categories.rst:18
+msgid "JupyterHub"
+msgstr ""
+
+# fed298a75504421993d6e9e5bc630551
+#: ../../source/projects/doc-proj-categories.rst:19
+msgid "`JupyterHub <http://jupyterhub.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 7572a9cc7da44692b9f3bc4386564364
+#: ../../source/projects/doc-proj-categories.rst:20
+msgid ""
+"`configurable-http-proxy <https://github.com/jupyterhub/configurable-"
+"http-proxy>`_"
+msgstr ""
+
+# 5c5566158224426295e9e97bb73ecc46
+#: ../../source/projects/doc-proj-categories.rst:21
+msgid "`dockerspawner <https://github.com/jupyterhub/dockerspawner>`_"
+msgstr ""
+
+# bb55cce340ef4ea4892839cbd8337e8f
+#: ../../source/projects/doc-proj-categories.rst:22
+msgid "`ldapauthenticator <https://github.com/jupyterhub/ldapauthenticator>`_"
+msgstr ""
+
+# f7d54f483595450fa4b37781fd887452
+#: ../../source/projects/doc-proj-categories.rst:23
+msgid "`oauthenticator <https://github.com/jupyterhub/oauthenticator>`_"
+msgstr ""
+
+# dc23452377da44edbe127d34cd305a19
+#: ../../source/projects/doc-proj-categories.rst:24
+msgid "`sudospawner <https://github.com/jupyterhub/sudospawner>`_"
+msgstr ""
+
+# fec520fc2c8a4b7aa8f54bda8447e976
+# e31418dae87748369b4fa4826b428dfc
+#: ../../source/projects/doc-proj-categories.rst:27
+#: ../../source/projects/subprojects.rst:91
+msgid "Education"
+msgstr ""
+
+# e8ecf2b2e0e240438b897616cb0d1cec
+#: ../../source/projects/doc-proj-categories.rst:28
+msgid "`nbgrader <http://nbgrader.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# bcf3e08d367944c39c38201049663273
+#: ../../source/projects/doc-proj-categories.rst:31
+msgid "Notebook Conversion and Formatting"
+msgstr ""
+
+# 6f5a84f0d0b64958a31aeb68b9bd9d43
+#: ../../source/projects/doc-proj-categories.rst:32
+msgid "`nbconvert <http://nbconvert.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 87e7cf3391ae49e2b5719e4f2843a9bc
+#: ../../source/projects/doc-proj-categories.rst:33
+msgid "`nbformat <http://nbformat.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 1642454b670a4f23b884da1cf8b42095
+# 838d9a305b6d4cf29191f3b95bd29e52
+#: ../../source/projects/doc-proj-categories.rst:36
+#: ../../source/projects/subprojects.rst:39
+msgid "Kernels"
+msgstr ""
+
+# 12d4b4b3066048b68cc4ff247e2beb3c
+#: ../../source/projects/doc-proj-categories.rst:37
+msgid "`IPython <https://ipython.readthedocs.io/en/stable/>`_"
+msgstr ""
+
+# 0939ba530c894801ae11b4e65e2530f2
+#: ../../source/projects/doc-proj-categories.rst:38
+msgid "`IRkernel <https://irkernel.github.io/>`_"
+msgstr ""
+
+# 10e09d0397ef4458890c8ed800194814
+#: ../../source/projects/doc-proj-categories.rst:39
+msgid "`IJulia <https://github.com/JuliaLang/IJulia.jl>`_"
+msgstr ""
+
+# e7d05d24d92f4db3a46dd43f6b247ad6
+#: ../../source/projects/doc-proj-categories.rst:40
+msgid ""
+"`List of community maintained language kernels "
+"<https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-"
+"languages>`_"
+msgstr ""
+
+# 831ada76059b4ebea4e80a139b91ef06
+#: ../../source/projects/doc-proj-categories.rst:43
+msgid "IPython"
+msgstr ""
+
+# 38ae294a26394b5d97233f08b0fe9b0d
+#: ../../source/projects/doc-proj-categories.rst:44
+msgid "`IPython`_"
+msgstr ""
+
+# 8c06cd6a311e440a8b4b90313e599a5d
+#: ../../source/projects/doc-proj-categories.rst:45
+msgid "`ipykernel <https://ipython.readthedocs.io/en/stable/>`_"
+msgstr ""
+
+# b890abfa9d4c4040a128bf67fdaa6139
+#: ../../source/projects/doc-proj-categories.rst:46
+msgid "`ipyparallel <https://ipyparallel.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 1f0fbbbf059d4c7182c15c9c48dd5450
+# aafbcd62f5d4479f9501ef2df6a138f0
+#: ../../source/projects/doc-proj-categories.rst:49
+#: ../../source/projects/subprojects.rst:106
+msgid "Deployment"
+msgstr ""
+
+# 3e5210e31d784c19acf03439c303ab54
+#: ../../source/projects/doc-proj-categories.rst:50
+msgid "`docker-stacks <https://github.com/jupyter/docker-stacks>`_"
+msgstr ""
+
+# 4ee088e2656c4478ae6af2f710282744
+#: ../../source/projects/doc-proj-categories.rst:51
+msgid "`ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 6ce5c42884a14600bb1271b40d06d02b
+#: ../../source/projects/doc-proj-categories.rst:52
+msgid "`jupyter-drive <https://github.com/jupyter/jupyter-drive>`_"
+msgstr ""
+
+# 97e013d4dc7e44dc88d18c6151f7f7e7
+#: ../../source/projects/doc-proj-categories.rst:53
+msgid "`jupyter-sphinx-theme <https://github.com/jupyter/jupyter-sphinx-theme>`_"
+msgstr ""
+
+# 2844f35d88594b1cbcdd4fabba433e14
+#: ../../source/projects/doc-proj-categories.rst:54
+msgid ""
+"`kernel_gateway <http://jupyter-kernel-"
+"gateway.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 6b76351692c6479493985193869e2a03
+#: ../../source/projects/doc-proj-categories.rst:55
+msgid "`nbviewer <https://github.com/jupyter/nbviewer>`_"
+msgstr ""
+
+# 66405b5e2ad54aa39e2dd7f77874a08c
+#: ../../source/projects/doc-proj-categories.rst:56
+msgid "`tmpnb <https://github.com/jupyter/tmpnb>`_"
+msgstr ""
+
+# 0a3317a3f98a4a428c7af8adb2d282be
+#: ../../source/projects/doc-proj-categories.rst:57
+msgid "`traitlets <http://traitlets.readthedocs.io/en/stable/>`_"
+msgstr ""
+
+# 469c33adacf44e77be8479c50a3afde7
+#: ../../source/projects/doc-proj-categories.rst:60
+msgid "JupyterLab"
+msgstr ""
+
+# e73d09d0ce1245c88186f99fb6d07143
+#: ../../source/projects/doc-proj-categories.rst:61
+msgid "`jupyter-js-notebook <https://github.com/jupyter/jupyter-js-notebook>`_"
+msgstr ""
+
+# 312f96ae98194c598857978bec70d4e1
+#: ../../source/projects/doc-proj-categories.rst:62
+msgid "`jupyter-js-phosphide <https://github.com/jupyter/jupyter-js-phosphide>`_"
+msgstr ""
+
+# 3f8abf0c8fa54d01ba938fe0cfa6ae3f
+#: ../../source/projects/doc-proj-categories.rst:63
+msgid "`jupyter-js-plugins <https://github.com/jupyter/jupyter-js-plugins>`_"
+msgstr ""
+
+# f563f0f8921b40c9a56aa72a62a7ae08
+#: ../../source/projects/doc-proj-categories.rst:64
+msgid "`jupyter-js-services <http://jupyter.org/jupyter-js-services/>`_"
+msgstr ""
+
+# 932e4e56da8149dc9b19c939d0ce6291
+#: ../../source/projects/doc-proj-categories.rst:65
+msgid "`jupyter-js-ui <http://jupyter.org/jupyter-js-ui/>`_"
+msgstr ""
+
+# 5d5e4940d3624873a4b2c39ce7d4ea00
+#: ../../source/projects/doc-proj-categories.rst:66
+msgid "`jupyter-js-utils <http://jupyter.org/jupyter-js-utils/>`_"
+msgstr ""
+
+# edd42737bc98463498d711d9d916c157
+# 73d33f0f3c864e74b012a215450194c5
+#: ../../source/projects/doc-proj-categories.rst:69
+#: ../../source/projects/subprojects.rst:151
+msgid "Architecture"
+msgstr ""
+
+# 94f4104fc2a346e9b752026e94ccb9b8
+#: ../../source/projects/doc-proj-categories.rst:70
+msgid "`jupyter_client <http://jupyter-client.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# a7c0c77907204a10aa56b382435e60e7
+#: ../../source/projects/doc-proj-categories.rst:71
+msgid "`jupyter_core <http://jupyter-core.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# cba6565dfef44292847ee4619fb67cdd
+#: ../../source/projects/incubator.rst:2
+msgid "Incubator Projects"
+msgstr ""
+
+# 28287c3575fc4697829583939cfd9ef0
+#: ../../source/projects/incubator.rst:7
+msgid ""
+"The `Jupyter incubator <https://github.com/jupyter-incubator>`_ gives "
+"emerging projects a place to evolve."
+msgstr ""
+
+# b6fadf1a90d64f40bc531afda9e7f181
+#: ../../source/projects/incubator.rst:11
+msgid "Descriptions"
+msgstr ""
+
+# 75694883742b41c7b1dbf76b66fab082
+#: ../../source/projects/incubator.rst:13
+msgid "Interesting projects include:"
+msgstr ""
+
+# edf5c1a57381452f81241ced74bfd684
+#: ../../source/projects/incubator.rst:15
+msgid ""
+"`content management extensions <https://github.com/jupyter-"
+"incubator/contentmanagement>`_ - Jupyter Content Management Extensions"
+msgstr ""
+
+# 60cda82020be42c08afd057695bea4a4
+#: ../../source/projects/incubator.rst:16
+msgid ""
+"`dashboards <https://github.com/jupyter-incubator/dashboards>`_ - Jupyter"
+" Dynamic Dashboards from Notebooks"
+msgstr ""
+
+# 254de647304647ab8073b020d1cc3b01
+#: ../../source/projects/incubator.rst:17
+msgid ""
+"`declarative widgets <https://github.com/jupyter-"
+"incubator/declarativewidgets>`_ - Jupyter Declarative Widgets Extension"
+msgstr ""
+
+# 43b5a7a788f74c0fa8d7532dcec2a001
+#: ../../source/projects/incubator.rst:18
+msgid ""
+"`kernel gateway bundlers <https://github.com/jupyter-"
+"incubator/kernel_gateway_bundlers>`_ - Converts a notebook to a kernel "
+"gateway microservice bundle for download"
+msgstr ""
+
+# a70e8c643c034c8f95ecc7d52c3b76eb
+#: ../../source/projects/incubator.rst:19
+msgid ""
+"`showcase`_ - A spot to try demos of one or more incubating Jupyter "
+"projects in `Binder <http://mybinder.org/>`_"
+msgstr ""
+
+# d70eebc552ab4bd197ee7bbd9def1a9b
+#: ../../source/projects/incubator.rst:20
+msgid ""
+"`sparkmagic <https://github.com/jupyter-incubator/sparkmagic>`_ - Jupyter"
+" magics and kernels for working with remote Spark clusters"
+msgstr ""
+
+# 99fd5864d2694a498188465e90d5e366
+#: ../../source/projects/incubator.rst:21
+msgid ""
+"`traittypes <https://github.com/jupyter-incubator/traittypes>`_ - "
+"Traitlets types for NumPy, SciPy and friends"
+msgstr ""
+
+# 39368898693b438885f9f91f59f62a9f
+#: ../../source/projects/incubator.rst:23
+msgid ""
+"There's also a `repository with proposals <https://github.com/jupyter-"
+"incubator/proposals>`_ of projects wishing to enter the incubator."
+msgstr ""
+
+# 71076519b1d94f87afd451f597df50a4
+#: ../../source/projects/incubator.rst:27
+msgid "Try the Incubator Projects"
+msgstr ""
+
+# a90ed853561445ad937d3baab7ed807a
+#: ../../source/projects/incubator.rst:29
+msgid ""
+"The `showcase`_ application allows you to try demos of one or more "
+"incubating Jupyter projects in `Binder <http://mybinder.org/>`_. Just "
+"head over to the `showcase`_ repo and press the :guilabel:`Launch Binder`"
+" button badge to launch the online trial. You should see an interactive "
+"notebook similar to this one:"
+msgstr ""
+
+# d70338c3f7bf458daf73b7925ba29e35
+#: ../../source/projects/ipython_projects.rst:2
+msgid "IPython Projects"
+msgstr ""
+
+# 7f631307348a402f9ab66eba132737cb
+# 40bf2641321f415f931e61d4e62e90cb
+#: ../../source/projects/ipython_projects.rst:8
+#: ../../source/projects/jupyter-command.rst:16
+msgid "Description"
+msgstr ""
+
+# 543da61e80f44ef1b1e3d57d909161c4
+#: ../../source/projects/ipython_projects.rst:10
+msgid ""
+"`IPython <https://ipython.org>`_ provides a rich architecture for "
+"interactive computing with:"
+msgstr ""
+
+# 8e4ff36b60e9432594471c8fee1d7163
+#: ../../source/projects/ipython_projects.rst:13
+msgid "A powerful interactive shell."
+msgstr ""
+
+# d432b9c2e4c64adfb2f6100665eb0f9c
+#: ../../source/projects/ipython_projects.rst:14
+msgid "A kernel for Jupyter."
+msgstr ""
+
+# b0e52b8513b0457eb61bda3e14f785ec
+#: ../../source/projects/ipython_projects.rst:15
+msgid "Support for interactive data visualization and use of GUI toolkits."
+msgstr ""
+
+# aaaead17f2ca44c896c99ed5e1192dee
+#: ../../source/projects/ipython_projects.rst:16
+msgid "Flexible, embeddable interpreters to load into your own projects."
+msgstr ""
+
+# ea29a6d9e0734512a00cfa5ad436bec1
+#: ../../source/projects/ipython_projects.rst:17
+msgid "Easy to use, high performance tools for parallel computing."
+msgstr ""
+
+# 2cc5f1f88b0c4d8cb1a1613e4282356c
+#: ../../source/projects/ipython_projects.rst:20
+msgid "Background"
+msgstr ""
+
+# 3fe872113f4c4e15b82282d04efface1
+#: ../../source/projects/ipython_projects.rst:22
+msgid ""
+"IPython is a growing project, with increasingly language-agnostic "
+"components. IPython 3.x was the last monolithic release of IPython, "
+"containing the notebook server, qtconsole, etc. As of IPython 4.0, the "
+"language-agnostic parts of the project: the notebook format, message "
+"protocol, qtconsole, notebook web application, etc. have moved to new "
+"projects under the name Jupyter. IPython itself is focused on interactive"
+" Python, part of which is providing a Python kernel for Jupyter."
+msgstr ""
+
+# b42a67733d444e32973954185f0f70cb
+#: ../../source/projects/ipython_projects.rst:31
+msgid "Resources"
+msgstr ""
+
+# 3e453e9551974bec9e26dd108e807789
+#: ../../source/projects/ipython_projects.rst:33
+msgid "The projects with repos in the IPython organization on GitHub include:"
+msgstr ""
+
+# 5031645557cd44ecb80e167383ac147f
+#: ../../source/projects/ipython_projects.rst:35
+msgid ""
+"IPython `ipykernel <https://ipython.readthedocs.io/en/stable/>`_ "
+"interactive computing in Python."
+msgstr ""
+
+# fcd79ae7b74b40ccbf3aaf50a7ace569
+#: ../../source/projects/ipython_projects.rst:37
+msgid ""
+"`ipyparallel <https://ipyparallel.readthedocs.io/en/latest/>`_ "
+"lightweight parallel computing in Python offering seamless notebook "
+"integration"
+msgstr ""
+
+# 69568ee92daf451489775caebb747947
+#: ../../source/projects/ipython_projects.rst:39
+msgid ""
+"`ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`_ interactive "
+"widgets for Python in the Jupyter Notebook"
+msgstr ""
+
+# 5873cdc3af584936a50d5b8af40991b8
+#: ../../source/projects/jupyter-command.rst:4
+msgid "The :command:`jupyter` Command"
+msgstr ""
+
+# dc3c602ec8854657a96f6c09c3dd9f45
+#: ../../source/projects/jupyter-command.rst:9
+msgid "Synopsis"
+msgstr ""
+
+# 5d111077ba074d05aa380c53ba1077ea
+#: ../../source/projects/jupyter-command.rst:18
+msgid ""
+"Commands like ``jupyter notebook`` start Jupyter applications. The "
+"``jupyter`` command is primarily a namespace for subcommands. A command "
+"like ``jupyter-foo`` found on your :envvar:`PATH` will be available as a "
+"subcommand ``jupyter foo``."
+msgstr ""
+
+# 0e8211d5b2854743b58424aefd143a97
+#: ../../source/projects/jupyter-command.rst:23
+msgid ""
+"The :command:`jupyter` command can also be used to do actions other than "
+"starting a Jupyter application."
+msgstr ""
+
+# a546e6c4a3b24260a822ed09c7693c0b
+#: ../../source/projects/jupyter-command.rst:27
+msgid "Command options"
+msgstr ""
+
+# d3d42ef830c540d385919f7ed738f6a4
+#: ../../source/projects/jupyter-command.rst:31
+msgid "Show help information, including available subcommands."
+msgstr ""
+
+# 2ee91915ba0a4908852438e641def692
+#: ../../source/projects/jupyter-command.rst:35
+msgid "Show the location of the config directory."
+msgstr ""
+
+# 997e64311bf24e22a8e4e0a0a9b89dbd
+# 22ee798fcab64510b6f0c41b0df73590
+#: ../../source/projects/jupyter-command.rst:39
+#: ../../source/projects/jupyter-command.rst:43
+msgid "Show the location of the data directory."
+msgstr ""
+
+# e5c4ae5c93e746cda9ba4d8983622523
+#: ../../source/projects/jupyter-command.rst:47
+msgid "Show all Jupyter directories and search paths."
+msgstr ""
+
+# 4d02755d025148c1a043839fec6f39ac
+#: ../../source/projects/jupyter-command.rst:51
+msgid "Print directories and search paths in machine-readable JSON format."
+msgstr ""
+
+# ccb6b7bfee9d4fad9e1e4da9ab283003
+#: ../../source/projects/jupyter-directories.rst:4
+msgid "Common Directories and File Locations"
+msgstr ""
+
+# 0b4e49809d05429a85146eae83d1b3a5
+#: ../../source/projects/jupyter-directories.rst:9
+msgid ""
+"Jupyter stores different files (i.e. configuration, data, runtime) in a "
+"number of different locations. Environment variables may be set to "
+"customize for the location of each file type."
+msgstr ""
+
+# bee4d55638044b5ca68875379f764a1c
+#: ../../source/projects/jupyter-directories.rst:16
+msgid "Configuration files"
+msgstr ""
+
+# a2bb292bb5b44bc6ac0a00926eb1a21c
+#: ../../source/projects/jupyter-directories.rst:18
+msgid "Config files are stored by default in the :file:`~/.jupyter` directory."
+msgstr ""
+
+# e41adbe74f6d474e9cc3eb26c516ce89
+#: ../../source/projects/jupyter-directories.rst:22
+msgid ""
+"Set this environment variable to use a particular directory, other than "
+"the default, for Jupyter config files."
+msgstr ""
+
+# e12398b48b1340d6bbaf749a104ae9e7
+#: ../../source/projects/jupyter-directories.rst:25
+msgid ""
+"Besides the user config directory mentioned above, Jupyter has a search "
+"path of additional locations from which a config file will be loaded. "
+"Here's a table of the locations to be searched, in order of preference:"
+msgstr ""
+
+# 279e6f91f5d44886a35a4c1357897789
+#: ../../source/projects/jupyter-directories.rst:30
+msgid "Unix"
+msgstr ""
+
+# 6fd5c493414044c59661c483a397b901
+# 7ac748a5da594a0e8795dc4d126d5ff6
+#: ../../source/projects/jupyter-directories.rst:30
+#: ../../source/projects/jupyter-directories.rst:67
+msgid "Windows"
+msgstr ""
+
+# 7d93e5f1b6964a0a8749d3f4589b2c66
+#: ../../source/projects/jupyter-directories.rst:32
+msgid ":envvar:`JUPYTER_CONFIG_DIR`"
+msgstr ""
+
+# 76ba7f9b667d4164a38b80798883a1b7
+#: ../../source/projects/jupyter-directories.rst:34
+msgid "``{sys.prefix}/etc/jupyter/``"
+msgstr ""
+
+# 91813f6c49834cf3af9f4a75bdd82a3f
+#: ../../source/projects/jupyter-directories.rst:36
+msgid "``/usr/local/etc/jupyter/`` ``/etc/jupyter/``"
+msgstr ""
+
+# e74637fd387f47ccb068dbc01bded802
+#: ../../source/projects/jupyter-directories.rst:36
+msgid "``%PROGRAMDATA%\\jupyter\\``"
+msgstr ""
+
+# 712a90ba320f4bda9acb4e6df9b85bc2
+#: ../../source/projects/jupyter-directories.rst:40
+msgid ""
+"To list the config directories currrently being used you can run the "
+"below command from the :term:`command line`::"
+msgstr ""
+
+# 64964fbe2be242c8bac8ee7af6ec573a
+#: ../../source/projects/jupyter-directories.rst:48
+msgid "Data files"
+msgstr ""
+
+# 11ceec0e782b4fc29d0268325a9e2a2c
+#: ../../source/projects/jupyter-directories.rst:50
+msgid ""
+"Jupyter uses a search path to find installable data files, such as "
+":ref:`kernelspecs <kernelspecs>` and notebook extensions. When searching "
+"for a resource, the code will search the search path starting at the "
+"first directory until it finds where the resource is contained."
+msgstr ""
+
+# c90c9a0db78f48a2a2d9c62ec1d46ab6
+#: ../../source/projects/jupyter-directories.rst:55
+msgid ""
+"Each category of file is in a subdirectory of each directory of the "
+"search path. For example, kernel specs are in ``kernels`` subdirectories."
+msgstr ""
+
+# ba1504c274984be89d08649e83e6a9a4
+#: ../../source/projects/jupyter-directories.rst:60
+msgid ""
+"Set this environment variable to provide extra directories for the data "
+"search path. :envvar:`JUPYTER_PATH` should contain a series of "
+"directories, separated by ``os.pathsep`` (``;`` on Windows, ``:`` on "
+"Unix). Directories given in :envvar:`JUPYTER_PATH` are searched before "
+"other locations."
+msgstr ""
+
+# f8a146011f294865a766b75fa7e17ca7
+#: ../../source/projects/jupyter-directories.rst:67
+msgid "Linux (& other free desktops)"
+msgstr ""
+
+# b050321d85634c2b8e2b2a6dcd904919
+#: ../../source/projects/jupyter-directories.rst:67
+msgid "Mac"
+msgstr ""
+
+# cd9e53136025484cacee2884c4b0d516
+#: ../../source/projects/jupyter-directories.rst:69
+msgid ":envvar:`JUPYTER_PATH`"
+msgstr ""
+
+# 391fe50861314e57a7daa84d3e5e2bab
+#: ../../source/projects/jupyter-directories.rst:71
+msgid "``~/.local/share/jupyter/`` (respects ``$XDG_DATA_HOME``)"
+msgstr ""
+
+# 06e83363053c4fbba0effd942e901744
+#: ../../source/projects/jupyter-directories.rst:71
+msgid "``~/Library/Jupyter``"
+msgstr ""
+
+# 6d67a10caff64039a15564a99c3006f9
+#: ../../source/projects/jupyter-directories.rst:71
+msgid "``%APPDATA%\\jupyter``"
+msgstr ""
+
+# deb75cfd63164420803927a5649e969a
+#: ../../source/projects/jupyter-directories.rst:74
+msgid "``{sys.prefix}/share/jupyter/``"
+msgstr ""
+
+# f0d3dcdaccca4791b9a44deae35c97e4
+#: ../../source/projects/jupyter-directories.rst:76
+msgid "``/usr/local/share/jupyter`` ``/usr/share/jupyter``"
+msgstr ""
+
+# b7b523630e9242a4a12dbf7542ad65dc
+#: ../../source/projects/jupyter-directories.rst:76
+msgid "``%PROGRAMDATA\\jupyter``"
+msgstr ""
+
+# b93aebf5941e4312998c3a4c9f1e295e
+#: ../../source/projects/jupyter-directories.rst:83
+msgid "Runtime files"
+msgstr ""
+
+# 9e1d0a2fed714ebdad259185c2c0ebbc
+#: ../../source/projects/jupyter-directories.rst:85
+msgid ""
+"Things like connection files, which are only useful for the lifetime of a"
+" particular process, have a runtime directory."
+msgstr ""
+
+# 6863708a008443d2b5c64ccc5536c1e0
+#: ../../source/projects/jupyter-directories.rst:88
+msgid ""
+"On Linux and other free desktop platforms, these runtime files are stored"
+" in ``$XDG_RUNTIME_DIR/jupyter`` by default. On other platforms, it's a "
+"``runtime/`` subdirectory of the user's data directory (second row of the"
+" table above)."
+msgstr ""
+
+# bd275402d825484bb6293ac54280c325
+#: ../../source/projects/jupyter-directories.rst:93
+msgid "An environment variable may also be used to set the runtime directory."
+msgstr ""
+
+# dffbcd47c8624f2b9add3a0577b40ea2
+#: ../../source/projects/jupyter-directories.rst:97
+msgid "Set this to override where Jupyter stores runtime files."
+msgstr ""
+
+# f79b9f3ae9f64f58abb71234571306d4
+#: ../../source/projects/jupyter-directories.rst:102
+msgid ":envvar:`JUPYTER_CONFIG_DIR` for config file location"
+msgstr ""
+
+# 337b31b2027e41ee99263264a0e43464
+#: ../../source/projects/jupyter-directories.rst:104
+msgid ":envvar:`JUPYTER_PATH` for datafile directory locations"
+msgstr ""
+
+# 5d107ae276ea4dc8bf1d85dbb80bc83d
+#: ../../source/projects/jupyter-directories.rst:106
+msgid ":envvar:`JUPYTER_RUNTIME_DIR` for runtime file location"
+msgstr ""
+
+# e23bc6d9b72d47548301020f53a1ed24
+#: ../../source/projects/jupyter-directories.rst:112
+msgid ":mod:`jupyter_core.paths`"
+msgstr ""
+
+# ca3b8f756259407baf25bf422b315237
+#: ../../source/projects/jupyter-directories.rst:112
+msgid "The Python API to locate these directories."
+msgstr ""
+
+# 5ce8e7c0d39740a1bfcbf01c68fd1eaf
+#: ../../source/projects/jupyter-directories.rst:114
+msgid ":ref:`jupyter_command`"
+msgstr ""
+
+# 77254e7e6f644d49a9475e8bd2e47d8a
+#: ../../source/projects/jupyter-directories.rst:115
+msgid "Locate these directories from the command line."
+msgstr ""
+
+# 8ccbc30eb55f436d8af25b13a9cd5ef7
+#: ../../source/projects/kernels.rst:4
+msgid "Kernels (Programming Languages)"
+msgstr ""
+
+# badc42c2b34c4d11ae7aa2b2767f3728
+#: ../../source/projects/kernels.rst:6
+msgid ""
+"The Jupyter team maintains the `IPython kernel "
+"<https://github.com/ipython/ipython>`_ since the Jupyter notebook server "
+"depends on the IPython :term:`kernel` functionality. Many other "
+"languages, in addition to Python, may be used in the notebook."
+msgstr ""
+
+# 028a578af22144598ff940f737764962
+#: ../../source/projects/kernels.rst:11
+msgid ""
+"The community maintains many other language kernels, and new kernels "
+"become available often. Please see the `list of available kernels`_ for "
+"additional languages and `kernel installation instructions`_ to begin "
+"using these language kernels."
+msgstr ""
+
+# 9910335ae4fe47adbef725bbdb9f7faa
+#: ../../source/projects/subprojects.rst:5
+msgid "Jupyter Projects"
+msgstr ""
+
+# b8c9bc5ad06b47d1bf4eb72a5bb7778a
+#: ../../source/projects/subprojects.rst:10
+msgid ""
+"Project Jupyter is developed as a set of subprojects. This section "
+"describes the subprojects with links to their documentation or GitHub "
+"repositories."
+msgstr ""
+
+# c84899e578ac4b95b3ddcb1e19ae40e4
+#: ../../source/projects/subprojects.rst:15
+msgid ""
+"The Jupyter user interfaces offer a foundation of interactive computing "
+"environments where scientific computing, data science, and analytics can "
+"be performed using a wide range of programming languages."
+msgstr ""
+
+# 3c3427b170f3480eacb5a12321c2763f
+#: ../../source/projects/subprojects.rst:20
+msgid "`Jupyter Notebook <https://jupyter-notebook.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 83a65fc880d64bcd9cbdc020b85c0c6c
+#: ../../source/projects/subprojects.rst:22
+msgid ""
+"Web-based application for authoring documents that combine live-code with"
+" narrative text, equations and visualizations. `Documentation <https"
+"://jupyter-notebook.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/notebook>`__"
+msgstr ""
+
+# aec9f2d0779b4c4c92d8cf427f0d8716
+#: ../../source/projects/subprojects.rst:26
+msgid "`Jupyter Console <https://jupyter-console.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 1849d5bef10540caba484b7e713d550c
+#: ../../source/projects/subprojects.rst:28
+msgid ""
+"Terminal based console for interactive computing. `Documentation <https"
+"://jupyter-console.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/jupyter_console>`__"
+msgstr ""
+
+# 6d562e69261247958e947bf1f99a1578
+#: ../../source/projects/subprojects.rst:31
+msgid "`Jupyter QtConsole <https://jupyter.org/qtconsole/stable/>`__"
+msgstr ""
+
+# d11809f22b934f51994dbdd75402efe0
+#: ../../source/projects/subprojects.rst:33
+msgid ""
+"Qt application for interactive computing with rich output. `Documentation"
+" <https://jupyter.org/qtconsole/stable/>`__ | `Repo "
+"<https://github.com/jupyter/qtconsole>`__"
+msgstr ""
+
+# c4527340da8c4cb89829a1a1b39ed1a5
+#: ../../source/projects/subprojects.rst:40
+msgid ""
+"Kernels are `programming language specific` processes that run "
+"independently and interact with the Jupyter Applications and their user "
+"interfaces. `IPython <https://ipython.org>`__ is the reference Jupyter "
+"kernel, providing a powerful environment for interactive computing in "
+"Python."
+msgstr ""
+
+# 6dd6dcd0bc1840da8916fc03f01788ef
+#: ../../source/projects/subprojects.rst:46
+msgid "`IPython <https://ipython.org>`__"
+msgstr ""
+
+# f2c9f65822ee444fbaa722750c715cce
+#: ../../source/projects/subprojects.rst:48
+msgid ""
+"interactive computing in Python. `Documentation "
+"<http://ipython.readthedocs.io/en/stable/>`__ | `Repo "
+"<https://github.com/ipython/ipython>`__"
+msgstr ""
+
+# bb0dcd6ea74f438e8a548661894d6f19
+#: ../../source/projects/subprojects.rst:51
+msgid "`ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# ca8e8d5e5b844a9ca0d94fbd32717a7a
+#: ../../source/projects/subprojects.rst:53
+msgid ""
+"interactive widgets for Python in the Jupyter Notebook. `Documentation "
+"<https://ipywidgets.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/ipython/ipywidgets>`__"
+msgstr ""
+
+# c377fd53c79042d6b56baae717d8c2a0
+#: ../../source/projects/subprojects.rst:56
+msgid "`ipyparallel <https://ipyparallel.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 6d54f08db9124d3ab5eb18ab39c88c6e
+#: ../../source/projects/subprojects.rst:58
+msgid ""
+"lightweight parallel computing in Python offering seamless notebook "
+"integration. `Documentation "
+"<https://ipyparallel.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/ipython/ipyparallel>`__"
+msgstr ""
+
+# 5d320a536a8b490fa66f06971b80fcbf
+#: ../../source/projects/subprojects.rst:64
+msgid ""
+"`Jupyter kernels <https://github.com/ipython/ipython/wiki/IPython-"
+"kernels-for-other-languages>`_"
+msgstr ""
+
+# 9474725a4e414c47a8a2c081deb7d361
+#: ../../source/projects/subprojects.rst:66
+msgid ""
+"A full list of kernels available for other languages. Many of these "
+"kernels are developed by third parties and may or may not be stable."
+msgstr ""
+
+# bada42846faa4c76bcb0870aa7b4ff67
+#: ../../source/projects/subprojects.rst:70
+msgid "Formatting and Conversion"
+msgstr ""
+
+# 8a0210fab25448ce9a8ce955a5e98b81
+#: ../../source/projects/subprojects.rst:71
+msgid ""
+"Notebooks are rich interactive documents that combine live code, "
+"narrative text (using markdown), visualizations, and other rich media. "
+"The following utility subprojects allow programmatic format conversion "
+"and manipulation of notebook documents."
+msgstr ""
+
+# 63aa809df72b43d187a73bb2e4e6a583
+#: ../../source/projects/subprojects.rst:77
+msgid "`nbconvert <https://nbconvert.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 4c57295fbf23443daf9fdd2905ef7fcf
+#: ../../source/projects/subprojects.rst:79
+msgid ""
+"Convert dynamic notebooks to static formats such as HTML, Markdown, "
+"LaTeX/PDF, and reStrucuredText. `Documentation "
+"<https://nbconvert.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/nbconvert>`__"
+msgstr ""
+
+# ce77e006f955438aa5a921968dc8b922
+#: ../../source/projects/subprojects.rst:83
+msgid "`nbformat <https://nbformat.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 6dff295e412a47da84bb23b4786708b9
+#: ../../source/projects/subprojects.rst:85
+msgid ""
+"Work with notebook documents programmatically. `Documentation "
+"<https://nbformat.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/nbformat>`__"
+msgstr ""
+
+# de4778c3365b43a3b2f0eaf1202f009e
+#: ../../source/projects/subprojects.rst:92
+msgid ""
+"Jupyter Notebooks offer exciting and creative possibilities in education."
+" The following subprojects are focused on supporting the use of Jupyter "
+"Notebook in a variety of educational settings."
+msgstr ""
+
+# 7c1bb06e24c34d31a3e5d647eb968ef4
+#: ../../source/projects/subprojects.rst:97
+msgid "`nbgrader <https://nbgrader.readthedocs.io/en/stable/>`__"
+msgstr ""
+
+# e871a361fed74d7984ccf6be1d16ae4f
+#: ../../source/projects/subprojects.rst:99
+msgid ""
+"tools for managing, grading, and reporting of notebook based assignments."
+" `Documentation <https://nbgrader.readthedocs.io/en/stable/>`__ | `Repo "
+"<https://github.com/jupyter/nbgrader>`__"
+msgstr ""
+
+# 9bddab1e2cba4c829b435171cbe67474
+#: ../../source/projects/subprojects.rst:107
+msgid ""
+"To serve a variety of users and use cases, these subprojects are being "
+"developed to support notebook deployment in various contexts, including "
+"multiuser capabilities and secure, scalable cloud deployments."
+msgstr ""
+
+# eefb0ea614334021a3d54a1978ace7c4
+#: ../../source/projects/subprojects.rst:112
+msgid "`jupyterhub <https://github.com/jupyterhub/jupyterhub>`__"
+msgstr ""
+
+# 17d831ed81344a498d1e6449876780e6
+#: ../../source/projects/subprojects.rst:114
+msgid ""
+"Multi-user notebook for organizations with pluggable authentication and "
+"scalability. `Documentation "
+"<https://jupyterhub.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyterhub/jupyterhub>`__"
+msgstr ""
+
+# bf80256b0a2d49beb74926620c0e63d0
+#: ../../source/projects/subprojects.rst:118
+msgid "`jupyter-drive <https://github.com/jupyter/jupyter-drive>`__"
+msgstr ""
+
+# d6e3c6aaebe44f4cb095e4097d8ffbfe
+#: ../../source/projects/subprojects.rst:120
+msgid ""
+"Store notebooks on Google Drive. `Documentation "
+"<https://github.com/jupyter/jupyter-drive>`__ | `Repo "
+"<https://github.com/jupyter/jupyter-drive>`__"
+msgstr ""
+
+# 7abe71ed8d0c4b78abda9410c630fce5
+#: ../../source/projects/subprojects.rst:123
+msgid "`nbviewer <https://nbviewer.jupyter.org/>`__"
+msgstr ""
+
+# 9f9dbdacd8284a36a9e4fabb09e6f75b
+#: ../../source/projects/subprojects.rst:125
+msgid ""
+"Share notebooks as static HTML on the web. `Documentation "
+"<https://github.com/jupyter/nbviewer>`__ | `Repo "
+"<https://github.com/jupyter/nbviewer>`__"
+msgstr ""
+
+# 21c5717ce0bb494abeb4f7efe21689cf
+#: ../../source/projects/subprojects.rst:128
+msgid "`tmpnb <https://github.com/jupyter/tmpnb>`__"
+msgstr ""
+
+# b33b868fce914e299fd08a5835536be1
+#: ../../source/projects/subprojects.rst:130
+msgid ""
+"Create temporary, transient notebooks in the cloud. `Documentation "
+"<https://github.com/jupyter/tmpnb>`__ | `Repo "
+"<https://github.com/jupyter/tmpnb>`__"
+msgstr ""
+
+# 21a190811e944b0da16ade016dc3b614
+#: ../../source/projects/subprojects.rst:133
+msgid "`tmpnb-deploy <https://github.com/jupyter/tmpnb-deploy>`__"
+msgstr ""
+
+# 5daf6e80c11b44c595c655040dc09d64
+#: ../../source/projects/subprojects.rst:135
+msgid ""
+"Deployment tools for tmpnb. `Documentation <https://github.com/jupyter"
+"/tmpnb-deploy>`__ | `Repo <https://github.com/jupyter/tmpnb-deploy>`__"
+msgstr ""
+
+# 1f8ac9a7b4db4bb3b330567ac288e212
+#: ../../source/projects/subprojects.rst:138
+msgid "`dockerspawner <https://github.com/jupyterhub/dockerspawner>`__"
+msgstr ""
+
+# 2b17819baf714cbea333e87b1007f41a
+#: ../../source/projects/subprojects.rst:140
+msgid ""
+"Deploy notebooks for 'jupyterhub' inside Docker containers. "
+"`Documentation <https://github.com/jupyterhub/dockerspawner>`__ | `Repo "
+"<https://github.com/jupyterhub/dockerspawner>`__"
+msgstr ""
+
+# 8ef739ace1cf4cc8bad61fb84a2d4c6d
+#: ../../source/projects/subprojects.rst:143
+msgid "`docker-stacks <https://github.com/jupyter/docker-stacks>`__"
+msgstr ""
+
+# d77ec1880fb64bef854fafe43b182310
+#: ../../source/projects/subprojects.rst:145
+msgid ""
+"Stacks of Jupyter applications and kernels as Docker containers. "
+"`Documentation <https://github.com/jupyter/docker-stacks>`__ | `Repo "
+"<https://github.com/jupyter/docker-stacks>`__"
+msgstr ""
+
+# 2c6f57f2e66247acbba9d318b5c2ce75
+#: ../../source/projects/subprojects.rst:152
+msgid ""
+"The Jupyter architecture relies on these projects' specifications and "
+"implementation."
+msgstr ""
+
+# 682935d71e0f4ab7be95b5b3aea567d5
+#: ../../source/projects/subprojects.rst:156
+msgid "`jupyter_client <https://jupyter-client.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 0e90e5cc30614edab2b9cb1f02d94a33
+#: ../../source/projects/subprojects.rst:158
+msgid ""
+"The specification of the Jupyter message protocol and a client library in"
+" Python. `Documentation <https://jupyter-"
+"client.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/jupyter_client>`__"
+msgstr ""
+
+# ed800037c68c47df8948d52e1b135a2b
+#: ../../source/projects/subprojects.rst:162
+msgid "`jupyter_core <https://jupyter-core.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# d925cc4bc47747ea85133aad35a742dc
+#: ../../source/projects/subprojects.rst:164
+msgid ""
+"Core functionality and miscellaneous utilities. `Documentation <https"
+"://jupyter-core.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/jupyter_core>`__"
+msgstr ""
+
+# 42f7355e70a2465091323cab4580f41c
+#: ../../source/projects/upgrade-notebook.rst:2
+msgid "Upgrading Jupyter Notebook"
+msgstr ""
+
+# 440ad06fd1184be59ef54118786fb0e4
+#: ../../source/projects/upgrade-notebook.rst:8
+msgid "Upgrading Jupyter Notebook using Anaconda"
+msgstr ""
+
+# 18dbe73b2ce04c938891ba31dea7fe2c
+# dd8463cadc3a4083a009cd56974e52d5
+#: ../../source/projects/upgrade-notebook.rst:9
+#: ../../source/projects/upgrade-notebook.rst:28
+msgid "If using **Anaconda**, update Jupyter using ``conda``:"
+msgstr ""
+
+# a9da6695326c43b2a352e704d29b2dca
+# 6fab146490114576a0eb827544c97bda
+#: ../../source/projects/upgrade-notebook.rst:15
+#: ../../source/projects/upgrade-notebook.rst:42
+msgid "See :ref:`Run the Notebook <running>` for running the Jupyter Notebook."
+msgstr ""
+
+# f8b0d1051b0744969dc1f9f522461d3e
+#: ../../source/projects/upgrade-notebook.rst:21
+msgid "Upgrading IPython Notebook to Jupyter Notebook"
+msgstr ""
+
+# 1a22753f51114de08d7186b0712d06b8
+#: ../../source/projects/upgrade-notebook.rst:23
+msgid ""
+"The Jupyter Notebook used to be called the IPython Notebook. If you are "
+"running an older version of the IPython Notebook (version 3 or earlier) "
+"you can use the following to upgrade to the latest version of the Jupyter"
+" Notebook."
+msgstr ""
+
+# d88146b35caa48739050570489690ea2
+#: ../../source/projects/upgrade-notebook.rst:34
+msgid "*or*"
+msgstr ""
+
+# e5a0f0b2480d4d288496520262d1b1f5
+#: ../../source/projects/upgrade-notebook.rst:36
+msgid "If using :term:`pip`:"
+msgstr ""
+
+# f3af7fac60674d649aee3681c819a3f8
+#: ../../source/projects/upgrade-notebook.rst:46
+msgid ""
+"The :ref:`migrating <migrating>` document has additional information "
+"about migrating from IPython 3 to Jupyter."
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/reference.po
+++ b/docs/source/locale/en/LC_MESSAGES/reference.po
@@ -1,0 +1,79 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 4186a713d84a4c2b806a912fb2becfc9
+#: ../../source/reference/content-reference.rst:2
+msgid "Reference"
+msgstr ""
+
+# 47d932f599ef4dc1a3fce9d83d3e7bc4
+#: ../../source/reference/content-reference.rst:12
+msgid "Resources"
+msgstr ""
+
+# 23b33a4ebf624f9f8ac3989d8fb30bd8
+#: ../../source/reference/content-reference.rst:14
+msgid ":ref:`genindex`"
+msgstr ""
+
+# fdf2e34429ec43cfa4182e18d95e3546
+#: ../../source/reference/content-reference.rst:15
+msgid ":ref:`search`"
+msgstr ""
+
+# 1af8e86e71ef4cdfa9a78a51877391cc
+#: ../../source/reference/mimetype.md:1
+msgid "Custom mimetypes (MIME types)"
+msgstr ""
+
+# 42772fdb996b48deb68314fc87c61069
+#: ../../source/reference/mimetype.md:4
+msgid "What's a mimetype?"
+msgstr ""
+
+# b4587f2848af4bb6bedc27fc5478e0e1
+#: ../../source/reference/mimetype.md:6
+msgid ""
+"When an internet request and response occurs, a Content-Type header is "
+"passed. A mimetype, also referred to as MIME type, identifies how the "
+"content that is being returned should be handled or used, based on type, "
+"by the application and browser. A MIME type is made up of a MIME group "
+"(i.e. application, image, audio, etc.) and a MIME subtype. For example, a"
+" MIME type is image/png where MIME group is image and subtype is png."
+msgstr ""
+
+# 45992d4e958c48eeade184b7bf32f2a1
+#: ../../source/reference/mimetype.md:13
+msgid ""
+"As types may contain vendor specific items, a custom vendor specific MIME"
+" type, vnd, can be used. A vendor specific MIME type will contain vnd "
+"such as application/vnd.jupyter.cells."
+msgstr ""
+
+# 197f07f4e1a64a4abeaae091b0bc2bcd
+#: ../../source/reference/mimetype.md:19
+msgid "Custom mimetypes used in Jupyter and IPython projects"
+msgstr ""
+
+# e9b912b57b8149408f2ac38653e37ccf
+#: ../../source/reference/mimetype.md:29
+msgid "Listing of custom mimetypes used for display"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/releases.po
+++ b/docs/source/locale/en/LC_MESSAGES/releases.po
@@ -1,0 +1,44 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 999687e2672c4830be8be849ba17fdd8
+#: ../../source/releases/content-releases.rst:2
+msgid "Release Notes"
+msgstr ""
+
+# f2e5171237034eeeafdd4917d74a1fdb
+#: ../../source/releases/content-releases.rst:4
+msgid ""
+"Each project's documentation and GitHub repository has information about "
+"releases and changes from the prior release."
+msgstr ""
+
+# b6a439cd2ee94119bbd0f928c111ccda
+#: ../../source/releases/content-releases.rst:7
+msgid "Coming Soon"
+msgstr ""
+
+# eb314f1a6b1c47b8b4aaf0281c3f1c94
+#: ../../source/releases/content-releases.rst:9
+msgid ""
+"We're actively working on a graphic that displays each project, their "
+"current release, and a link to the changelog. Thanks for your patience."
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/running.po
+++ b/docs/source/locale/en/LC_MESSAGES/running.po
@@ -1,0 +1,153 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 034fbf47daca43d69d2f69db956f0925
+#: ../../source/running.rst:5
+msgid "Running the Notebook"
+msgstr ""
+
+# 0f84d33b57f44a6c866def4270ab75d4
+#: ../../source/running.rst:9
+msgid "Contents"
+msgstr ""
+
+# de423761fe414a8bb5c042ffafd69e67
+#: ../../source/running.rst:12
+msgid "Basic Steps"
+msgstr ""
+
+# 772caec806c34073bc157412767069c3
+#: ../../source/running.rst:14
+msgid "Start the notebook server from the :term:`command line`::"
+msgstr ""
+
+# 381fc8c07c8d4b12907dece1a9391603
+#: ../../source/running.rst:18
+msgid "You should see the notebook open in your browser."
+msgstr ""
+
+# 5b2da16c94e74d859ce8055fdce8aeb6
+#: ../../source/running.rst:21
+msgid "Starting the Notebook Server"
+msgstr ""
+
+# 81d1855aa3064e38a5145051195be5ce
+#: ../../source/running.rst:23
+msgid ""
+"After you have installed the Jupyter Notebook on your computer, you are "
+"ready to run the notebook server. You can start the notebook server from "
+"the :term:`command line` (using :term:`Terminal` on Mac/Linux, "
+":term:`Command Prompt` on Windows) by running::"
+msgstr ""
+
+# 178e1601d2154fc198cd68d6167cb4ee
+#: ../../source/running.rst:30
+msgid ""
+"This will print some information about the notebook server in your "
+"terminal, including the URL of the web application (by default, "
+"``http://localhost:8888``):"
+msgstr ""
+
+# 2499df7720c9421eaf3671e9c9a7e4b7
+#: ../../source/running.rst:42
+msgid "It will then open your default web browser to this URL."
+msgstr ""
+
+# f9ca618037bf469490a7fc5a2e793ebf
+#: ../../source/running.rst:44
+msgid ""
+"When the notebook opens in your browser, you will see the :term:`Notebook"
+" Dashboard`, which will show a list of the notebooks, files, and "
+"subdirectories in the directory where the notebook server was started. "
+"Most of the time, you will wish to start a notebook server in the highest"
+" level directory containing notebooks. Often this will be your home "
+"directory."
+msgstr ""
+
+# dc50f37acb364b30924ee135608f01e4
+#: ../../source/running.rst:50
+msgid "**Notebook Dashboard**"
+msgstr ""
+
+# 1cd18ab0da2945bbaefbe684313b04a0
+#: ../../source/running.rst:55
+msgid "Introducing the Notebook Server's Command Line Options"
+msgstr ""
+
+# 6e674cad5104461aa03097ede9bb7b7f
+#: ../../source/running.rst:58
+msgid "How do I open a specific Notebook?"
+msgstr ""
+
+# dfbad8a998c7422ca95f3c2a41fb3964
+#: ../../source/running.rst:60
+msgid ""
+"The following code should open the given notebook in the currently "
+"running notebook server, starting one if necessary."
+msgstr ""
+
+# 57ba78a74c634ad5a2709e1cc3bbe370
+#: ../../source/running.rst:67
+msgid "How do I start the Notebook using a custom IP or port?"
+msgstr ""
+
+# 425d27eeb2084312960454783a563cdd
+#: ../../source/running.rst:69
+msgid ""
+"By default, the notebook server starts on port 8888. If port 8888 is "
+"unavailable or in use, the notebook server searches the next available "
+"port. You may also specify a port manually. In this example, we set the "
+"server's port to 9999:"
+msgstr ""
+
+# e4bf6e61b19a4c33b6aff46cf9e29eaf
+#: ../../source/running.rst:79
+msgid "How do I start the Notebook server without opening a browser?"
+msgstr ""
+
+# 56643f36db0446c38012f871fbabf0d7
+#: ../../source/running.rst:81
+msgid "Start notebook server without opening a web browser:"
+msgstr ""
+
+# 265b6dcd97d4439eaa5fb4436fcf1189
+#: ../../source/running.rst:88
+msgid "How do I get help about Notebook server options?"
+msgstr ""
+
+# ec00daf0abd7419d8fae626b3ea49805
+#: ../../source/running.rst:90
+msgid ""
+"The notebook server provides help messages for other command line "
+"arguments using the ``--help`` flag:"
+msgstr ""
+
+# b21136ba910742b9b9ecaccaa257051b
+#: ../../source/running.rst:99
+msgid ":ref:`Jupyter Installation, Configuration, and Usage <content-projects>`"
+msgstr ""
+
+# aece793a237545f9817252206a46e633
+#: ../../source/running.rst:100
+msgid ""
+"Detailed information about command line arguments, configuration, and "
+"usage."
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/sphinx.po
+++ b/docs/source/locale/en/LC_MESSAGES/sphinx.po
@@ -1,0 +1,283 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 20:11-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 7c11dbc4811f481794057766800832ee
+#: ../../source/_templates/index.html:2
+msgid "Overview"
+msgstr ""
+
+# 87674d21ac2842d9b2ca32525a06983c
+#: ../../source/_templates/index.html:4
+msgid "Welcome"
+msgstr ""
+
+# fbe326ee1913477fbbef9e36280cb3d5
+#: ../../source/_templates/index.html:7
+msgid "Start Here"
+msgstr ""
+
+# dd871a3570ef4360993c9f5f9a6e9a6f
+#: ../../source/_templates/index.html:13
+msgid "Jupyter Notebook Quickstart"
+msgstr ""
+
+# 5b38b22813c440bda17aa0cb1015468a
+#: ../../source/_templates/index.html:14
+msgid "Try the notebook"
+msgstr ""
+
+# e24d669c50e84c10a9b7d2db8e2a206b
+#: ../../source/_templates/index.html:15
+msgid "Architecture"
+msgstr ""
+
+# 666d449fc8564f81951df06fb28f857b
+#: ../../source/_templates/index.html:16
+msgid "What is Jupyter?"
+msgstr ""
+
+# b73a8286763d448c8e471e7c19863f07
+#: ../../source/_templates/index.html:17
+msgid "Narratives and Use Cases"
+msgstr ""
+
+# 27c32a3a5ae34fba8a569bee972dc21a
+#: ../../source/_templates/index.html:18
+msgid "Narratives of common deployment scenarios"
+msgstr ""
+
+# 073c45ea86594cad8be3d011b9b3b5ed
+# 209be84e7b1c48b59ed8ad4f4ba9bd9e
+# e68ee3bc1d344ea892e96b9a0c557ec4
+#: ../../source/_templates/index.html:19 ../../source/_templates/index.html:61
+#: ../../source/_templates/index.html:67
+msgid "IPython"
+msgstr ""
+
+# fa896a9ecf334ec59243584de08ebc4c
+#: ../../source/_templates/index.html:20
+msgid "An interactive Python kernel and REPL"
+msgstr ""
+
+# d8bfcdc723ba4ff9be620bc7a48c9bbb
+#: ../../source/_templates/index.html:21
+msgid "Installation, Configuration, and Usage"
+msgstr ""
+
+# b85884536fe94bbbb0bc361199515e97
+#: ../../source/_templates/index.html:22
+msgid "Documentation for users"
+msgstr ""
+
+# 187c62af4f4946368cc1912dc4ed72bd
+#: ../../source/_templates/index.html:25
+msgid "Community"
+msgstr ""
+
+# 01be44444a6944f8b66f5d33ecada473
+#: ../../source/_templates/index.html:26
+msgid "Sustainability and growth"
+msgstr ""
+
+# 1c7430b771f34dea888a279f5159cfd1
+#: ../../source/_templates/index.html:27
+msgid "Contributor Guides"
+msgstr ""
+
+# 060fa8d986484cc5920822becdc72633
+#: ../../source/_templates/index.html:28
+msgid "How to contribute to the projects"
+msgstr ""
+
+# 4a62e635396944ce8ac3b0a846bee09c
+#: ../../source/_templates/index.html:29
+msgid "Release Notes"
+msgstr ""
+
+# e008293ddb6c4b84ba2ae3c01af0ddd8
+#: ../../source/_templates/index.html:30
+msgid "New features, upgrades, deprecation notes, and bug fixes"
+msgstr ""
+
+# 632f425094284248a3904601833d3282
+#: ../../source/_templates/index.html:31
+msgid "Reference"
+msgstr ""
+
+# 60a7fa2b852447948397bee452574352
+#: ../../source/_templates/index.html:32
+msgid "APIs"
+msgstr ""
+
+# 078a4e5b447d464f980c754d79bd0d8f
+#: ../../source/_templates/index.html:33
+msgid "Contents"
+msgstr ""
+
+# fe624220d72f4eb68b635b704ce7857d
+#: ../../source/_templates/index.html:34
+msgid "Full table of contents"
+msgstr ""
+
+# fd469284c910443c9a94f1e5c2890809
+#: ../../source/_templates/index.html:40
+msgid "Project Documentation"
+msgstr ""
+
+# 82990c9abe5a481b8e029e99d56eda97
+#: ../../source/_templates/index.html:45
+msgid "Jupyter Notebook"
+msgstr ""
+
+# 0fa103f6933a4fae8e861337f0dc4dfe
+#: ../../source/_templates/index.html:46
+msgid "Jupyter console"
+msgstr ""
+
+# aeecc22f41504fa78c3e6bc2a5918062
+#: ../../source/_templates/index.html:47
+msgid "Qt console"
+msgstr ""
+
+# e58d1a93d24a4dffb852da36feb32d2d
+#: ../../source/_templates/index.html:49
+msgid "JupyterHub"
+msgstr ""
+
+# b8c2f78b5e064757a6f7fd58b7a47d83
+#: ../../source/_templates/index.html:50
+msgid "configurable HTTP proxy"
+msgstr ""
+
+# 4b0500d653a140c6ae920817c825165f
+#: ../../source/_templates/index.html:51
+msgid "dockerspawner"
+msgstr ""
+
+# d6bed661873740d9b060211a971ab15e
+#: ../../source/_templates/index.html:52
+msgid "ldapauthenticator"
+msgstr ""
+
+# b00d98858cd348dc9c8aa5777c19b125
+#: ../../source/_templates/index.html:53
+msgid "oauthenticator"
+msgstr ""
+
+# a7ee2953ae3149bdbb7c6dedd24d39b4
+#: ../../source/_templates/index.html:54
+msgid "sudospawner"
+msgstr ""
+
+# 75f1af39b9134416a9c076a314298dbe
+#: ../../source/_templates/index.html:56
+msgid "nbgrader"
+msgstr ""
+
+# fc5ad0b0e7ed441ca42f9046d3d418bf
+#: ../../source/_templates/index.html:58
+msgid "nbconvert"
+msgstr ""
+
+# d2e632b13f7a4336814338eed74f44fb
+#: ../../source/_templates/index.html:59
+msgid "nbformat"
+msgstr ""
+
+# 5e25a71dee6f4ba6a9798efa502a8636
+#: ../../source/_templates/index.html:62
+msgid "IRkernel"
+msgstr ""
+
+# 9cf27e2f496f472d8b31c31a8d50f93f
+#: ../../source/_templates/index.html:63
+msgid "IJulia"
+msgstr ""
+
+# a4408d07c95b4196ad698778f8f67033
+#: ../../source/_templates/index.html:64
+msgid "Community maintained kernels"
+msgstr ""
+
+# 2904cce51a98448491bb284edb4307fa
+#: ../../source/_templates/index.html:68
+msgid "ipykernel"
+msgstr ""
+
+# 6568de0311404a3a8e217053421abd97
+#: ../../source/_templates/index.html:69
+msgid "ipyparallel"
+msgstr ""
+
+# 41e36095f7f742798a17eb53fbd9e115
+#: ../../source/_templates/index.html:71
+msgid "jupyter_client"
+msgstr ""
+
+# 0829b56cf4c64e43ad26445146b01b00
+#: ../../source/_templates/index.html:72
+msgid "jupyter_core"
+msgstr ""
+
+# 443f2d6d97e94855a386370356e7d859
+#: ../../source/_templates/index.html:74
+msgid "docker-stacks"
+msgstr ""
+
+# 1ce3fe422ec24231abd162189e6a1b84
+#: ../../source/_templates/index.html:75
+msgid "ipywidgets"
+msgstr ""
+
+# 6523ea7d2bfd43b99a6f08b105fb0e50
+#: ../../source/_templates/index.html:76
+msgid "jupyter-drive"
+msgstr ""
+
+# f01bf4a28b1c4ac8bdf4d8a13cfdae5e
+#: ../../source/_templates/index.html:77
+msgid "jupyter-sphinx-theme"
+msgstr ""
+
+# 744f8e6f66474cf4bee3f3bed2f28750
+#: ../../source/_templates/index.html:78
+msgid "kernel_gateway"
+msgstr ""
+
+# e74b30a13ebd473c89b8678769cc6e14
+#: ../../source/_templates/index.html:79
+msgid "nbviewer"
+msgstr ""
+
+# 3465cff3b57a4f3d87d71548f0b523b8
+#: ../../source/_templates/index.html:80
+msgid "tmpnb"
+msgstr ""
+
+# a89a262455e04f8881482759567c34f5
+#: ../../source/_templates/index.html:81
+msgid "traitlets"
+msgstr ""
+
+# c319a5d418a24253ba83ff826d666716
+#: ../../source/_templates/index.html:83
+msgid "jupyter-js-services"
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/tryjupyter.po
+++ b/docs/source/locale/en/LC_MESSAGES/tryjupyter.po
@@ -1,0 +1,62 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# aac44b6e1fec4f468a8d726af2e658a1
+#: ../../source/tryjupyter.rst:5
+msgid "Try Jupyter"
+msgstr ""
+
+# 3a668d6e2d0c48e1a9edb05dccda1893
+#: ../../source/tryjupyter.rst:8
+msgid "Contents"
+msgstr ""
+
+# 69cbf5beb07e43cbb0ca9eb9fa01a78e
+#: ../../source/tryjupyter.rst:11
+msgid "Try in Your Browser. No Installation Needed."
+msgstr ""
+
+# 4a876c620c274d63abade59bdfd082a3
+#: ../../source/tryjupyter.rst:13
+msgid "Go to https://try.jupyter.org. No installation is needed."
+msgstr ""
+
+# 3dfbe1fd06a44fc8be1b057fa7a62b43
+#: ../../source/tryjupyter.rst:15
+msgid "**Notebook Dashboard**"
+msgstr ""
+
+# 6b4e878bb42947ef8919b89bc6217086
+#: ../../source/tryjupyter.rst:19
+msgid "**Notebook Editor**"
+msgstr ""
+
+# 8c70aa16e8b54e769815667cf4b4b4da
+#: ../../source/tryjupyter.rst:25
+msgid "Are You Ready to Install Jupyter?"
+msgstr ""
+
+# 11a41db69b334abfb7687cfe4721da14
+#: ../../source/tryjupyter.rst:27
+msgid ""
+"If you have tried Jupyter and like it, please use our detailed "
+":ref:`Installation Guide <install>` to install Jupyter on your computer."
+msgstr ""
+

--- a/docs/source/locale/en/LC_MESSAGES/use-cases.po
+++ b/docs/source/locale/en/LC_MESSAGES/use-cases.po
@@ -1,0 +1,373 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# c7a3e6ef18974fdf9970ec0c8cf6b1a4
+#: ../../source/use-cases/content-user.rst:2
+msgid "Narratives and Use Cases"
+msgstr ""
+
+# 74a57ce9257b4dcf8cd496659310f050
+#: ../../source/use-cases/content-user.rst:5
+msgid "What are Narratives?"
+msgstr ""
+
+# 4d5ab784c1c0495a953ec916572ab868
+#: ../../source/use-cases/content-user.rst:6
+msgid ""
+"Narratives are *collaborative*, *shareable*, *publishable*, and "
+"*reproducible*. We believe that Narratives help both yourself and other "
+"researchers by sharing your use of Jupyter projects, technical specifics "
+"of your deployment, and installation and configuration tips so that "
+"others can learn from your experiences."
+msgstr ""
+
+# 38991fbc6546442fac82338471a16196
+#: ../../source/use-cases/data_science.rst:5
+msgid "Jupyter for Data Science"
+msgstr ""
+
+# 9b4934127359431a8eae07c4e6d35177
+#: ../../source/use-cases/data_science.rst:7
+msgid ""
+"The purpose of this page is to highlight kernels and other projects that "
+"are central to the usage of Jupyter in data science. This page is not "
+"meant to be comprehensive or unbiased, but rather to provide an "
+"opinionated view of the usage of Jupyter in data science based on our "
+"interactions with users."
+msgstr ""
+
+# 79646aee3a3a4e799435131c32b9fa38
+#: ../../source/use-cases/data_science.rst:12
+msgid "The following Jupyter kernels are widely used in data science:"
+msgstr ""
+
+# 61a8d058c87947fcb61ad48ca8b85c1c
+#: ../../source/use-cases/data_science.rst:14
+msgid "python"
+msgstr ""
+
+# e1ab9a92301d44bbb0e3792b6ed0490d
+#: ../../source/use-cases/data_science.rst:15
+msgid "IPython (`GitHub Repo <https://github.com/ipython/ipykernel>`__)"
+msgstr ""
+
+# 0d1a6ecffddc475596df6bc7d7ab6ac9
+#: ../../source/use-cases/data_science.rst:18
+msgid "R"
+msgstr ""
+
+# b617b75cdf6b4f09bd81a46e54f67b4c
+#: ../../source/use-cases/data_science.rst:17
+msgid ""
+"IRkernel (`Documentation <https://irkernel.github.io/>`__, `GitHub Repo "
+"<https://github.com/IRkernel/IRkernel>`__)"
+msgstr ""
+
+# 6c033e0b10c943c7b1d015a324bd5043
+#: ../../source/use-cases/data_science.rst:18
+msgid "IRdisplay (`GitHub Repo <https://github.com/IRkernel/IRdisplay>`__)"
+msgstr ""
+
+# b5577205b7ea4a5e863601eedc8826fc
+#: ../../source/use-cases/data_science.rst:19
+msgid "repr (`GitHub Repo <https://github.com/IRkernel/repr>`__)"
+msgstr ""
+
+# e204fea1f5694325a9ebb16297f8efff
+#: ../../source/use-cases/data_science.rst:21
+msgid "Julia"
+msgstr ""
+
+# aee5a4b089b04f0080ad7ba2a1f5031f
+#: ../../source/use-cases/data_science.rst:21
+msgid "IJulia Kernel (`GitHub Repo <https://github.com/JuliaLang/IJulia.jl>`__)"
+msgstr ""
+
+# 7bbb9b36f2f84459aef3fb97869ce6b9
+#: ../../source/use-cases/data_science.rst:22
+msgid ""
+"Interactive Widgets (`GitHub Repo "
+"<https://github.com/JuliaLang/Interact.jl>`__)"
+msgstr ""
+
+# 1b6b2ad9e6f3428dbf5172927a9169a9
+#: ../../source/use-cases/data_science.rst:23
+msgid "Bash (`GitHub Repo <https://github.com/takluyver/bash_kernel>`__)"
+msgstr ""
+
+# 37b3885a41144745a83ca6b4cd08778e
+#: ../../source/use-cases/education.rst:2
+msgid "Jupyter in Education"
+msgstr ""
+
+# 537dc039d5b140bdaf1f53e9a7e508ab
+# d387c0b434c84dd2842f3f53e48eaca9
+# 51f6e28c5aae4489afff3acfd1033f00
+# 5824e4f59f5a48a5a8441ea228e71850
+# ad1ed25e378745da95f1815cc1a9c5ca
+#: ../../source/use-cases/education.rst:5
+#: ../../source/use-cases/narrative-hub.rst:29
+#: ../../source/use-cases/narrative-notebook.rst:24
+#: ../../source/use-cases/narrative-other.rst:23
+#: ../../source/use-cases/science.rst:5
+msgid ""
+"We're actively working on this section of the documentation to improve it"
+" for you. Thanks for your patience."
+msgstr ""
+
+# e5ea9daf28014d91919d78648a1a3c6c
+#: ../../source/use-cases/enterprise.rst:5
+msgid "Jupyter in the Enterprise"
+msgstr ""
+
+# e6075014f1a94cb08daccbf89fa4bf7e
+# 0d285e91e9e34a579165b524a3bc024e
+# 04b5bb4dfe2d49c7bcbeb444bd97a735
+# 45567a5466db4b78905ff14d59ede989
+#: ../../source/use-cases/enterprise.rst:8
+#: ../../source/use-cases/narrative-hub.rst:5
+#: ../../source/use-cases/narrative-notebook.rst:5
+#: ../../source/use-cases/narrative-other.rst:5
+msgid "Contents"
+msgstr ""
+
+# 0192beb23b4842a0a1e6cb765973592b
+# aca370754a0b41dbaba092dd77a3f385
+# 9d431db72aa14375914f90b6b7e2d86f
+# 0e0b9dc725fc4c6da2f26d04f88f70a6
+#: ../../source/use-cases/enterprise.rst:11
+#: ../../source/use-cases/narrative-hub.rst:8
+#: ../../source/use-cases/narrative-notebook.rst:8
+#: ../../source/use-cases/narrative-other.rst:8
+msgid "Description"
+msgstr ""
+
+# 4d5b3832ecb24a678ed06238e69a35b8
+#: ../../source/use-cases/enterprise.rst:13
+msgid ""
+"Businesses, especially those that started their ‘digital transformation’ "
+"journey, are producing ever-increasing volumes of data. Enterprise data "
+"science aims to unearth the hidden value of those digital assets, which "
+"are typically siloed, uncategorized, and inaccessible to humans."
+msgstr ""
+
+# e9407a7e2195481583ac70537e535b51
+#: ../../source/use-cases/enterprise.rst:17
+msgid ""
+"Jupyter and JupyterHub can play a major role in related initiatives, "
+"especially in companies with an established open-source culture. The "
+"intent of this page is to provide you with ideas how Jupyter technology "
+"can fit into *your* organization's processes and system landscapes, by "
+"providing real-world examples and showcases."
+msgstr ""
+
+# 92f850f3933a4c82972254363d00920d
+#: ../../source/use-cases/enterprise.rst:24
+msgid "Example Use-Cases"
+msgstr ""
+
+# 1124b2efb8e5441a9bae96db904a4d13
+#: ../../source/use-cases/enterprise.rst:26
+msgid ""
+"`Beyond Interactive: Notebook Innovation at Netflix <https://medium.com"
+"/netflix-techblog/notebook-innovation-591ee3221233>`_"
+msgstr ""
+
+# a032d148013249c19a4b7997d144d6e5
+#: ../../source/use-cases/enterprise.rst:28
+msgid ""
+"`Part 2: Scheduling Notebooks at Netflix <https://medium.com/netflix-"
+"techblog/scheduling-notebooks-348e6c14cfd6>`_"
+msgstr ""
+
+# 3ea08bce807d455c97b4e99507bf7bc1
+#: ../../source/use-cases/enterprise.rst:30
+msgid ""
+"`PayPal Notebooks: Data science and machine learning at scale, powered by"
+" Jupyter <https://conferences.oreilly.com/jupyter/jup-"
+"ny/public/schedule/detail/68405>`_ (JupyterCon 2018 · `video "
+"<https://youtu.be/KVGrACWVUgE>`_)"
+msgstr ""
+
+# 12d4de71971e4485aa5f391ea154dd5f
+#: ../../source/use-cases/enterprise.rst:32
+msgid "Bloomberg BQuant platform:"
+msgstr ""
+
+# b8efa7cb7d964b33a93f5f889328f5e9
+#: ../../source/use-cases/enterprise.rst:34
+msgid "`Part 1: Overview <https://adrian-gao.com/2018/02/bloomberg-bqnt-1/>`_"
+msgstr ""
+
+# ec673432d6994bbca5bcd2e8703688d3
+#: ../../source/use-cases/enterprise.rst:35
+msgid "`Part 2: The BQNT App <https://adrian-gao.com/2018/04/bloomberg-bqnt-2/>`_"
+msgstr ""
+
+# a5be50b562b649af8ab4406992e4e1cb
+#: ../../source/use-cases/enterprise.rst:37
+msgid ""
+"`Jupyter & Python in the corporate LAN "
+"<https://medium.com/@olivier.borderies/jupyter-python-in-the-corporate-"
+"lan-109e2ffde897>`_"
+msgstr ""
+
+# 6319bc990dcd4dca8a8d84f86ed2742e
+#: ../../source/use-cases/enterprise.rst:39
+msgid ""
+"`DevOps Intelligence with JupyterHub "
+"<https://nbviewer.jupyter.org/github/jhermann/jupyter-by-"
+"example/blob/master/complete-scenarios/devops-intelligence.ipynb>`_"
+msgstr ""
+
+# 9684506604dc48f8bf0349b784ab1317
+#: ../../source/use-cases/enterprise.rst:43
+msgid ""
+"We're actively working on this section of the documentation to improve it"
+" for you. If you've got a suggestion for a resource that would be "
+"helpful, please create an issue or a pull request!"
+msgstr ""
+
+# a2f2ed36e51e49eb8e0dafad92b083dd
+#: ../../source/use-cases/narrative-hub.rst:2
+msgid "JupyterHub Narratives"
+msgstr ""
+
+# 5fd29ccb39f546d3b5c56980d35d5443
+#: ../../source/use-cases/narrative-hub.rst:10
+msgid ""
+"JupyterHub Narratives explore deployment and scaling of the Jupyter "
+"Notebook for a group of users. JupyterHub allows flexibility in "
+"configuration and deployment which makes JupyterHub valuable to "
+"education, industry research teams, and service providers. In these "
+"Narratives, we will look at differences in deployment, deployment "
+"advantages, and best practices."
+msgstr ""
+
+# 6a00f5a8c10b4becba9ae2de4e09920d
+# d11d3f4bb4654347884f0e30aeff7efc
+# 93f4d0e4bb044d388ee7e9568d0351c6
+#: ../../source/use-cases/narrative-hub.rst:17
+#: ../../source/use-cases/narrative-notebook.rst:14
+#: ../../source/use-cases/narrative-other.rst:15
+msgid "Narrative examples"
+msgstr ""
+
+# 37667e2cc4db44b7840b61219286817c
+#: ../../source/use-cases/narrative-hub.rst:19
+msgid "A basic JupyterHub deployment"
+msgstr ""
+
+# 9efafc8059f74b20a96a0f2cf057b7ba
+#: ../../source/use-cases/narrative-hub.rst:20
+msgid ""
+"A `reference deployment of JupyterHub using Docker "
+"<https://github.com/jupyterhub/jupyterhub-deploy-docker>`_"
+msgstr ""
+
+# 83e972a4838b45b985c3795f51d91325
+#: ../../source/use-cases/narrative-hub.rst:21
+msgid ""
+"Teaching a Course with JupyterHub and nbgrader using a `reference "
+"deployment on a single server and Ansible scripts "
+"<https://github.com/jupyterhub/jupyterhub-deploy-teaching>`_ to automate "
+"set up"
+msgstr ""
+
+# bc90954a01844a18aabe588e48560982
+#: ../../source/use-cases/narrative-hub.rst:24
+msgid "Teaching a Course with JupyterHub, nbgrader, and containers"
+msgstr ""
+
+# a63a5a9c78b541d39c2ca4a324bfa928
+#: ../../source/use-cases/narrative-hub.rst:25
+msgid "JupyterHub deployments using Containers including Docker"
+msgstr ""
+
+# 1eaed5aeb1c44f48907382a9aa29974f
+#: ../../source/use-cases/narrative-notebook.rst:2
+msgid "Notebook Narratives"
+msgstr ""
+
+# 97653c247b5542f3a630af8650f8bc2a
+#: ../../source/use-cases/narrative-notebook.rst:10
+msgid ""
+"The Notebook Narratives explore uses of the Jupyter Notebook in a variety"
+" of applications."
+msgstr ""
+
+# 5f19fbc7dd8449e4aa030e5c901b4333
+#: ../../source/use-cases/narrative-notebook.rst:16
+msgid "Using the Notebook for data exploration"
+msgstr ""
+
+# 83ddeff477bb456599fe4d3361ef91f2
+#: ../../source/use-cases/narrative-notebook.rst:17
+msgid "Using extensions and widgets"
+msgstr ""
+
+# aa06224177374fe7ab21442a4e3f0e72
+#: ../../source/use-cases/narrative-notebook.rst:18
+msgid "Using nbconvert for code execution and workflow simplification"
+msgstr ""
+
+# 53697b1c3430469484f08a5b162b5f5e
+#: ../../source/use-cases/narrative-notebook.rst:19
+msgid "Using nbconvert for publishing"
+msgstr ""
+
+# 9a1429ea23d141af91a1c12036e2d00e
+#: ../../source/use-cases/narrative-notebook.rst:20
+msgid "Using multiple language kernels"
+msgstr ""
+
+# 8ccaa5dcc48c4ce1af5b541d84bc5402
+#: ../../source/use-cases/narrative-other.rst:2
+msgid "Narratives - Building blocks"
+msgstr ""
+
+# fd119e2d9ecb43c4814df9aa194455f7
+#: ../../source/use-cases/narrative-other.rst:10
+msgid ""
+"This section presents some examples of integrating different projects "
+"together. These projects form the foundation of innovative services and "
+"provide building blocks for future applications."
+msgstr ""
+
+# f9eee5e4fc7445408ff13eaa508df0cf
+#: ../../source/use-cases/narrative-other.rst:17
+msgid "A Narrative about Creating Dashboards"
+msgstr ""
+
+# f4349de4a38643859d8c319858ea9a86
+#: ../../source/use-cases/narrative-other.rst:18
+msgid "A Narrative about Thebe"
+msgstr ""
+
+# 7f4210300d32495db6891fdfb61bce00
+#: ../../source/use-cases/narrative-other.rst:19
+msgid "A Narrative about Hydrogen"
+msgstr ""
+
+# fe891df6078e4c7995cb79e020549cda
+#: ../../source/use-cases/science.rst:2
+msgid "Jupyter and Scientific Computing"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/architecture.po
+++ b/docs/source/locale/es/LC_MESSAGES/architecture.po
@@ -1,0 +1,252 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 0bc823304e0d4ab39f2774b29044df9b
+#: ../../source/architecture/content-architecture.rst:2
+msgid "Architecture Guides"
+msgstr ""
+
+# 8ce5c1bb3b244604b361cd2384066f68
+#: ../../source/architecture/how_jupyter_ipython_work.rst:2
+msgid "How IPython and Jupyter Notebook work"
+msgstr ""
+
+# 242c15d658d64a13a2b8b13502845298
+#: ../../source/architecture/how_jupyter_ipython_work.rst:5
+msgid "Contents"
+msgstr ""
+
+# a7b9fc6771f845528e8f7135c51754fa
+#: ../../source/architecture/how_jupyter_ipython_work.rst:8
+msgid "Abstract"
+msgstr ""
+
+# 3b9b38491da4493b95225b77bcd32438
+#: ../../source/architecture/how_jupyter_ipython_work.rst:9
+msgid ""
+"This section focuses on IPython and Jupyter notebook and how they "
+"interact. When we discuss ``IPython``, we talk about two fundamental "
+"roles:"
+msgstr ""
+
+# 676993980a9e4a9082f9f313e09af108
+#: ../../source/architecture/how_jupyter_ipython_work.rst:12
+msgid "Terminal IPython as the familiar REPL"
+msgstr ""
+
+# 5164fcd91a8a4700ac734562245773ad
+#: ../../source/architecture/how_jupyter_ipython_work.rst:13
+msgid ""
+"The IPython kernel that provides computation and communication with the "
+"frontend interfaces, like the notebook"
+msgstr ""
+
+# e79b4b9cf0d4461e8c91e35c54941346
+#: ../../source/architecture/how_jupyter_ipython_work.rst:16
+msgid ""
+"Jupyter Notebook and its flexible interface extends the notebook beyond "
+"code to visualization, multimedia, collaboration, and more."
+msgstr ""
+
+# f0e8484a13374e5ba11bc5673feecc30
+#: ../../source/architecture/how_jupyter_ipython_work.rst:20
+msgid "Terminal IPython"
+msgstr ""
+
+# d52946417b8a4a04a551622ce78e0c78
+#: ../../source/architecture/how_jupyter_ipython_work.rst:22
+msgid ""
+"When you type ``ipython``, you get the original IPython interface, "
+"running in the terminal. It does something like this::"
+msgstr ""
+
+# 9c51878d67554820815080da49295cb3
+#: ../../source/architecture/how_jupyter_ipython_work.rst:29
+msgid ""
+"Of course, it's much more complex, because it has to deal with multi-line"
+" code, tab completion using :mod:`readline`, magic commands, and so on. "
+"But the model is like code example: prompt the user for some code, and "
+"when they've entered it, execute it in the same process. This model is "
+"often called a :term:`REPL`, or Read-Eval-Print-Loop."
+msgstr ""
+
+# 6948d86fd4fd47a1a4ca54d29e72d46e
+#: ../../source/architecture/how_jupyter_ipython_work.rst:36
+msgid "The IPython Kernel"
+msgstr ""
+
+# 61f9b43b0f3148a1b6c8c770dbe95970
+#: ../../source/architecture/how_jupyter_ipython_work.rst:38
+msgid ""
+"All the other interfaces —- the Notebook, the Qt console, ``ipython "
+"console`` in the terminal, and third party interfaces —- use the IPython "
+"Kernel. The IPython Kernel is a separate process which is responsible for"
+" running user code, and things like computing possible completions. "
+"Frontends, like the notebook or the Qt console, communicate with the "
+"IPython Kernel using JSON messages sent over `ZeroMQ "
+"<http://zeromq.org/>`_ sockets; the protocol used between the frontends "
+"and the IPython Kernel is described in :ref:`jupyterclient:messaging`."
+msgstr ""
+
+# 6560f963da914c78b12c61e8795a9852
+#: ../../source/architecture/how_jupyter_ipython_work.rst:47
+msgid ""
+"The core execution machinery for the kernel is shared with terminal "
+"IPython:"
+msgstr ""
+
+# b5bd0a2f608542fe92f8b57ddcb9ea7b
+#: ../../source/architecture/how_jupyter_ipython_work.rst:51
+msgid ""
+"A kernel process can be connected to more than one frontend "
+"simultaneously. In this case, the different frontends will have access to"
+" the same variables."
+msgstr ""
+
+# 59dd6f3fbb4a46008c898b307aec5a25
+#: ../../source/architecture/how_jupyter_ipython_work.rst:56
+msgid ""
+"This design was intended to allow easy development of different frontends"
+" based on the same kernel, but it also made it possible to support new "
+"languages in the same frontends, by developing kernels in those "
+"languages, and we are refining IPython to make that more practical."
+msgstr ""
+
+# e35918a2fb124784a83c135812faf800
+#: ../../source/architecture/how_jupyter_ipython_work.rst:61
+msgid ""
+"Today, there are two ways to develop a kernel for another language. "
+"Wrapper kernels reuse the communications machinery from IPython, and "
+"implement only the core execution part. Native kernels implement "
+"execution and communications in the target language:"
+msgstr ""
+
+# 3395f44193b54f5cb9b9d380fa4a16bd
+#: ../../source/architecture/how_jupyter_ipython_work.rst:68
+msgid ""
+"Wrapper kernels are easier to write quickly for languages that have good "
+"Python wrappers, like `octave_kernel "
+"<https://pypi.python.org/pypi/octave_kernel>`_, or languages where it's "
+"impractical to implement the communications machinery, like `bash_kernel "
+"<https://pypi.python.org/pypi/bash_kernel>`_. Native kernels are likely "
+"to be better maintained by the community using them, like `IJulia "
+"<https://github.com/JuliaLang/IJulia.jl>`_ or `IHaskell "
+"<https://github.com/gibiansky/IHaskell>`_."
+msgstr ""
+
+# 59d8323c382a4adeb3d622424943b708
+#: ../../source/architecture/how_jupyter_ipython_work.rst:78
+msgid ":ref:`jupyterclient:kernels`"
+msgstr ""
+
+# 3418914ee39240879155089a0b29a69e
+#: ../../source/architecture/how_jupyter_ipython_work.rst:80
+msgid ":ref:`Kernels <kernels-langs>`"
+msgstr ""
+
+# 4866548d799b4cfc95159d7494d66afb
+#: ../../source/architecture/how_jupyter_ipython_work.rst:83
+msgid "Notebooks"
+msgstr ""
+
+# f414110d9cde4b048d6d4d0c65f274dd
+#: ../../source/architecture/how_jupyter_ipython_work.rst:85
+msgid ""
+"The Notebook frontend does something extra. In addition to running your "
+"code, it stores code and output, together with markdown notes, in an "
+"editable document called a notebook. When you save it, this is sent from "
+"your browser to the notebook server, which saves it on disk as a JSON "
+"file with a ``.ipynb`` extension."
+msgstr ""
+
+# ce4a6fb377344df295e9512b1d36743c
+#: ../../source/architecture/how_jupyter_ipython_work.rst:93
+msgid ""
+"The notebook server, not the kernel, is responsible for saving and "
+"loading notebooks, so you can edit notebooks even if you don't have the "
+"kernel for that language—you just won't be able to run code. The kernel "
+"doesn't know anything about the notebook document: it just gets sent "
+"cells of code to execute when the user runs them."
+msgstr ""
+
+# 9041dc2c7e0b46e19e1694f6bb081592
+#: ../../source/architecture/how_jupyter_ipython_work.rst:100
+msgid "Exporting notebooks to other formats"
+msgstr ""
+
+# dedd7458edfc44a99f423e2a9b8e1d93
+#: ../../source/architecture/how_jupyter_ipython_work.rst:102
+msgid ""
+"The Nbconvert tool in Jupyter converts notebook files to other formats, "
+"such as HTML, LaTeX, or reStructuredText. This conversion goes through a "
+"series of steps:"
+msgstr ""
+
+# 082ebb9d5777479da8f71672f538c484
+#: ../../source/architecture/how_jupyter_ipython_work.rst:108
+msgid ""
+"Preprocessors modify the notebook in memory. E.g. ExecutePreprocessor "
+"runs the code in the notebook and updates the output."
+msgstr ""
+
+# c6be8db7ca164f379d97800723004956
+#: ../../source/architecture/how_jupyter_ipython_work.rst:110
+msgid ""
+"An exporter converts the notebook to another file format. Most of the "
+"exporters use templates for this."
+msgstr ""
+
+# 9de2fa198489488fa316b950d1228fa3
+#: ../../source/architecture/how_jupyter_ipython_work.rst:112
+msgid "Postprocessors work on the file produced by exporting."
+msgstr ""
+
+# e00d7f3b870a40879882ee53ed417463
+#: ../../source/architecture/how_jupyter_ipython_work.rst:114
+msgid ""
+"The `nbviewer <http://nbviewer.jupyter.org/>`_ website uses nbconvert "
+"with the HTML exporter. When you give it a URL, it fetches the notebook "
+"from that URL, converts it to HTML, and serves that HTML to you."
+msgstr ""
+
+# e30efeea3614465f95ff49220796d182
+#: ../../source/architecture/how_jupyter_ipython_work.rst:119
+msgid "IPython.parallel"
+msgstr ""
+
+# 074d0dac254c44b58ea96c7b4a451d27
+#: ../../source/architecture/how_jupyter_ipython_work.rst:121
+msgid ""
+"IPython also includes a parallel computing framework, `IPython.parallel "
+"<https://ipyparallel.readthedocs.io/en/latest/>`_. This allows you to "
+"control many individual engines, which are an extended version of the "
+"IPython kernel described above."
+msgstr ""
+
+# 0118a72a2b1e4c14800c1c3dd77b6c4e
+#: ../../source/architecture/visual_overview.rst:2
+msgid "A Visual Overview of Projects"
+msgstr ""
+
+# cc1b649f66b949ebb3984ea361c9ee45
+#: ../../source/architecture/visual_overview.rst:4
+msgid "**A high level visual overview of project relationships**"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/community.po
+++ b/docs/source/locale/es/LC_MESSAGES/community.po
@@ -1,0 +1,419 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 70d1cfa46ec24e65819ddd4624a9ca6e
+#: ../../source/community/community-call-notes/2019-april.md:1
+msgid "All-Jupyter Community Video Call - April 2019"
+msgstr ""
+
+# 2f49975ac531463b8c6e2c761c400dc1
+#: ../../source/community/community-call-notes/2019-april.md:3
+msgid "Date: 30 April 2019 at 9am PST (your timezome)"
+msgstr ""
+
+# 3ff834bb5e6f4062bd88ace0a2863bdd
+# 4037dac263a44247abfb27d9873dd712
+#: ../../source/community/community-call-notes/2019-april.md:5
+#: ../../source/community/community-call-notes/2019-march.md:5
+msgid "Video-conference link: https://calpoly.zoom.us/my/jupyter"
+msgstr ""
+
+# 683dfa91bfde466eb4283e7adb0dd4d3
+# c7caa4e78e38454cb84d44620583084b
+#: ../../source/community/community-call-notes/2019-april.md:8
+#: ../../source/community/community-call-notes/2019-march.md:9
+msgid "Welcome to the Team Meeting"
+msgstr ""
+
+# 04d5ac5c03974dc3ad3024b473dd04b9
+# f796eb5b94c1489a9a5078a95e84a502
+# 678a64e0a30e4d9e8e37391ffb59c761
+#: ../../source/community/community-call-notes/2019-april.md:10
+#: ../../source/community/community-call-notes/2019-march.md:11
+#: ../../source/community/community-call-notes/2019-may.md:12
+msgid "Hello!"
+msgstr ""
+
+# 5f85661b1cfe4ac3973039ac4ba67b95
+# 4583925b76234b589f464156251e5ec0
+# bf9319f9db9a4d19970ee91c2740086f
+#: ../../source/community/community-call-notes/2019-april.md:12
+#: ../../source/community/community-call-notes/2019-march.md:13
+#: ../../source/community/community-call-notes/2019-may.md:34
+msgid ""
+"The purpose of these monthly video conference calls is to share and "
+"demonstrate the awesome things happening in Jupyter community. We invite "
+"anyone to present their work, engage in discussion, or just sit in and "
+"listen. Whether you have a new lab extension you've created, a new "
+"jupyterhub deployment you're excited about, or an nteract papermill "
+"pipeline powering your business, we'd love to hear about it! And, we'll  "
+"record and publish these calls on YouTube for anyone unable to attend."
+msgstr ""
+
+# eb8b2b49c8344b9c9f86af3e3bdd709d
+# 9bd556f607d047e8a63acd17380c885c
+# 60805fe9261f4111b779c3958058cd47
+#: ../../source/community/community-call-notes/2019-april.md:14
+#: ../../source/community/community-call-notes/2019-march.md:15
+#: ../../source/community/community-call-notes/2019-may.md:36
+msgid "For more discussion on the format of these calls, see the thread here."
+msgstr ""
+
+# 9b8670fc875040e7a301c3fa32fbc0cb
+# ee073abf726949b3b7548766058b87f9
+# 7463b23704b541d999d54d62cc43733c
+#: ../../source/community/community-call-notes/2019-april.md:16
+#: ../../source/community/community-call-notes/2019-march.md:17
+#: ../../source/community/community-call-notes/2019-may.md:38
+msgid "Short reports, celebrations, shout-outs"
+msgstr ""
+
+# b45b39d83ba8498b9e6e6201e0a0e1a3
+# 4d646269262148788ea6a42810d3598f
+# f9ba94f81af2444fb13543d874f67075
+#: ../../source/community/community-call-notes/2019-april.md:18
+#: ../../source/community/community-call-notes/2019-march.md:19
+#: ../../source/community/community-call-notes/2019-may.md:40
+msgid ""
+"This is a place to make short announcements (without a need for "
+"discussion). This is also a great place to give shout-outs to "
+"contributors! We’ll read through these at the beginning of the meeting."
+msgstr ""
+
+# 86e3c39710ba4d4687e570352ded4fa0
+# 9865f0ad138d4fe4a990ef00b514b730
+# 2a1e1ccf1a0c487da922d8dce791ffd1
+#: ../../source/community/community-call-notes/2019-april.md:32
+#: ../../source/community/community-call-notes/2019-march.md:30
+#: ../../source/community/community-call-notes/2019-may.md:48
+msgid "Agenda Items"
+msgstr ""
+
+# 53ec054add254945959fe787b4987fbb
+# 5797de76ce064ac98b3d80b2df943b4e
+#: ../../source/community/community-call-notes/2019-april.md:34
+#: ../../source/community/community-call-notes/2019-may.md:50
+msgid ""
+"Add your potential agenda item here 24 hours before the meeting at the "
+"latest. We will reorganize the agenda so that it fits in the 60m meeting "
+"slot."
+msgstr ""
+
+# bbf4c673748c458fbf4ee88129b415ab
+#: ../../source/community/community-call-notes/2019-april.md:82
+msgid "University of Edinburgh materials and contact:"
+msgstr ""
+
+# 83efbe0c91e740faa2548c87d0be912a
+# d1ad78f64d1e48d090bbcc353cade2c6
+#: ../../source/community/community-call-notes/2019-april.md:90
+#: ../../source/community/community-call-notes/2019-march.md:85
+msgid "In Attendance"
+msgstr ""
+
+# 42562fcb34704715bff217a5180cd439
+#: ../../source/community/community-call-notes/2019-april.md:92
+msgid "Name / Institution / Github Handle"
+msgstr ""
+
+# 286362fe622748019eea29d3a4524bfa
+#: ../../source/community/community-call-notes/2019-march.md:1
+msgid "All-Jupyter Community Video Call - March 2019"
+msgstr ""
+
+# d3ccd0d36a8d4ff9bf551dec59aa23bf
+#: ../../source/community/community-call-notes/2019-march.md:3
+msgid "Date: 26 March 2019 at 9am PST (your timezome)"
+msgstr ""
+
+# 2bae86b710b0411fa1380daeefcb57c4
+#: ../../source/community/community-call-notes/2019-march.md:7
+msgid "Link to prior meeting's virtual meeting report"
+msgstr ""
+
+# 9a919edea46042fda80ad5719ba42c25
+#: ../../source/community/community-call-notes/2019-march.md:83
+msgid "Don't get limitted to technical discusions !"
+msgstr ""
+
+# 6a1d536f3f6c46b2b79fcdecd6491c4c
+#: ../../source/community/community-call-notes/2019-march.md:87
+msgid "Name              | Institution             | Github Handle"
+msgstr ""
+
+# 67d530ac592947f79ea603b5ff446c15
+# b17fcf6338a54b82a41b9406cba398cb
+#: ../../source/community/community-call-notes/2019-may.md:1
+#: ../../source/community/community-call-notes/index.rst:5
+msgid "Jupyter Community Call"
+msgstr ""
+
+# 158d1e8d768f4477b23a3b164ca9655b
+#: ../../source/community/community-call-notes/2019-may.md:3
+msgid "May 28th, 2019"
+msgstr ""
+
+# 12428c2c96ec4c04aefe1b9d747f88d9
+#: ../../source/community/community-call-notes/2019-may.md:5
+msgid "Date: 28 May 2019 at 9am PST (your timezome)"
+msgstr ""
+
+# 79384d54cd5e4953a63c65329e467e2c
+#: ../../source/community/community-call-notes/2019-may.md:7
+msgid "Link: Youtube Video"
+msgstr ""
+
+# 34838ee2bdd046babf35699d0a2b17d3
+#: ../../source/community/community-call-notes/2019-may.md:10
+msgid "Welcome to the All-Jupyter Community Meeting"
+msgstr ""
+
+# 1ba7041adbf8498ebcaf7bfa6b1be2ed
+#: ../../source/community/community-call-notes/2019-may.md:14
+msgid ""
+"If you are joining the All-Jupyter Community video meeting, sign in below"
+" so we know who was here. Roll call:"
+msgstr ""
+
+# 087428f3c619458ab1215faa7725bfb7
+#: ../../source/community/community-call-notes/2019-may.md:32
+msgid "Purpose"
+msgstr ""
+
+# 2bdfad80e4bc4c62a0f6f6a24e0fd7f2
+#: ../../source/community/community-call-notes/index.rst:7
+msgid ""
+"The Jupyter Community Call is an open video call. Think of this as a "
+"\"monthly, virtual JupyterCon\". It's a place for *anyone* to announce "
+"and share fun things happening in the Jupyter community. Everyone is "
+"welcome (even if you're not presenting). We record these videos and post "
+"them on YouTube. For more information, `read this discourse thread "
+"<https://discourse.jupyter.org/t/all-jupyter-community-calls/668>`__."
+msgstr ""
+
+# 1267e686bd0d4b039cedfdb4f29dd262
+#: ../../source/community/community-call-notes/index.rst:9
+msgid "**Previous Community Calls**"
+msgstr ""
+
+# ba90bd9d9ad94b8c98e873ac5b4431e6
+#: ../../source/community/content-community.rst:5
+msgid "Community Guides"
+msgstr ""
+
+# d54af2f83db8471499576db794d43eb0
+#: ../../source/community/content-community.rst:8
+msgid ""
+"Welcome to the Community Guides for Jupyter. These guides are intended to"
+" provide information about the Jupyter community such as background, "
+"events, and communication channels. As our community is highly dynamic, "
+"information may change, and we will do our best to keep it up to date."
+msgstr ""
+
+# ddb34dc7214346588c43db31dd75a02c
+#: ../../source/community/content-community.rst:15
+msgid "Monthly Meetings"
+msgstr ""
+
+# 1619503c14774902b78d65ca9b79d141
+#: ../../source/community/content-community.rst:17
+msgid ""
+"The core developers of various Jupyter sub-projects have regular meetings"
+" to discuss and demo what they have been working on, discuss future "
+"plans, and bootstrap conversation. These meetings are public and you are "
+"welcome to join remotely."
+msgstr ""
+
+# f34a0721b4874356a8ac819e93fef795
+#: ../../source/community/content-community.rst:21
+msgid ""
+"Each team has their own processes around logistics and planning for the "
+"team meetings. The following pages should help you find the information "
+"for each."
+msgstr ""
+
+# e191ff6ab041422b94c082b8194f1bb5
+#: ../../source/community/content-community.rst:24
+msgid ""
+"**All-Jupyter Community Calls** happen on the last Tuesday of every "
+"month, and are focused around demonstrations and sharing information "
+"across all of the Jupyter projects."
+msgstr ""
+
+# bab41d17142c4f01a84e8931031ef15b
+#: ../../source/community/content-community.rst:27
+msgid ""
+"Find information on `this Discourse thread "
+"<https://discourse.jupyter.org/t/all-jupyter-community-calls/668>`_."
+msgstr ""
+
+# b14012ac8c7d4f7d9b1fa40ad998d8a5
+#: ../../source/community/content-community.rst:28
+msgid ""
+"Watch previous calls on `our YouTube channel "
+"<https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP>`_."
+msgstr ""
+
+# 94fd509d19b04c98ac0e82a0aa3003aa
+#: ../../source/community/content-community.rst:29
+msgid "Read the `notes from previous calls <community-call-notes/index.html>`_."
+msgstr ""
+
+# b6c188f529e043bb8740f19fad6db3a2
+#: ../../source/community/content-community.rst:32
+msgid ""
+"**JupyterHub meetings** happen monthly. For a calendar of future team "
+"meetings, see `the JupyterHub team compass repository <https"
+"://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html>`_."
+msgstr ""
+
+# d87217c537f04a3e94fee9b03871ddb8
+#: ../../source/community/content-community.rst:35
+msgid ""
+"**JupyterLab meetings** happen weekly. For more information about when "
+"these meetings happen, as well as notes from each meeting, see `the "
+"JupyterLab README <https://github.com/jupyterlab/jupyterlab#weekly-dev-"
+"meeting>`_."
+msgstr ""
+
+# 5cb8eb65c5d342cb82cd6e06b515c4bb
+#: ../../source/community/content-community.rst:38
+msgid ""
+"**General meeting conversation and planning** often happens in the `dev-"
+"meeting-attendance Gitter channel <https://gitter.im/jupyter/dev-meeting-"
+"attendance>`_. We recommend checking it periodically for new information "
+"about when meetings are happening."
+msgstr ""
+
+# 85d662482e654ca8a60eb03ea3c16a49
+#: ../../source/community/content-community.rst:47
+msgid "Jupyter communications"
+msgstr ""
+
+# af1931399f504fde9b5c379ab97c3788
+#: ../../source/community/content-community.rst:49
+msgid ""
+"As a general rule, most project-wide conversation happens in the `Jupyter"
+" community forum <https://discourse.jupyter.org>`_. There are also many "
+"other kinds of communication that happens within the community. See below"
+" for links and other relevant information."
+msgstr ""
+
+# 2c02c8ede4514562b849edfba6bcc50e
+#: ../../source/community/content-community.rst:54
+msgid "Community forum `<https://discourse.jupyter.org/>`_"
+msgstr ""
+
+# fb525140606947bebc38796903ee7659
+#: ../../source/community/content-community.rst:55
+msgid "Blog `<https://blog.jupyter.org/>`_"
+msgstr ""
+
+# 64fab8ffafb24a7bb060d4359ec04feb
+#: ../../source/community/content-community.rst:56
+msgid "Newsletter `<https://newsletter.jupyter.org/>`_"
+msgstr ""
+
+# ef8f773e0424467eb83e939805663888
+#: ../../source/community/content-community.rst:57
+msgid "Website `<https://jupyter.org>`_"
+msgstr ""
+
+# 8e575a689ab845919c525a57feacbdb3
+#: ../../source/community/content-community.rst:58
+msgid "Twitter `<https://twitter.com/ProjectJupyter>`_"
+msgstr ""
+
+# 80103b709d94489da4c958855044ce23
+#: ../../source/community/content-community.rst:59
+msgid "Gitter `<https://gitter.im/jupyter/jupyter>`_"
+msgstr ""
+
+# dd12e64a1c6242688e11b1e72d4b7d17
+#: ../../source/community/content-community.rst:60
+msgid ""
+"Mailing lists (Jupyter, Jupyter in Education) "
+"`<https://jupyter.org/community.html>`_"
+msgstr ""
+
+# d8926bc097014aa68efb0246f0e69e7e
+#: ../../source/community/content-community.rst:64
+msgid "Governance"
+msgstr ""
+
+# 415a23b6140845c1b39b127b61a35e6e
+#: ../../source/community/content-community.rst:66
+msgid ""
+"Steering council: Information about the steering council and its members "
+"can be found on the `Jupyter website <https://jupyter.org>`_."
+msgstr ""
+
+# 9849b1d2be9949b790f8d9cb251e7531
+#: ../../source/community/content-community.rst:68
+msgid ""
+"Jupyter Enhancement Proposal (JEP) process: Details about the process can"
+" be found in the `jupyter/enhancement-proposals GitHub repo "
+"<https://github.com/jupyter/enhancement-proposals>`_."
+msgstr ""
+
+# 03da538fdae3452f9e7fa72740db23a8
+#: ../../source/community/content-community.rst:72
+msgid "Code of conduct"
+msgstr ""
+
+# b6254391831147a4afcef3c22844e45c
+#: ../../source/community/content-community.rst:74
+msgid ""
+"Information can be found in the `Jupyter Governance repo on GitHub "
+"<https://github.com/jupyter/governance>`_."
+msgstr ""
+
+# 4546949c9a144a1298252a5bd089279d
+#: ../../source/community/content-community.rst:77
+msgid "What is a Jovyan?"
+msgstr ""
+
+# c1508a5151854f74bf4c8deb7fde2c73
+#: ../../source/community/content-community.rst:79
+msgid ""
+"You may see the word **Jovyan** used in Jupyter tools (such as the user "
+"ID in the `Jupyter Docker stacks <https://github.com/jupyter/docker-"
+"stacks?`_ or referenced in conversations. But what is a Jovyan?"
+msgstr ""
+
+# 7a43f41ad815452bb5df25efb5a039bb
+#: ../../source/community/content-community.rst:83
+msgid ""
+"In astronomical terms, the word \"Jovian\" means \"like Jupiter\". It "
+"describes `several planets that share Jupyter-like properties "
+"<https://www.universetoday.com/33061/what-are-the-jovian-planets/>`_."
+msgstr ""
+
+# 5f92f3a419da4e1aa815eb1ce1929306
+#: ../../source/community/content-community.rst:86
+msgid ""
+"Much like the planet Jupiter and our solar system, the Jupyter community "
+"is large, distributed, and nebulous. We like to use the word **Jovyan** "
+"to describe members of this community. Jovyans are fellow open "
+"enthusiasts that use, develop, promote, teach, learn, and otherwise enjoy"
+" tools in Jupyter's orbit. They make up the Jupyter community. If you're "
+"not sure whether you're a Jovyan, you probably are :-)"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/content-quickstart.po
+++ b/docs/source/locale/es/LC_MESSAGES/content-quickstart.po
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 313dee758bfc43d485397132ce7413a0
+#: ../../source/content-quickstart.rst:2
+msgid "Jupyter Notebook Quickstart"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/contents.po
+++ b/docs/source/locale/es/LC_MESSAGES/contents.po
@@ -1,0 +1,137 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 33435e4f8e8e4d108f3ee03172fbca55
+#: ../../source/contents.rst:3
+msgid "Project Jupyter and IPython"
+msgstr ""
+
+# a8847d2993b84d8a80a23f7807c1aff3
+#: ../../source/contents.rst:5
+msgid "**Table of Contents**"
+msgstr ""
+
+# 7d38cf5fdf954c39a2fe68592724bc41
+#: ../../source/contents.rst:67
+msgid "Indices and tables"
+msgstr ""
+
+# 289ae6113b3f4c9eb1d29b8e2c8fb24d
+#: ../../source/contents.rst:69
+msgid ":ref:`genindex`"
+msgstr ""
+
+# 6421140cb92e40758c79f76b99f3e96f
+#: ../../source/contents.rst:70
+msgid ":ref:`glossary`"
+msgstr ""
+
+# a18e0af2c678400f9984da4463c144d0
+#: ../../source/contents.rst:71
+msgid ":ref:`search`"
+msgstr ""
+
+# 03b4d1007ed14d4d910b6c03fd6fd9f2
+#: ../../source/contents.rst:74
+msgid "**Resources:**"
+msgstr ""
+
+# 548ecdd6f5484efa80f8a2b05e4ef451
+#: ../../source/contents.rst:1
+msgid "Site"
+msgstr ""
+
+# 0ff92b1d24764e81957e7d1fc8ff8d9f
+#: ../../source/contents.rst:1
+msgid "Description"
+msgstr ""
+
+# 83e11f238d834561af6f97697b27f6fb
+#: ../../source/contents.rst:1
+msgid "`Jupyter website <https://jupyter.org>`_"
+msgstr ""
+
+# 920fa49c6db7411983595935f7e92f3e
+#: ../../source/contents.rst:1
+msgid "Keep up to date on Jupyter"
+msgstr ""
+
+# 30a274f35cf2474797945a935da85cb4
+#: ../../source/contents.rst:1
+msgid "`IPython website <https://ipython.org>`_"
+msgstr ""
+
+# 88231b674ec542179be7c7445ec8583b
+#: ../../source/contents.rst:1
+msgid "Learn more about IPython"
+msgstr ""
+
+# b8c70c9438f644118a68109f5eba874e
+#: ../../source/contents.rst:1
+msgid "`jupyter/help repo <https://github.com/jupyter/help>`_"
+msgstr ""
+
+# 72da60819619401b9a96f5504ba59c97
+#: ../../source/contents.rst:1
+msgid "Start here for help and support questions"
+msgstr ""
+
+# 0dc8121fb6244c189d0104edd3a0ad5d
+#: ../../source/contents.rst:1
+msgid "`Jupyter mailing list <https://groups.google.com/forum/#!forum/jupyter>`_"
+msgstr ""
+
+# cbdb33adaed94934807dd96aad51d04c
+#: ../../source/contents.rst:1
+msgid "General discussion of Jupyter's use"
+msgstr ""
+
+# 90cd4bd7587a41baaa4fe9b254e06b73
+#: ../../source/contents.rst:1
+msgid ""
+"`Jupyter in Education group <https://groups.google.com/forum/#!forum"
+"/jupyter-education>`_"
+msgstr ""
+
+# a53a7f1c3e0542529b17ea18db13af07
+#: ../../source/contents.rst:1
+msgid "Discussion of Jupyter's use in education"
+msgstr ""
+
+# be4502efd1b8405f9006fcc3b8d830f7
+#: ../../source/contents.rst:1
+msgid "`NumFocus <http://www.numfocus.org>`_"
+msgstr ""
+
+# aad8855017f4495b9d094b28d9a17a7c
+#: ../../source/contents.rst:1
+msgid "Promotes world-class, innovative, open source scientific software"
+msgstr ""
+
+# af4b1ede6ede498c982e94e44261c974
+#: ../../source/contents.rst:1
+msgid "`Donate to Project Jupyter <https://jupyter.org/donate.html>`_"
+msgstr ""
+
+# 46564fbd685543a9a25fb09fe204970a
+#: ../../source/contents.rst:1
+msgid "Please contribute to open science collaboration and sustainability"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/contrib_docs.po
+++ b/docs/source/locale/es/LC_MESSAGES/contrib_docs.po
@@ -1,0 +1,676 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 8951f6f4ecb1413bbb04b398218015c5
+#: ../../source/contrib_docs/doc-future-index.rst:2
+msgid "Setting up a project's documentation infrastructure"
+msgstr ""
+
+# 7cdfc8fab5b84b2a888d19fbfe55aa37
+#: ../../source/contrib_docs/doc-future-index.rst:4
+msgid "Contents:"
+msgstr ""
+
+# 1bde3a53c29249958887df3f45554bdf
+#: ../../source/contrib_docs/doc-future-index.rst:13
+msgid ""
+"This section helps a contributor set up the documentation infrastructure "
+"for a new project or an existing project without Sphinx documentation."
+msgstr ""
+
+# 232486a6287c412b99f0022d6d84e90a
+#: ../../source/contrib_docs/doc-new-build.md:1
+msgid "Building automatically on ReadTheDocs"
+msgstr ""
+
+# fbc01acaa56d459985a5988de5128194
+#: ../../source/contrib_docs/doc-new-build.md:3
+msgid ""
+"This explains how to automatically rebuild documentation on ReadtheDocs "
+"every time a pull request is merged into its corresponding GitHub repo."
+msgstr ""
+
+# 27905f3382e1420588048c37cb32d617
+#: ../../source/contrib_docs/doc-new-build.md:6
+msgid "Using the ReadTheDocs service"
+msgstr ""
+
+# 548f76347eeb494da8083cb3c13d39f2
+#: ../../source/contrib_docs/doc-new-build.md:8
+msgid ""
+"Webhooks and services can be enabled in GitHub repo settings to allow "
+"third party services such as ReadTheDocs. The ReadTheDocs service "
+"rebuilds the project documentation whenever a pull request is merged into"
+" the GitHub repo."
+msgstr ""
+
+# 1ff476bad0cf4c0bab9ba8c06d1af401
+#: ../../source/contrib_docs/doc-new-build.md:12
+msgid "Navigate to Settings"
+msgstr ""
+
+# c3fb69257cb4414f8c0b7af8054e4811
+#: ../../source/contrib_docs/doc-new-build.md:14
+msgid ""
+"Each GitHub repo has a Settings tab at the far right of the repo menubar."
+" Navigate to Settings and then the Webhooks & services submenu tab."
+msgstr ""
+
+# 3dedea5f462f482580216a01d0730972
+#: ../../source/contrib_docs/doc-new-build.md:16
+msgid "Settings and Webhooks & services submenu"
+msgstr ""
+
+# e1791743951046f796933c3014462134
+#: ../../source/contrib_docs/doc-new-build.md:18
+msgid "Add the ReadTheDocs service"
+msgstr ""
+
+# b492918cb93240ed8719e6876a9ef1d9
+#: ../../source/contrib_docs/doc-new-build.md:20
+msgid ""
+"Select Add service and enter ReadTheDocs in the Available Services input "
+"box."
+msgstr ""
+
+# 55a4fff635a5445fb6d765c4e40ce046
+#: ../../source/contrib_docs/doc-new-build.md:22
+msgid ""
+"The Services/Add ReadTheDocs window will open. Press the green Add "
+"service button to activate the ReadTheDocs service."
+msgstr ""
+
+# 505867437b214d4f812e8fb9b70ca0d9
+#: ../../source/contrib_docs/doc-new-build.md:24
+msgid "Add ReadTheDocs service"
+msgstr ""
+
+# 112b55c373134049a1fc640695b3799e
+#: ../../source/contrib_docs/doc-new-build.md:26
+msgid "Success"
+msgstr ""
+
+# f38a664a1d164422ae6a4aa7b3d5bb50
+#: ../../source/contrib_docs/doc-new-build.md:28
+msgid ""
+"The ReadTheDocs service is added successfully. The service will take "
+"effect on the next merged pull request to the project repo."
+msgstr ""
+
+# 4012a2bd5b4a452aa2bc78013a0ae401
+#: ../../source/contrib_docs/doc-new-build.md:30
+msgid "Service successfully added"
+msgstr ""
+
+# c03788a9bdba433c9198fb72eaf07450
+#: ../../source/contrib_docs/doc-new-build.md:33
+msgid "Created: 01-07-2016"
+msgstr ""
+
+# 64bec8ddf86a46e3be1010335ab3b857
+#: ../../source/contrib_docs/doc-new-repos.md:1
+msgid "Setting up a README"
+msgstr ""
+
+# d22ac7f8b0574e0493a17b325c369177
+#: ../../source/contrib_docs/doc-new-repos.md:3
+msgid ""
+"Providing users and developers consistency across repos is a valuable "
+"time saver and improves user productivity."
+msgstr ""
+
+# f3c2890b764d4be989a58f23591ac8f4
+#: ../../source/contrib_docs/doc-new-repos.md:6
+msgid ""
+"On a larger scope, having the Jupyter name appear prominently in a repo's"
+" README.md file improves the project's name awareness."
+msgstr ""
+
+# 36da1d4b745446a184f24d86860ee5cf
+#: ../../source/contrib_docs/doc-new-repos.md:9
+msgid "Recommended elements in Jupyter project repos"
+msgstr ""
+
+# d7ed0a7e260844f3929c586a5bcec7d6
+#: ../../source/contrib_docs/doc-new-repos.md:11
+msgid "Link in repo description"
+msgstr ""
+
+# 3188a81d5e804531bc59f4fc56d45db5
+#: ../../source/contrib_docs/doc-new-repos.md:12
+msgid "Please include a link to the documentation in the repo's description."
+msgstr ""
+
+# 7077cfb8652645adb68f9d5bf15d8c2b
+#: ../../source/contrib_docs/doc-new-repos.md:14
+msgid "Repo description and documentation link"
+msgstr ""
+
+# 362deb326ee04287888a851b40b75f26
+#: ../../source/contrib_docs/doc-new-repos.md:16
+msgid "Badges in README"
+msgstr ""
+
+# ac386bdd61694670af3624cef2c354fa
+#: ../../source/contrib_docs/doc-new-repos.md:17
+msgid ""
+"One common way that individuals find documentation is to look for and "
+"click on the doc badge that commonly is found right after the title. "
+"Another benefit is an easy visual indication if the docs are not "
+"rendering properly."
+msgstr ""
+
+# b7335017aa17487d8a3e44cbdc89d333
+#: ../../source/contrib_docs/doc-new-repos.md:21
+msgid "Badges in README.md"
+msgstr ""
+
+# 16fc8f66cf7b406b8c2876ba146d5761
+#: ../../source/contrib_docs/doc-new-repos.md:23
+msgid "Resources section in README"
+msgstr ""
+
+# 85c29f39bd9e4b7b9148b6d98300bf75
+#: ../../source/contrib_docs/doc-new-repos.md:25
+msgid ""
+"A Resources section at the end of the README.md gives useful links and "
+"information to users about the individual project and the larger Project "
+"Jupyter organization. Make sure to include any links to the individual "
+"project's demo notebooks, if available."
+msgstr ""
+
+# e3415ff12b4b44e49f2851fb583115a4
+#: ../../source/contrib_docs/doc-new-repos.md:30
+msgid "The Resources section includes:"
+msgstr ""
+
+# bbd10f86669b4c6fb425b08981536b35
+#: ../../source/contrib_docs/doc-new-repos.md:32
+msgid "Resources section in"
+msgstr ""
+
+# 49575d164ce8451592d3bc3717307aa3
+#: ../../source/contrib_docs/doc-new-repos.md:35
+msgid "Checklist adding docs to a new or existing GitHub Repo"
+msgstr ""
+
+# 335e33a3a2ec4b8994a769c697be5039
+#: ../../source/contrib_docs/doc-new-repos.md:42
+msgid "Dated: 1-4-2016 Revised: 1-7-2016"
+msgstr ""
+
+# 7f017745d5c34b3f91c54f653b2793d1
+#: ../../source/contrib_docs/doc-tools.rst:2
+msgid "Tools for documentation"
+msgstr ""
+
+# f82aa18212984518ac1371f956fc5f12
+# 0e6a4fd1bdd7427dbc0d45d78f5cd710
+#: ../../source/contrib_docs/doc-tools.rst:5
+#: ../../source/contrib_docs/getting-started.rst:5
+msgid "Contents"
+msgstr ""
+
+# 70ea135c1ab44fbba9a46a8f7992d014
+#: ../../source/contrib_docs/doc-tools.rst:8
+msgid "Packages"
+msgstr ""
+
+# 0cd99c51dc1344f2a28d229978446fdb
+#: ../../source/contrib_docs/doc-tools.rst:9
+msgid ""
+"For user documentation, contributor guides, and communications content, "
+"we use:"
+msgstr ""
+
+# e4db7b119bc747ab932bd5b9475de798
+#: ../../source/contrib_docs/doc-tools.rst:12
+msgid "`Sphinx <http://www.sphinx-doc.org/en/stable>`_"
+msgstr ""
+
+# 89cb08a083b7405b899da55da2c386dc
+#: ../../source/contrib_docs/doc-tools.rst:14
+msgid ""
+"For developer API documentation (especially for JupyterLab js repos), we "
+"use:"
+msgstr ""
+
+# 66229f6c114e4652b13bd066643cae2a
+#: ../../source/contrib_docs/doc-tools.rst:16
+msgid "`swagger <http://swagger.io/>`_"
+msgstr ""
+
+# 4241f08f75b745cc91401487dfb43473
+#: ../../source/contrib_docs/doc-tools.rst:19
+msgid "Source file formats"
+msgstr ""
+
+# 0e502ec731f24f729b096c7ef2aac637
+#: ../../source/contrib_docs/doc-tools.rst:20
+msgid ""
+"We use the following input source file formats when developing Sphinx "
+"documentation:"
+msgstr ""
+
+# c35638daf71349ab94f174d9c40088fa
+#: ../../source/contrib_docs/doc-tools.rst:23
+msgid "reStructuredText (``.rst``)"
+msgstr ""
+
+# 31a7dcfa85f545308ff3c24f7f5fa6da
+#: ../../source/contrib_docs/doc-tools.rst:24
+msgid "Markdown (``.md``)"
+msgstr ""
+
+# 99f22d7ed28e4ec6b6739ab4d3b0fca1
+#: ../../source/contrib_docs/doc-tools.rst:25
+msgid "Notebook (``.ipynb``)"
+msgstr ""
+
+# 6bc8c61685c94741b9a52990ac840a31
+#: ../../source/contrib_docs/doc-tools.rst:27
+msgid ""
+"A modern code editor should be used. Many are available including Atom, "
+"SublimeText, gedit, vim, emacs. `Atom <https://atom.io/>`_ is a good "
+"choice for new contributors."
+msgstr ""
+
+# 36d19549dd2e4365a6c5e8e035cd54c6
+#: ../../source/contrib_docs/doc-tools.rst:32
+msgid "Sphinx themes"
+msgstr ""
+
+# 1eb43a99bb26411382f63038cc477cee
+#: ../../source/contrib_docs/doc-tools.rst:33
+msgid "Our projects use the following themes:"
+msgstr ""
+
+# 29670e07c5044935b15456980e34fae1
+#: ../../source/contrib_docs/doc-tools.rst:35
+msgid "sphinx_rtd_theme (currently used by Jupyter projects)"
+msgstr ""
+
+# f9cd1912e9bc4bd79e22274b5ce9acdf
+#: ../../source/contrib_docs/doc-tools.rst:36
+msgid "jupyter_sphinx_theme (used by ipywidgets)"
+msgstr ""
+
+# d987578c0b164c1ba1296f4b300cac54
+#: ../../source/contrib_docs/doc-tools.rst:39
+msgid "Git and Github Resources"
+msgstr ""
+
+# 50b964b050404597b31edeb7431ffb85
+#: ../../source/contrib_docs/doc-tools.rst:40
+msgid ""
+"If this is your first time working with Github or git, you can leverage "
+"the following resources to learn about the tools."
+msgstr ""
+
+# 0b58d8ea7318429ba17fb25d493dbe11
+#: ../../source/contrib_docs/doc-tools.rst:43
+msgid "`Try Git  <https://try.github.io/levels/1/challenges/1>`_"
+msgstr ""
+
+# 319d5b76f66a42d3894269987178b99c
+#: ../../source/contrib_docs/doc-tools.rst:44
+msgid "`Github Guides  <https://guides.github.com>`_"
+msgstr ""
+
+# 3b0ab86be2604595be117b97ae517309
+#: ../../source/contrib_docs/doc-tools.rst:45
+msgid "`Git Real  <https://www.codeschool.com/courses/git-real>`_"
+msgstr ""
+
+# 9bf487d7abfc44c3ab65fc60610916db
+#: ../../source/contrib_docs/doc-tools.rst:46
+msgid "`Git Documentation <https://git-scm.com/documentation>`_"
+msgstr ""
+
+# 6f130c2608c74cd481206a5302ce6ab4
+#: ../../source/contrib_docs/doc-tools.rst:47
+msgid ""
+"`Git Rebase <https://github.com/pydata/pandas/wiki/Git-Workflows#user-"
+"content-git-rebase>`_"
+msgstr ""
+
+# 73369309d0264c91801dadff4096eda3
+#: ../../source/contrib_docs/doc-workflow.rst:2
+msgid "Understanding our workflow"
+msgstr ""
+
+# 3ad46563bdea4c718af906b06996645d
+#: ../../source/contrib_docs/doc-workflow.rst:4
+msgid "**High level documentation workflow**"
+msgstr ""
+
+# bea011364bb5447f9a5ee2e0a1813bb7
+#: ../../source/contrib_docs/doc-workflow.rst:6
+msgid "Identify a documentation change."
+msgstr ""
+
+# 0ecc5172dfa9449bb3fd7ddee5ab7a8f
+#: ../../source/contrib_docs/doc-workflow.rst:8
+msgid "*Typos:* please go ahead and fix it (or report as a bug)."
+msgstr ""
+
+# d2eec42d01aa43c49c9f599c56cf67f7
+#: ../../source/contrib_docs/doc-workflow.rst:9
+msgid ""
+"*Open issues:* leave a note in the issue comments that you are working on"
+" the issue."
+msgstr ""
+
+# 5594fd91be4844ba8361a65dfea30f57
+#: ../../source/contrib_docs/doc-workflow.rst:11
+msgid ""
+"*New documentation:* open an issue with your idea or suggestion. We'll "
+"review the issue and work with you to identify next steps."
+msgstr ""
+
+# df7b4d15c41f4003b695a2e4ba5f9257
+#: ../../source/contrib_docs/doc-workflow.rst:14
+msgid "Update the source file."
+msgstr ""
+
+# 0a600b26d0214280b77a6ae44f71294f
+#: ../../source/contrib_docs/doc-workflow.rst:16
+msgid "Commit the change."
+msgstr ""
+
+# 241782c238de4ebeb594ebe6cc2fe7a6
+#: ../../source/contrib_docs/doc-workflow.rst:18
+msgid "Test changes locally."
+msgstr ""
+
+# b8f4ff91d74f453e8e4c680f537967de
+#: ../../source/contrib_docs/doc-workflow.rst:20
+msgid "Open a pull request."
+msgstr ""
+
+# e943c50580c64ecaa32dd38a2ac2f8e2
+#: ../../source/contrib_docs/doc-workflow.rst:22
+msgid "Check response of automated tests."
+msgstr ""
+
+# 47edb06fb3c0469f87b591aa0e30925c
+#: ../../source/contrib_docs/doc-workflow.rst:24
+msgid ""
+"If tests pass: Nice job. Wait for reviewer feedback and/ or your pull "
+"request to be merged."
+msgstr ""
+
+# 6b9c7c1cbd7d4772a778cc9c2f33a0d4
+#: ../../source/contrib_docs/doc-workflow.rst:27
+msgid ""
+"If tests show an error: Revise and resubmit your pull request. You do not"
+" need to open a new pull request. If needed, please ask for assistance."
+msgstr ""
+
+# 6c100a83bc8547909df09e2de4fa16f2
+#: ../../source/contrib_docs/doc-workflow.rst:31
+msgid "Celebrate your documentation contribution."
+msgstr ""
+
+# 7f491e4696da4e01af2e68b97352a3f4
+#: ../../source/contrib_docs/doc-workflow.rst:33
+msgid ""
+"Repeat. If you would like suggestions for a new documentation issue to "
+"work on, please ask."
+msgstr ""
+
+# 4837ec4c20d84023875b77de40950374
+#: ../../source/contrib_docs/doc-workflow.rst:37
+msgid "Thanks for contributing!"
+msgstr ""
+
+# 96f8c8d5bd6b48b79a6fbfdadfe293b9
+#: ../../source/contrib_docs/getting-started.rst:2
+msgid "Getting started"
+msgstr ""
+
+# 41b8445aaef14b0f9277132ef8f7c64d
+#: ../../source/contrib_docs/getting-started.rst:8
+msgid "Preparing for your first contribution"
+msgstr ""
+
+# 5ff1615eb97f4322bc6b824fe2975e78
+#: ../../source/contrib_docs/getting-started.rst:9
+msgid "Our documentation uses reStructured Text as well as Jupyter notebooks."
+msgstr ""
+
+# 4f862af8ce2648e6a6f36a65f166c17a
+#: ../../source/contrib_docs/getting-started.rst:10
+msgid "We use Sphinx extensively to build documentation."
+msgstr ""
+
+# 074f79e5aada4cf48e49e75da9a6f2e4
+#: ../../source/contrib_docs/getting-started.rst:11
+msgid "We host our documentation on Read the Docs."
+msgstr ""
+
+# 273c21f2f4c64cdc905c4b9c65df07e6
+#: ../../source/contrib_docs/getting-started.rst:14
+msgid "Developing your contribution"
+msgstr ""
+
+# d34708a450ae4c98b03feb4ff944a1cc
+#: ../../source/contrib_docs/getting-started.rst:16
+msgid ""
+"Jupyter's documentation is split across several projects, listed on the "
+"`Jupyter documentation home page "
+"<https://jupyter.readthedocs.io/en/latest/>`_. These instructions apply "
+"to all Jupyter projects, though some projects have further contribution "
+"guidelines."
+msgstr ""
+
+# 583255d870384645b0b076e657c2e763
+#: ../../source/contrib_docs/getting-started.rst:19
+msgid "Clone the repository"
+msgstr ""
+
+# 024a7bc45f3a45fab5500b2d1904d9bc
+#: ../../source/contrib_docs/getting-started.rst:20
+msgid ""
+"Fork the appropriate project repository on GitHub, depending on which "
+"project's documentation you want to contribute to."
+msgstr ""
+
+# 7e9da73cdb4c469db3dce5d160b5208a
+#: ../../source/contrib_docs/getting-started.rst:21
+msgid "Clone the repository to your system."
+msgstr ""
+
+# 9e4c1b704e594ce19b00ef8075748237
+#: ../../source/contrib_docs/getting-started.rst:24
+msgid "Edit the documentation source file"
+msgstr ""
+
+# a6b8f285170c4f8eb6aecdd1cbfdb7b9
+#: ../../source/contrib_docs/getting-started.rst:26
+msgid ""
+"Source files for projects are typically found in the project's "
+"``docs/source`` directory. The reStructured text filenames end with "
+"``.rst``, and Jupyter notebook files end with ``.ipynb``."
+msgstr ""
+
+# 8b7b25fa65204498b0a9266c8541311e
+#: ../../source/contrib_docs/getting-started.rst:30
+msgid ""
+"In your favorite text editor, make desired changes to the ``.rst`` file "
+"when working with a reStructured text source file."
+msgstr ""
+
+# 28f854c4861346b09d69499d50d03dd4
+#: ../../source/contrib_docs/getting-started.rst:32
+msgid ""
+"If a notebook file requires editing, you will need to install Jupyter "
+"notebook according to the :ref:`Installation <install>` document. Then, "
+"run the Jupyter notebook and edit the desired file. Before saving the "
+"Jupyter ``.ipynb`` file, please clear the output cells. Save the file and"
+" test your change."
+msgstr ""
+
+# 41995af34a5046bca276d62634ae3b10
+#: ../../source/contrib_docs/getting-started.rst:39
+msgid "Testing changes"
+msgstr ""
+
+# 65e377a9fbe04a0b8775881db9467ab8
+#: ../../source/contrib_docs/getting-started.rst:41
+msgid ""
+"Sphinx should be installed to test your documentation changes. For best "
+"results, we recommend that you install the stable development version "
+"Sphinx (``pip install git+https://github.com/sphinx-doc/sphinx@stable``) "
+"or the current released version of Sphinx (``pip install sphinx``)."
+msgstr ""
+
+# 521e95671d3349b79075277e3822bc61
+#: ../../source/contrib_docs/getting-started.rst:46
+msgid ""
+"In addition, you may need the following packages: sphinxcontrib-spelling,"
+" sphinx_rtd_theme, nbsphinx, pyenchant, recommonmark and "
+"jupyter_sphinx_theme, which can be installed via ``pip install "
+"sphinxcontrib-spelling sphinx_rtd_theme nbsphinx pyenchant recommonmark "
+"jupyter_sphinx_theme``."
+msgstr ""
+
+# 1140b74d6bd547d2923b29eb2c769293
+#: ../../source/contrib_docs/getting-started.rst:48
+msgid ""
+"If you are on Linux, you may also need to install the Enchant C library "
+"by running ``sudo apt-get install enchant``."
+msgstr ""
+
+# 710e465eeb7d49f8bcf3279361e211ea
+#: ../../source/contrib_docs/getting-started.rst:50
+msgid ""
+"Once everything is installed, the following commands should be executed "
+"using the Terminal/command line from the ``docs`` directory:"
+msgstr ""
+
+# 874edec47dfe41aab09ca2dc976ac9be
+#: ../../source/contrib_docs/getting-started.rst:53
+msgid ""
+"``make html`` builds a local html version of the documentation. The "
+"output message will either display errors or provide the location of the "
+"html documents. For example, the location provided may be ``build/html`` "
+"and to view these documents in your browser enter ``open "
+"build/html/index.html``."
+msgstr ""
+
+# 3c47075546064151940cfddaa6b97e97
+#: ../../source/contrib_docs/getting-started.rst:58
+msgid ""
+"``make linkcheck`` will check whether the external links in the "
+"documentation are valid or if they are not longer current (i.e. cause a "
+"500 not found error)."
+msgstr ""
+
+# 3b5e8519815b43ab82350bed26580555
+#: ../../source/contrib_docs/getting-started.rst:62
+msgid ""
+"Note: We recommend using Python 3.4+ for building the documentation. If "
+"you are editing the documentation, you can use Python 2.7.9+ or the "
+"Github editor."
+msgstr ""
+
+# 3a598ce6355d49589108ebb8b3584478
+#: ../../source/contrib_docs/getting-started.rst:65
+msgid "Creating a pull request"
+msgstr ""
+
+# c5b5c1b181a54762a10f3d97ce5d19e8
+#: ../../source/contrib_docs/getting-started.rst:66
+msgid ""
+"Once you are satisfied with your changes, submit a GitHub pull request, "
+"per the instructions above. If the documentation change is related to an "
+"open GitHub issue, please mention the issue number in the pull request "
+"message."
+msgstr ""
+
+# 4ae44c0cf02a45b99d0c7f14640c4f6e
+#: ../../source/contrib_docs/getting-started.rst:70
+msgid ""
+"A project reviewer will look over your changes and provide feedback or "
+"merge your changes into the documentation."
+msgstr ""
+
+# baccae949fb54e6491856084b68e4827
+#: ../../source/contrib_docs/getting-started.rst:74
+msgid "Asking questions"
+msgstr ""
+
+# 990c9e57e8fc4e9c9da2ea3980ddebac
+#: ../../source/contrib_docs/getting-started.rst:75
+msgid ""
+"Feel free to ask questions in the Google Group for Jupyter or on an open "
+"issue on GitHub."
+msgstr ""
+
+# 6ad43967c19843df85781d3ee0ba0658
+#: ../../source/contrib_docs/index.rst:5
+msgid "Documentation Guide"
+msgstr ""
+
+# e53cdb8f3ebb4f9d97c7824dfd462fef
+#: ../../source/contrib_docs/index.rst:7
+msgid "**Contents**"
+msgstr ""
+
+# 8710f55c2e51435881a40b68457010b8
+#: ../../source/contrib_docs/index.rst:17
+msgid ""
+"Documentation helps guide new users, fosters communication between "
+"developers, and shares tips and best practices with other community "
+"members. That's why the Jupyter project is focused on documenting new "
+"features and to keeping the documentation up-to-date."
+msgstr ""
+
+# 785e0d441719499ab42d427cbc7d6247
+#: ../../source/contrib_docs/repo-structure.md:1
+msgid "Structuring a repo for docs"
+msgstr ""
+
+# 90d5b35701d841f49957792e24da870a
+#: ../../source/contrib_docs/repo-structure.md:4
+msgid "Root level of the repo"
+msgstr ""
+
+# 7367f9983e43442b8e2e72da5ed51518
+#: ../../source/contrib_docs/repo-structure.md:10
+msgid "Repo root directory"
+msgstr ""
+
+# 98dae640b1424bad968989a88f0bbbac
+#: ../../source/contrib_docs/repo-structure.md:12
+msgid "Inside the docs directory"
+msgstr ""
+
+# 60e584f8cf344d5cbc1bd44ddb579f91
+#: ../../source/contrib_docs/repo-structure.md:19
+msgid "directory"
+msgstr ""
+
+# 18b0121e5dbd4d0cbfdc139f2087f09c
+#: ../../source/contrib_docs/repo-structure.md:22
+msgid "Sphinx"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/contributor.po
+++ b/docs/source/locale/es/LC_MESSAGES/contributor.po
@@ -1,0 +1,409 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 621a2e3dd84a4243839c3502e29814d9
+#: ../../source/contributor/content-contributor.rst:2
+msgid "Contributor Guides"
+msgstr ""
+
+# 1171d51e6719464b968b01a30c2df1d4
+#: ../../source/contributor/content-contributor.rst:13
+msgid ""
+"Whether you are a new, returning, or current contributor to Project "
+"Jupyter's subprojects or IPython, **we welcome you**."
+msgstr ""
+
+# 300e2003927049dab5e95afdb87961d3
+#: ../../source/contributor/content-contributor.rst:16
+msgid ""
+"Project Jupyter has seen steady growth over the past several years, and "
+"it is wonderful to see the many ways people are using these projects. As "
+"a result of this rapid expansion, our project maintainers are balancing "
+"many requirements, needs, and resources. We ask contributors to take some"
+" time to become familiar with our contribution guides and spend some time"
+" learning about our project communication and workflow."
+msgstr ""
+
+# b8bdcf9762b9420b982a51c87522bb59
+#: ../../source/contributor/content-contributor.rst:23
+msgid ""
+"The Contributor Guides and individual project documentation offer "
+"guidance. If you have a question, please ask us. `Community Resources "
+"<https://jupyter.org/community.html>`_ provides information on our "
+"commonly used communication methods."
+msgstr ""
+
+# a6410f8dcf2a40f4bb0ac93598cba376
+#: ../../source/contributor/content-contributor.rst:28
+msgid ""
+"We are very pleased to have you as a contributor, and we hope you will "
+"find valuable your impact on the projects. **Thank you** for sharing your"
+" interests, ideas, and skills with us."
+msgstr ""
+
+# 135f6b0b508342ce97970e34fc45d3e7
+#: ../../source/contributor/content-contributor.rst:33
+msgid "Do I really have something to contribute to Jupyter?"
+msgstr ""
+
+# c019e9e3e874449c97154d6e7a727e78
+#: ../../source/contributor/content-contributor.rst:35
+msgid ""
+"Absolutely ✅. There are always ways to contribute to this community! "
+"Whether it is is contributing code, improving documentation and "
+"communications, teaching others, or participating in conversations in the"
+" community, we welcome and value your contribution!"
+msgstr ""
+
+# 98869a235e8a4a889da32cec31b99573
+#: ../../source/contributor/content-contributor.rst:41
+msgid "What kinds of contributions can I make?"
+msgstr ""
+
+# 8f10671ad67d4eea908dd64ffee52b4c
+#: ../../source/contributor/content-contributor.rst:43
+msgid ""
+"The following sections try to provide inspirations for different ways "
+"that you can contribute to the Jupyter ecosystem. They're non-complete - "
+"if you can think up any way to make an improvement, we appreciate it!"
+msgstr ""
+
+# f409e68056af43bd9e38d096103a3883
+#: ../../source/contributor/content-contributor.rst:48
+msgid "Improving documentation"
+msgstr ""
+
+# 34eefffe7e794af4a56bd5ea20b11a78
+#: ../../source/contributor/content-contributor.rst:50
+msgid ""
+"One of the most important parts of the Jupyter ecosystem is its "
+"documentation. Good documentation makes it easier for users to learn how "
+"to use the tools. It also makes it easier to teach others, and to "
+"maintain and improve the code itself. There are many ways to improve "
+"documentation, such as **reading tutorials and reporting confusing "
+"parts**, **finding type-os and minor errors in docs**, **writing your own"
+" guides and tutorials**, **improving docstrings within the code**, and "
+"**improving documentation style and design**."
+msgstr ""
+
+# 9e1b5f837c5544e0b1b10324e31869ae
+#: ../../source/contributor/content-contributor.rst:57
+msgid ""
+"If you'd like to improve documentation in the Jupyter community, check "
+"out the :ref:`documentation-guide`."
+msgstr ""
+
+# 560230393e4349dd825bc8cb04bd85e8
+#: ../../source/contributor/content-contributor.rst:60
+msgid "Improving code"
+msgstr ""
+
+# d630c52da53f4130862db11c2c4d45e6
+#: ../../source/contributor/content-contributor.rst:62
+msgid ""
+"There are many different codebases that make up the tools in the Jupyter "
+"ecosystem. These are split across many repositories in several GitHub "
+"organizations. They cover many different parts of interactive computing, "
+"such as **user interfaces**, **kernels**, **shared infrastructure**, "
+"**interactive widgets**, or **structured documents**."
+msgstr ""
+
+# 904018e4262349c680f3e06291ab5284
+#: ../../source/contributor/content-contributor.rst:67
+msgid ""
+"We recommend checking out the :ref:`developer-guide` for more information"
+" about how you can find the right project to contribute to, and where to "
+"go next."
+msgstr ""
+
+# 25a6e078d67442a2ba84ead181c460b3
+#: ../../source/contributor/content-contributor.rst:71
+msgid "Participating in the community"
+msgstr ""
+
+# a87966fbbbd14c878db02da9489bce82
+#: ../../source/contributor/content-contributor.rst:73
+msgid ""
+"The most important part of Jupyter is its community - this is a large and"
+" diverse group of people spread across the globe. One of the best ways to"
+" contribute to Jupyter is to simply be a positive and helpful member of "
+"this community. Whether it **participating in online conversations**, "
+"**offering to help others**, **coming to community meetings**, or "
+"**teaching others about Jupyter**, there are many ways to improve the "
+"Jupyter community. For more information about this, we recommend starting"
+" with the :ref:`community-guide`."
+msgstr ""
+
+# 593c43f0e5764d01a171016560a00f00
+#: ../../source/contributor/contrib_guide_blog.rst:3
+msgid "Communications Guide"
+msgstr ""
+
+# 1b294ad959f94bd3b8dba73f56642cb2
+#: ../../source/contributor/contrib_guide_blog.rst:6
+msgid "Contents"
+msgstr ""
+
+# c6416f19a43d4ae1a19bb1f7b9888966
+#: ../../source/contributor/contrib_guide_blog.rst:9
+msgid "Blog"
+msgstr ""
+
+# a9b5e28dfd994ef29cdf392ff8a36fba
+#: ../../source/contributor/contrib_guide_blog.rst:11
+msgid ""
+"We publish our blog at `<https://blog.jupyter.org>`_. We welcome ideas "
+"for posts or guest posts to the Jupyter blog. If you have a suggestion "
+"for a future post, please feel free to share your idea with us. We would "
+"like to discuss the idea with you."
+msgstr ""
+
+# 12ff4c6ea66d445991bcadec7ba0b31f
+#: ../../source/contributor/contrib_guide_blog.rst:16
+msgid ""
+"Do you enjoy writing? Please contact us about becoming a guest blogger. "
+"We can help guide you through the process of creating a post."
+msgstr ""
+
+# b3be44427ae8472a8a215b6e33127cca
+#: ../../source/contributor/contrib_guide_blog.rst:20
+msgid "Technical overview"
+msgstr ""
+
+# f09b1742f1744a83893baf77b9ff4ffc
+#: ../../source/contributor/contrib_guide_blog.rst:22
+msgid ""
+"Jupyter's blog uses the Ghost blog platform for its contributor "
+"flexibility and ease of use. Jupyter's blog is deployed at "
+"`<https://blog.jupyter.org>`_."
+msgstr ""
+
+# 43151242cf8847c792841f97ae59e095
+#: ../../source/contributor/contrib_guide_blog.rst:26
+msgid "Basic workflow from blog idea to published post"
+msgstr ""
+
+# 1be90c5561f143808cb47de0c8c8022a
+#: ../../source/contributor/contrib_guide_blog.rst:28
+msgid ""
+"There are several major steps in the workflow from blog idea to a "
+"published post including:"
+msgstr ""
+
+# 3c5ad2bb281a4aa6ac16b54a10dbdd1e
+#: ../../source/contributor/contrib_guide_blog.rst:31
+msgid "Be inspired to write a post"
+msgstr ""
+
+# 92a83a1a36a144c9ba2bcf30cc4da74b
+#: ../../source/contributor/contrib_guide_blog.rst:32
+msgid ""
+"Send us a message on the Jupyter mailing list and ask us for an author "
+"account on our blog"
+msgstr ""
+
+# 1cd0cdf496bf4a71b38d89513c9351f6
+# c454ba131c7947f3b756d636a19e3d39
+#: ../../source/contributor/contrib_guide_blog.rst:33
+#: ../../source/contributor/contrib_guide_blog.rst:42
+msgid "Creating a draft"
+msgstr ""
+
+# d60237d5d70c48e289be8db755f5488a
+#: ../../source/contributor/contrib_guide_blog.rst:34
+msgid "Draft Review"
+msgstr ""
+
+# 8e5bbd0595ae4f22abc31856f1b54c0d
+# 7a67f5bd5e864a89bdde0121c28c83cb
+#: ../../source/contributor/contrib_guide_blog.rst:35
+#: ../../source/contributor/contrib_guide_blog.rst:99
+msgid "Editorial acceptance"
+msgstr ""
+
+# 2a828f70ea3a42ebb52ab8fe17c58d83
+# 8ca1d1189f084c22a6513a9f7f370c3a
+#: ../../source/contributor/contrib_guide_blog.rst:36
+#: ../../source/contributor/contrib_guide_blog.rst:102
+msgid "Publishing the post"
+msgstr ""
+
+# 205eccbcaafc4d1c87184fdfa20ea1e0
+#: ../../source/contributor/contrib_guide_blog.rst:38
+msgid ""
+"We'll cover each of these as well as how to update a post once it has "
+"been published."
+msgstr ""
+
+# bbeb420a823542ee9f81fb9a9d9e9a4b
+#: ../../source/contributor/contrib_guide_blog.rst:45
+msgid "Title and metadata"
+msgstr ""
+
+# cb2170d8f32f40ab8ddb9dfe33eb88ec
+#: ../../source/contributor/contrib_guide_blog.rst:47
+msgid ""
+"Alway check in the metadata fields that a blog post has a title and a "
+"canonical URL. It is possible to put the date in the canonical URL, in "
+"particular for events like jupyter-day, that can occur several times. The"
+" date of the event can differ from the date of the blog post."
+msgstr ""
+
+# 275b539c7a0b4de092e7cbf9b0d07286
+#: ../../source/contributor/contrib_guide_blog.rst:52
+msgid ""
+"Once a post is published, **never** change the post's title or the url. "
+"These changes will break links of tweets and RSS feeds that have already "
+"referenced the existing, published URL. Keep in mind that when publishing"
+" some platforms cache the url immediately; as a result changing the title"
+" will direct people to a 404 page."
+msgstr ""
+
+# 7c80a8faf2824bd4a6a0a8848026e336
+#: ../../source/contributor/contrib_guide_blog.rst:58
+msgid ""
+"Title and metadata can always be refined after the actual content of the "
+"blog is written, but should not be changed after publication. As a guest "
+"you do not have to worry about metadata, the editor or admins will take "
+"care of that."
+msgstr ""
+
+# af2b4dd47be8465d9f86f09e8f35a907
+#: ../../source/contributor/contrib_guide_blog.rst:63
+msgid "Working with images"
+msgstr ""
+
+# 1dd8d06687a24b8294060cc78eb07ad9
+#: ../../source/contributor/contrib_guide_blog.rst:65
+msgid ""
+"Try not to link to external images. If you want to put an image in the "
+"post, insert ``![]()`` in the editor view and drag and drop an image from"
+" your desktop into the newly created field in the preview. External "
+"images can change, and can break the blog post if they are taken down. "
+"This cannot append if you drag and drop images. Moreover, these images  "
+"will be served from the same CDN (Content Delivery Network) as the blog, "
+"which will insure the best overall experience for our readers."
+msgstr ""
+
+# ae794323faec447a81ebde34bfcd39a1
+#: ../../source/contributor/contrib_guide_blog.rst:73
+msgid ""
+"The featured image you see at the top of a blog posts is set from within "
+"the metadata field, not using the `![]()`. The featured image is treated "
+"differently than inlined images by many feedreaders (especially on "
+"mobile) and allows a user on a slow connection to read the content of the"
+" blog earlier, which is a much better experience for the user than "
+"waiting for the featured image to render."
+msgstr ""
+
+# f8a4d5c3b90a4f598984c027f2b56f71
+#: ../../source/contributor/contrib_guide_blog.rst:80
+msgid "Links"
+msgstr ""
+
+# 5a9171fe32504c848544ef93477c13e0
+#: ../../source/contributor/contrib_guide_blog.rst:82
+msgid ""
+"Do not use minified links when possible. The multiple redirects of "
+"minified links degrades the mobile browsing experience. If you need "
+"analytics of the number of page views, this information is tracked by "
+"Google Analytics."
+msgstr ""
+
+# 36175d5a99a4463b9397b07b190925e3
+#: ../../source/contributor/contrib_guide_blog.rst:87
+msgid "Draft review"
+msgstr ""
+
+# 0b8e6790a0ea441c828238f2a79a627c
+#: ../../source/contributor/contrib_guide_blog.rst:90
+msgid "Ask for a review"
+msgstr ""
+
+# 3db41a20769540a18283ea37c44900b2
+#: ../../source/contributor/contrib_guide_blog.rst:92
+msgid ""
+"Once you think you are done, ask someone else to reread your post, and "
+"check the various parameters that you might have forgotten before "
+"publishing. You are not on your own, this is teamwork, we are here to "
+"help you. If we do things in a hurry you will probably spend more time "
+"fixing mistakes that actually doing things right in a first place."
+msgstr ""
+
+# 95365105a2e44a7d818b9f47b05853dc
+#: ../../source/contributor/contrib_guide_blog.rst:104
+msgid ""
+"Usually an editor or admin will take care of publishing the post. The "
+"task of the Editor/Admin is to check all metadata are correctly set, that"
+" no external images are used, as well as all other quality check describe"
+" before."
+msgstr ""
+
+# 809dc486262e437ebb95ce53542c0b79
+#: ../../source/contributor/contrib_guide_blog.rst:108
+msgid "It is then just a matter of making th post visible to everyone."
+msgstr ""
+
+# 0b9fd999238245dca7a574888ca974b5
+#: ../../source/contributor/contrib_guide_blog.rst:111
+msgid "Changing an existing post"
+msgstr ""
+
+# f7eb7e6e67924638b9fd1079ca1fd4be
+#: ../../source/contributor/contrib_guide_blog.rst:114
+msgid "Posts Updates"
+msgstr ""
+
+# eee44374b12542d9b54cb3618fd3e868
+#: ../../source/contributor/contrib_guide_blog.rst:116
+msgid ""
+"Blog subscribers may receive notification at every update. So use updates"
+" and fixes parsimoniously. It is OK to wait a few hours to fix a typo."
+msgstr ""
+
+# ab638c99ec3c460abfaad8d60a1e8800
+#: ../../source/contributor/contrib_guide_blog.rst:119
+msgid ""
+"If some substantial updates have to be made, like change of location, "
+"time etc, please insert an `[Update]` section at top (or bottom of the "
+"blog post depending on importance) with the Date/Time of the update. If "
+"the information in the body of the blog is wrong, try not to replace it, "
+"and just use strike-through to mark it as obsolete. This would help "
+"reader determine which information is correct when dealing with multiple "
+"source giving different informations."
+msgstr ""
+
+# 5fa61a2b985e43aa94c3cc695b08eed1
+#: ../../source/contributor/contrib_guide_blog.rst:128
+msgid "Newsletter"
+msgstr ""
+
+# 5122c3d734f24dbdb2f00e9731a31a27
+# 424ebb5fc17844658e7b83d9209374ce
+#: ../../source/contributor/contrib_guide_blog.rst:130
+#: ../../source/contributor/contrib_guide_blog.rst:136
+msgid "Documentation in progress."
+msgstr ""
+
+# 174fa91d9686461fa8f40c348d73dda3
+#: ../../source/contributor/contrib_guide_blog.rst:134
+msgid "Website"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/developer-docs.po
+++ b/docs/source/locale/es/LC_MESSAGES/developer-docs.po
@@ -1,0 +1,993 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 4af9f71750c8467e8467b4e5c923c079
+#: ../../source/developer-docs/contrib_first_time.rst:3
+msgid "Contributing for the First Time"
+msgstr ""
+
+# 856e1ce30fea448ebafd494bce7435e0
+# a1a8768c3922479fa3bb8f7c8ec19d78
+#: ../../source/developer-docs/contrib_first_time.rst:6
+#: ../../source/developer-docs/contrib_guide_code.rst:6
+msgid "Contents"
+msgstr ""
+
+# b75b7e5e93d443999da00800903a098c
+#: ../../source/developer-docs/contrib_first_time.rst:8
+msgid "Welcome fellow contributor! We appreciate your help."
+msgstr ""
+
+# feac7eb012a841038cfec4c31f26db07
+#: ../../source/developer-docs/contrib_first_time.rst:10
+msgid ""
+"We typically label issues appropriate for new contributors as ``good "
+"first issue`` or ``help wanted``.  To start an issue, you may comment to "
+"let everyone know that you'll be working on it.  Our repos typically "
+"provide development installation instructions in each repo's "
+"``CONTRIBUTING.md`` or ``README.md``. **Should you find an issue with our"
+" development installation instructions please let us know in our "
+"issues.**  We want to ensure that our documentation for development "
+"installation is accurate.  Additionally, other contributors are often "
+"available to answer questions about fixing the issue on the issue number "
+"or on the repo's gitter channel."
+msgstr ""
+
+# ee56c9c218734eb89634ced64adc7089
+#: ../../source/developer-docs/contrib_first_time.rst:20
+msgid ""
+"We strive to have a inclusive, welcoming community.  Please read our "
+"`code of conduct "
+"<https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`__"
+" to learn more."
+msgstr ""
+
+# fd7a319af3e449b6861b2d74e4e1c8cb
+#: ../../source/developer-docs/contrib_first_time.rst:25
+msgid "Major Repos and Issue Types"
+msgstr ""
+
+# fa17d1bbc25c469c8aa8e05eeeef1cca
+#: ../../source/developer-docs/contrib_first_time.rst:28
+msgid "Python"
+msgstr ""
+
+# cd8ab1883a03446b91db2f5d1f7c13db
+#: ../../source/developer-docs/contrib_first_time.rst:30
+msgid ""
+"IPython, nbgrader, JupyterHub, repo2docker, and Binder are major repos "
+"written primarily in Python."
+msgstr ""
+
+# 13e25fb7dc4c4715abc0394881b6e0f7
+#: ../../source/developer-docs/contrib_first_time.rst:34
+msgid "`IPython <https://github.com/ipython/ipython>`__"
+msgstr ""
+
+# c2da4aae25e4412a911d495ddecf8495
+#: ../../source/developer-docs/contrib_first_time.rst:33
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/ipython/ipython/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__"
+msgstr ""
+
+# c5ee2f00454c418ab40ddb37f145b04f
+#: ../../source/developer-docs/contrib_first_time.rst:34
+msgid ""
+"`Development Installation <https://github.com/ipython/ipython"
+"#development-and-instant-running>`__"
+msgstr ""
+
+# d4df3d9d6a3a4a69b57ea417354f7e43
+#: ../../source/developer-docs/contrib_first_time.rst:35
+msgid "`Gitter Channel <https://gitter.im/ipython/ipython>`__"
+msgstr ""
+
+# eb0579bf78894f9dbf75c8786657adb2
+#: ../../source/developer-docs/contrib_first_time.rst:37
+msgid "`nbgrader <https://github.com/jupyter/nbgrader>`__"
+msgstr ""
+
+# 4dbe9d98a5b04f3c97d6e3fcb5ac9c95
+#: ../../source/developer-docs/contrib_first_time.rst:37
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyter/nbgrader/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__"
+msgstr ""
+
+# 831273b724474075be7ed229e8f7f7e0
+#: ../../source/developer-docs/contrib_first_time.rst:38
+msgid ""
+"`Development Installation "
+"<https://nbgrader.readthedocs.io/en/latest/contributor_guide/installation_developer.html>`__"
+msgstr ""
+
+# d97b92c244d243088ab12928e87d6df7
+#: ../../source/developer-docs/contrib_first_time.rst:41
+msgid "`JupyterHub <https://github.com/jupyterhub/jupyterhub>`__"
+msgstr ""
+
+# 387d54bdacca494fbb48fe045047ad3b
+#: ../../source/developer-docs/contrib_first_time.rst:40
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyterhub/jupyterhub/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__"
+msgstr ""
+
+# 103323470924458c96863a2956b18934
+#: ../../source/developer-docs/contrib_first_time.rst:41
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyterhub/jupyterhub#contributing>`__"
+msgstr ""
+
+# b060a9da9d1341a4b1bb023eb4a2a514
+# 971d63207aa04f5a8f60aefcf4af75fa
+#: ../../source/developer-docs/contrib_first_time.rst:42
+#: ../../source/developer-docs/contrib_first_time.rst:46
+msgid "`Gitter Channel <https://gitter.im/jupyterhub/jupyterhub>`__"
+msgstr ""
+
+# c587dbe34ebf447e8ff83ec285a05cc4
+#: ../../source/developer-docs/contrib_first_time.rst:45
+msgid "`repo2docker <https://github.com/jupyter/repo2docker>`__"
+msgstr ""
+
+# 52bedabdb3b040e895cb1ca8f80d6041
+#: ../../source/developer-docs/contrib_first_time.rst:44
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyter/repo2docker/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__"
+msgstr ""
+
+# 2f57686e120c44d695178d92b790da17
+#: ../../source/developer-docs/contrib_first_time.rst:45
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyter/repo2docker#installation>`__"
+msgstr ""
+
+# 8d289dfea18048199cea959342abb58c
+#: ../../source/developer-docs/contrib_first_time.rst:50
+msgid "`Binder <https://github.com/jupyterhub/binderhub>`__"
+msgstr ""
+
+# 5857637ca0fd49e9808958dd94156769
+#: ../../source/developer-docs/contrib_first_time.rst:48
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyterhub/binderhub/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22>`__"
+msgstr ""
+
+# 782632da47684ce8a213946114dc86ed
+#: ../../source/developer-docs/contrib_first_time.rst:49
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md>`__"
+msgstr ""
+
+# 92bddf6026f94077b2f368e02315c5f9
+#: ../../source/developer-docs/contrib_first_time.rst:50
+msgid "`Gitter Channel <https://gitter.im/jupyterhub/binder>`__"
+msgstr ""
+
+# 9b380cabc14b47179027d99a76fb7b8b
+#: ../../source/developer-docs/contrib_first_time.rst:53
+msgid "Documentation"
+msgstr ""
+
+# ad4855a98345426b8ff5b1012d31ccfe
+#: ../../source/developer-docs/contrib_first_time.rst:55
+msgid ""
+"All our repos have documentation issues that are relevant for new "
+"contributors. For example, the source for the documentation you are "
+"reading right now can be found in the `jupyter/jupyter repository on "
+"GitHub <https://github.com/jupyter/jupyter>`__."
+msgstr ""
+
+# fb1acce4f0464fb583a61010ade7e13f
+#: ../../source/developer-docs/contrib_first_time.rst:59
+msgid "JavaScript/TypeScript"
+msgstr ""
+
+# d17b947479924673b44d5e34dba895af
+#: ../../source/developer-docs/contrib_first_time.rst:61
+msgid ""
+"Jupyter Notebook, JupyterLab, and IPyWidgets use JavaScript and "
+"TypeScript."
+msgstr ""
+
+# e73febabcbe341d4ab5cd9062fe95128
+#: ../../source/developer-docs/contrib_first_time.rst:65
+msgid "`Jupyter Notebook <https://github.com/jupyter/notebook>`__"
+msgstr ""
+
+# f1a0b2f2975f459e8c85be7dfe502070
+#: ../../source/developer-docs/contrib_first_time.rst:64
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyter/notebook/issues?q=is%3Aissue+is%3Aopen+label%3A%22tag%3ANew+Contributor%22>`__"
+msgstr ""
+
+# 67ec729c38dd4eb4afc774c99aad3512
+#: ../../source/developer-docs/contrib_first_time.rst:65
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyter/notebook/blob/master/CONTRIBUTING.rst>`__"
+msgstr ""
+
+# eacc49d0d4e046309c208bceab13b8cc
+#: ../../source/developer-docs/contrib_first_time.rst:66
+msgid "`Gitter Channel <https://gitter.im/jupyter/notebook>`__"
+msgstr ""
+
+# 15087cd5dd224b8a882fad3d6db3085b
+#: ../../source/developer-docs/contrib_first_time.rst:69
+msgid "`JupyterLab <https://github.com/jupyterlab/jupyterlab>`__"
+msgstr ""
+
+# f7a939c12a42438796221b1b3216b85c
+#: ../../source/developer-docs/contrib_first_time.rst:68
+#, python-format
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3AHelp+Wanted%22>`__"
+msgstr ""
+
+# 60727430accc47a59bdb9fd7c0dc9d10
+#: ../../source/developer-docs/contrib_first_time.rst:69
+msgid ""
+"`Development Installation "
+"<https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`__"
+msgstr ""
+
+# 889f6bb437974cbf98d5bc40c912e0b4
+#: ../../source/developer-docs/contrib_first_time.rst:70
+msgid "`Gitter Channel <https://gitter.im/jupyterlab/jupyterlab>`__"
+msgstr ""
+
+# e810bd44e3374585a51bf791e155e821
+#: ../../source/developer-docs/contrib_first_time.rst:74
+msgid "`IPyWidgets <https://github.com/jupyter-widgets/ipywidgets>`__"
+msgstr ""
+
+# 27cd0846c54e44769e1ca07e09612753
+#: ../../source/developer-docs/contrib_first_time.rst:72
+#, python-format
+msgid ""
+"`Notable Issues <https://github.com/jupyter-"
+"widgets/ipywidgets/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`__"
+msgstr ""
+
+# b2ed815f0f484e68a121c164065199df
+#: ../../source/developer-docs/contrib_first_time.rst:73
+msgid ""
+"`Development Instalation "
+"<https://ipywidgets.readthedocs.io/en/latest/dev_install.html>`__"
+msgstr ""
+
+# 72cbadaa4c3941bdb2196021192afe8c
+#: ../../source/developer-docs/contrib_first_time.rst:74
+msgid "`Gitter Channel <https://gitter.im/jupyter-widgets/Lobby>`__"
+msgstr ""
+
+# 540681780cc14e65925a8c0e9aad0405
+#: ../../source/developer-docs/contrib_first_time.rst:77
+msgid "DevOps"
+msgstr ""
+
+# 4b08f960f4e941e2b3aa717d7edca63b
+#: ../../source/developer-docs/contrib_first_time.rst:79
+msgid ""
+"JupyterHub, repo2docker, and Binder have many issues related to devops.  "
+"See the links above."
+msgstr ""
+
+# c0634775654042c2ad49c3d398f14230
+#: ../../source/developer-docs/contrib_first_time.rst:82
+msgid "Web Development"
+msgstr ""
+
+# 2920f2549f3c4ca5a27867664fd04def
+#: ../../source/developer-docs/contrib_first_time.rst:84
+msgid "We have issues related to the website."
+msgstr ""
+
+# 34830e753b7042d59da52a4bb2415161
+#: ../../source/developer-docs/contrib_first_time.rst:87
+msgid ""
+"`Project Jupyter's Website "
+"<https://github.com/jupyter/jupyter.github.io/>`__"
+msgstr ""
+
+# 2d035ecd6e9e40dfa1aa14533fd7e41c
+#: ../../source/developer-docs/contrib_first_time.rst:87
+msgid ""
+"`Notable Issues "
+"<https://github.com/jupyter/jupyter.github.io/issues?q=is%3Aissue+is%3Aopen+label"
+"%3Asprint-friendly>`__"
+msgstr ""
+
+# 2192a69a3d2f42008d5632996da49b7f
+#: ../../source/developer-docs/contrib_first_time.rst:88
+msgid ""
+"`Developer Installation <https://github.com/jupyter/jupyter.github.io"
+"#quick-local-testing>`__"
+msgstr ""
+
+# 0485183fb72344cf959bce1ba5420bd6
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:3
+msgid "Submitting a Bug"
+msgstr ""
+
+# af25f25c2cec41d8831b2e67c2a3e69c
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:4
+msgid ""
+"While using the Notebook, you might experience a bug that manifests "
+"itself in unexpected behavior.  If so, we encourage you  to open issues "
+"on GitHub. To make the navigating issues easier for both developers and "
+"users, we ask that you take the following steps before submitting an "
+"issue."
+msgstr ""
+
+# 139a72d8dfdb45cf90edf3e35aec0059
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:9
+msgid ""
+"Search through StackOverflow and existing GitHub issues to ensure that "
+"the issue has not already been reported by another user. If so, provide "
+"your input on the existing issue if you think it would be valuable."
+msgstr ""
+
+# cccad08769f44e52a04a90cbe76e2223
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:13
+msgid ""
+"Prepare a small, self-contained snippet of code that will allow others to"
+" reproduce the issue that you are experiencing."
+msgstr ""
+
+# c3a86b1233534248bb19fa1c1b09bd9d
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:16
+msgid ""
+"Prepare information about the environment that you are executing the code"
+" in, in order to aid in the debugging of the issue. You will need to "
+"provide information about the Python version, Jupyter version, operating "
+"system, and browser that you are using when submitting bugs. You can also"
+" use ``pip list`` or  ``conda list`` and ``grep`` in order to identify "
+"the versions of the libraries that are relevant to the issue that you are"
+" submitting."
+msgstr ""
+
+# b4302021c41448839eae6dca5b34a39e
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:24
+msgid ""
+"Prepare a simple test that outlines the expected behavior of the code or "
+"a description of the what the expected behavior should be."
+msgstr ""
+
+# 47c214b9890f43c599c9bf0b8c6e0582
+#: ../../source/developer-docs/contrib_guide_bugs_enh.rst:27
+msgid ""
+"Prepare an explanation of why the current behavior is not desired and "
+"what it should be."
+msgstr ""
+
+# 971e73dd85a54bf9b588dad72b000207
+# fcc463f334c9426abb8e84b007b2f6cd
+#: ../../source/developer-docs/contrib_guide_code.rst:3
+#: ../../source/developer-docs/index.rst:5
+msgid "Developer Guide"
+msgstr ""
+
+# 7c5e21c9bdad4985aeab19c9c6a7af56
+#: ../../source/developer-docs/contrib_guide_code.rst:9
+msgid "A Note on Contributing to Open Source"
+msgstr ""
+
+# b4b9389d3154437ba7df6c08d95bffb4
+#: ../../source/developer-docs/contrib_guide_code.rst:11
+msgid ""
+"Contributing to open source can be a nerve-wrecking process, but don't "
+"worry everyone on the Jupyter team is dedicated to making sure that your "
+"open source experience is as fun as possible. At any time during the "
+"process described below, you can reach out to the Jupyter team on Gitter "
+"or the mailing list for assistance. If you are nervous about asking "
+"questions in public, you can also reach out to one of the Jupyter "
+"developers in private. You can use the public Gitter to find someone who "
+"has the best knowledge about the code you are working with and interact "
+"with the in a personal chat."
+msgstr ""
+
+# cc89b39165a446e5b87c4f9266495c26
+#: ../../source/developer-docs/contrib_guide_code.rst:20
+msgid ""
+"As you begin your open source journey, remember that it's OK if you don't"
+" understand something, it's OK to make mistakes, and it's OK to only "
+"contribute a small amount of the code necessary to fix the issue you are "
+"tackling. Any and all help is welcome and any and all people are "
+"encouraged to contribute."
+msgstr ""
+
+# 641608cfd0864941a223bf39b6a0b4ce
+#: ../../source/developer-docs/contrib_guide_code.rst:26
+msgid "How can I help?"
+msgstr ""
+
+# a37196b3fb6a4df1870786ea3235406a
+#: ../../source/developer-docs/contrib_guide_code.rst:28
+msgid ""
+"Individuals are welcome, and encouraged, to submit pull requests and "
+"contribute to the Jupyter source. If you are a first-time contributor "
+"looking to get involved with Jupyter, you can use the following query in "
+"a GitHub search to find beginner-friendly issues to tackle across the "
+"Jupyter codebase. This query is particularly useful because the Jupyter "
+"codebase is scattered across several repositories within the jupyter "
+"organization, as opposed to a single repository. You can click the link "
+"below to find sprint-friendly issues."
+msgstr ""
+
+# 1eee498a843146fab2ef3b1e9317a7b3
+#: ../../source/developer-docs/contrib_guide_code.rst:36
+msgid ""
+"`is:issue is:open is:sprint-friendly user:jupyter "
+"<https://github.com/search?q=is%3Aissue+is%3Aopen+is%3Asprint-"
+"friendly+user%3Ajupyter&type=Issues&ref=searchresults>`_"
+msgstr ""
+
+# e2e8942ce25f4d44a4dc7cc2e67730b5
+#: ../../source/developer-docs/contrib_guide_code.rst:39
+msgid ""
+"Once you've found an issue that you are eager to solve, you can use the "
+"guide below to get started. If you experience any problems while working "
+"on the issue, leave a comment on the issue page in GitHub and someone on "
+"the core team will be able to lend you assistance."
+msgstr ""
+
+# df6093a6a72247089f0024bcb798dcbc
+#: ../../source/developer-docs/contrib_guide_code.rst:44
+msgid ""
+"Please keep in mind that what follows are guidelines. If you work through"
+" the steps and have questions or run into time constraints, please submit"
+" what you already have worked on as a pull request and ask questions on "
+"it. Your effort, including partial or in-progress work, is appreciated."
+msgstr ""
+
+# b3e3eb75571744d1b15d0d7f1bec2c13
+#: ../../source/developer-docs/contrib_guide_code.rst:49
+msgid ""
+"Fork the repository associated with the issue you are addressing and "
+"clone it to a local directory on your machine."
+msgstr ""
+
+# d4a40f6de2d243dc8f4c188d4bccb987
+#: ../../source/developer-docs/contrib_guide_code.rst:52
+msgid ""
+"``cd`` into the directory and create a new branch using ``git checkout -b"
+" insert-branch-name-here``. Pick a branch name that gives some insight "
+"into what the issue you are fixing is. For example, if you are updating "
+"the text that is logged out by the program when a certain error happens "
+"you might name your branch `update-error-text`."
+msgstr ""
+
+# 022300380d634dca91632205f9c0c3b8
+#: ../../source/developer-docs/contrib_guide_code.rst:58
+msgid ""
+"Refer to the repository's README and documentation for details on "
+"configuring your system for development."
+msgstr ""
+
+# b294af0b7be547ae948f435194728ad6
+#: ../../source/developer-docs/contrib_guide_code.rst:61
+msgid ""
+"Identify the module or class where the code change you will make will "
+"reside and leave a comment in the file describing what issue you are "
+"trying to address."
+msgstr ""
+
+# 3da7f1d0ab7249f893554f57520c67e6
+#: ../../source/developer-docs/contrib_guide_code.rst:65
+msgid ""
+"Open a pull request to the repository with ``[WIP]`` appended to the "
+"front so that the core team is aware that you are actively pursuing the "
+"issue. When creating a pull request, make sure that the title clearly and"
+" concisely described what your code does. For example, we might use the "
+"title \"Updated error message on ExampleException\". In the body of the "
+"pull request, make sure that you include the phrase \"Closes #issue-"
+"number-here\", where the issue number is the issue number of the issue "
+"that you are addressing in this PR."
+msgstr ""
+
+# 8a1d4bda15d54f63b755268e0ee3f928
+#: ../../source/developer-docs/contrib_guide_code.rst:74
+msgid ""
+"Feel free to open a PR as early as possible. Getting early feedback on "
+"your approach will save you time and prevent the need for an extensive "
+"refactor later."
+msgstr ""
+
+# 933a91389b064d329ba443dc8b4aac48
+#: ../../source/developer-docs/contrib_guide_code.rst:78
+msgid ""
+"Run the test suite locally in order to ensure that everything is properly"
+" configured on your system. Refer to the repository's README for "
+"information on how to run the test suite. This will typically require "
+"that you run the ``nosetests`` command on the commandline. Alternatively,"
+" you may submit a pull request. Our Continuous Integration system will "
+"test your code and report test results."
+msgstr ""
+
+# 4940b5b766d34b728500b8ee01b00a2e
+#: ../../source/developer-docs/contrib_guide_code.rst:85
+msgid ""
+"Find the test file associated with the module that you will be changing. "
+"In the test file, add some tests that outline what you expect the "
+"behavior of the change should be. If we continue with our example of "
+"updating the text that is logged on error, we might write test cases that"
+" check to see if the exception raised when you induce the error contains "
+"the appropriate string. When writing test cases, make sure that you test "
+"for the following things."
+msgstr ""
+
+# 190f4f31714c4eebbb80f054ed3b9ede
+#: ../../source/developer-docs/contrib_guide_code.rst:93
+msgid "What is the simplest test case I can write for this issue?"
+msgstr ""
+
+# bf18ca96f21e40d0a07cfa24d3f83ebb
+#: ../../source/developer-docs/contrib_guide_code.rst:94
+msgid "What will happen if your code is given messy inputs?"
+msgstr ""
+
+# 5e238f0155c44fc198bbe03b5eb52072
+#: ../../source/developer-docs/contrib_guide_code.rst:95
+msgid "What will happen if your code is given no inputs?"
+msgstr ""
+
+# f642285810ad4b74996365fabf4a36bc
+#: ../../source/developer-docs/contrib_guide_code.rst:96
+msgid "What will happen if your code is given too few inputs?"
+msgstr ""
+
+# fc7c95470d5c47d1a1c642101f0f128a
+#: ../../source/developer-docs/contrib_guide_code.rst:97
+msgid "What will happen if your code is given too many inputs?"
+msgstr ""
+
+# 1512fa1ef2674eb7b4fd8e0cffb9ea34
+#: ../../source/developer-docs/contrib_guide_code.rst:99
+msgid ""
+"If you need assistance writing test cases, you can place a comment on the"
+" pull request that was opened earlier and one of the core team members "
+"will be able to help you."
+msgstr ""
+
+# 8ef9e5734a364dc2988978fbf5c1f717
+#: ../../source/developer-docs/contrib_guide_code.rst:103
+msgid ""
+"Go back to the file that you are updating and begin adding the code for "
+"your pull request."
+msgstr ""
+
+# 10fd03dbbce04657995fe36c868333db
+#: ../../source/developer-docs/contrib_guide_code.rst:106
+msgid ""
+"Run the test suite again to see if your changes have caused any of the "
+"test cases to pass. If any of the test cases have failed, go back to your"
+" code and make the updates necessary to have them pass."
+msgstr ""
+
+# c8d1e89343e246daa2cdc22cdeb2611d
+#: ../../source/developer-docs/contrib_guide_code.rst:110
+msgid ""
+"Once all of your test cases have passed, commit both the test cases and "
+"the updated module and push the updates to the branch on your forked "
+"repository."
+msgstr ""
+
+# 87111861fffe4a49a87827323e112ce7
+#: ../../source/developer-docs/contrib_guide_code.rst:113
+msgid ""
+"Once you are ready for your pull request to be reviewed, remove the [WIP]"
+" tag from the front of issue, a project reviewer will review your code "
+"for quality. You can expect the reviewer to check for the documentation "
+"provided in the changes you made, how thorough the test cases you "
+"provided are, and how efficient your code is. Your reviewer will provide "
+"feedback on your code and you will have the chance to edit your code and "
+"apply fixes."
+msgstr ""
+
+# 5f6e2c2d4cc74b1686fec2915006f366
+#: ../../source/developer-docs/contrib_guide_code.rst:120
+msgid ""
+"Once your PR is ready to become a part of the code base, it will be "
+"merged by a member of the core team."
+msgstr ""
+
+# 0b6fc432cbc7440aa4365d35fe0e7533
+#: ../../source/developer-docs/contrib_guide_code.rst:124
+msgid "Contribution Workflow"
+msgstr ""
+
+# 9869fb16c17e4a2dbe7e220f2099e7a4
+#: ../../source/developer-docs/contrib_guide_code.rst:130
+msgid "Core Developer Workflow"
+msgstr ""
+
+# d88b2538fa7c4b65a87600628a3190fa
+#: ../../source/developer-docs/contrib_guide_code.rst:132
+msgid ""
+"To help you understand our review process by core developers after you "
+"submit a pull request, here's a guide that outlines the general process "
+"(specifics may vary a bit across our repositories). Here is an example "
+"for Jupyter notebook 4.x:"
+msgstr ""
+
+# 6afb4060cab3492f8185187faada55b2
+#: ../../source/developer-docs/contrib_guide_code.rst:139
+msgid ""
+"In general, Pull Requests are against ``master`` unless they only affect "
+"a backport branch. If a PR affects master and should be backported, the "
+"general flow is:"
+msgstr ""
+
+# 3b5bfc37063a4062a301ee23411528c0
+#: ../../source/developer-docs/contrib_guide_code.rst:143
+msgid "mark the PR with milestone for the next backport release (4.3)"
+msgstr ""
+
+# c42e3f791f6d4cc38b4fb9ac0eec129a
+#: ../../source/developer-docs/contrib_guide_code.rst:144
+msgid "merge into master"
+msgstr ""
+
+# 018cd8318aef471484dc9184b43973c3
+#: ../../source/developer-docs/contrib_guide_code.rst:145
+msgid "backport to 4.x"
+msgstr ""
+
+# 7b28314df8154e5b8606b722f4d73856
+#: ../../source/developer-docs/contrib_guide_code.rst:146
+msgid "push updated 4.x branch"
+msgstr ""
+
+# 10d9ca0afcf8439aac13eba4c1f428db
+#: ../../source/developer-docs/contrib_guide_code.rst:148
+msgid ""
+"Backports can be done in a variety of ways, but we have `a script "
+"<https://github.com/ipython/ipython/blob/master/tools/backport_pr.py>`_ "
+"for automating the common process to:"
+msgstr ""
+
+# 370a6eafee694f6ca5d7753ca3ef1962
+#: ../../source/developer-docs/contrib_guide_code.rst:152
+msgid ""
+"download the patch ` e.g. <https://patch-"
+"diff.githubusercontent.com/raw/jupyter/notebook/pull/1645.patch>`"
+msgstr ""
+
+# 1964c880516c43f99cbf34dadca2bdf1
+#: ../../source/developer-docs/contrib_guide_code.rst:153
+msgid "checkout the 4.x branch"
+msgstr ""
+
+# 70cb7a619981417393a3e1be5e661492
+#: ../../source/developer-docs/contrib_guide_code.rst:154
+msgid "apply the patch"
+msgstr ""
+
+# 1d6c472ef4e34a87ba54dd61299b1607
+#: ../../source/developer-docs/contrib_guide_code.rst:155
+msgid "make a commit"
+msgstr ""
+
+# bcc8acbb2663447fb1abece94d18a145
+#: ../../source/developer-docs/contrib_guide_code.rst:157
+msgid "which works for simple cases, at least."
+msgstr ""
+
+# 481646fca06049c39c7ccc2c7dfb000d
+#: ../../source/developer-docs/contrib_guide_code.rst:159
+msgid "In this case, it would be:"
+msgstr ""
+
+# 871218e69ea840f6a710fffda0f59255
+#: ../../source/developer-docs/contrib_guide_code.rst:161
+msgid ""
+"python /path/to/ipython-repo/tools/backport_pr.py jupyter/notebook 4.x "
+"1645"
+msgstr ""
+
+# 59008b88919d4084b6e7278a762249be
+#: ../../source/developer-docs/contrib_guide_vuln.rst:3
+msgid "Reporting a Vulnerability"
+msgstr ""
+
+# a848ceabd5bb48f9ba9cd7741ffe2733
+#: ../../source/developer-docs/contrib_guide_vuln.rst:5
+msgid ""
+"If you believe you've found a security vulnerability in a Jupyter "
+"project, please report it to "
+"[security@ipython.org](mailto:security@ipython.org). If you prefer to "
+"encrypt your security reports, you can use [this PGP public key](https"
+"://jupyter-"
+"notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc)."
+msgstr ""
+
+# c52d228e243243108261b278ecd95e9b
+#: ../../source/developer-docs/index.rst:7
+msgid "**Contents**"
+msgstr ""
+
+# 1dc0b8ea396a43d29a89a7917b0c918c
+#: ../../source/developer-docs/index.rst:20
+msgid ""
+"Whether you are a new contributor or a seasoned developer, we're pleased "
+"that you are working on Jupyter. We hope you find the Developer Guide is "
+"useful. Please suggest changes or ask questions about the contents. "
+"Thanks!"
+msgstr ""
+
+# ab19140a7ecf4481a9c8de4115df0760
+#: ../../source/developer-docs/index.rst:24
+msgid ""
+"If you are interested in installing a specific project from source, each "
+"project has documentation on ReadTheDocs. For example, IPython "
+"documentation can be found on `ReadTheDocs "
+"<http://ipython.readthedocs.io/en/latest/install/install.html"
+"#installation-from-source>`_. Most of our packages can be installed from "
+"the source directory like any other Python package, by running:"
+msgstr ""
+
+# 9219dc1779c14cdc86b8897e89749812
+#: ../../source/developer-docs/index.rst:34
+msgid ""
+"The Jupyter notebook needs some extra pieces to build Javascript "
+"components; the information about that is in the `notebook contributor "
+"documentation <http://jupyter-"
+"notebook.readthedocs.io/en/latest/contributing.html#setting-up-a"
+"-development-environment>`_."
+msgstr ""
+
+# ba9cdf4e3c534e8aaf851f3dda9197fa
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:2
+msgid "Jupyter Enhancement Proposals"
+msgstr ""
+
+# ca6fb9c7ab5a4fa886eeafec23b5e9d7
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:5
+msgid "Submitting an Enhancement Proposal"
+msgstr ""
+
+# 7b963188c0664d0eb0db00c494527254
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:6
+msgid ""
+"While using the Notebook, you might discover opportunities for growth and"
+" ideas for useful new features. If so, feel free to submit an enhancement"
+" proposal. The process for submitting enhancements is as follows:"
+msgstr ""
+
+# 00dbb9daf8e847ae9582179a7c574667
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:10
+msgid ""
+"Identify the scope of the enhancement. Is it a change that affects only "
+"on part of the codebase? Is the enhancement, to the best of your "
+"knowledge, fairly trivial to implement? If the scope of the enhancement "
+"is small, it should be be submitted as an issue in the project's "
+"repository. If the scope of your enhancement is large, it should be "
+"submitted to the official `Jupyter Enhancement Proposals repository "
+"<https://GitHub.com/jupyter/enhancement-proposals>`_."
+msgstr ""
+
+# ce6afac33e824a67b47c41ac989e42fe
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:17
+msgid ""
+"Prepare a brief write-up of the problem that your enhancement will "
+"address."
+msgstr ""
+
+# b3c8157c7deb456cbfc628b50b9cb3e5
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:19
+msgid "Prepare a brief write-up of the proposed enhancement itself."
+msgstr ""
+
+# a3742f392e7d48269a6eb5ad6b3b29db
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:21
+msgid ""
+"If the scope of your enhancement (as defined in step 1) is large, then "
+"prepare a detailed write-up of how your enhancement can be potentially "
+"implemented."
+msgstr ""
+
+# 8b68a4fe91c741fa8ca70adea65993b3
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:24
+msgid ""
+"Identify a brief list of the pros and cons associated with implementing "
+"the enhancement that you propose."
+msgstr ""
+
+# 05d6c080c5694b76b055702502bba802
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:27
+msgid ""
+"Identify the individuals who might be interested in implementing the "
+"enhancement."
+msgstr ""
+
+# c2300fb3ceac4a66a45558b7967a8b69
+#: ../../source/developer-docs/jupyter_enhancement_proposals.rst:29
+msgid ""
+"Depending on the scope of your enhancement, submit it either as an issue "
+"to the appropriate repository or as a Jupyter Enhancement Proposal."
+msgstr ""
+
+# 5229bf41eae2469e935b184e97efb92f
+#: ../../source/developer-docs/releasing.rst:5
+msgid "Basic template for releasing a Jupyter project"
+msgstr ""
+
+# cd861154d1f84d8ea5d16b605e863348
+#: ../../source/developer-docs/releasing.rst:7
+msgid ""
+"Jupyter consists of a bunch of small projects, and a few larger ones. "
+"This lays out the basic process of releasing a smaller project, which "
+"should also apply to larger projects, though they may have some added "
+"steps."
+msgstr ""
+
+# ee207b96ee4e491eb606356ff7070dfa
+#: ../../source/developer-docs/releasing.rst:14
+msgid "Milestones"
+msgstr ""
+
+# 2a00176ea8fb4fe794664c05e57dd8b5
+#: ../../source/developer-docs/releasing.rst:16
+msgid ""
+"Most Jupyter projects use a GitHub milestone system for marking issues "
+"and pull requests in releases. Each release should have a milestone "
+"associated with it. The first step in preparing for a release is to make "
+"sure that every issue and pull request has the right milestone."
+msgstr ""
+
+# 0c7eec680ceb4af9a72f8dab62c26656
+#: ../../source/developer-docs/releasing.rst:20
+msgid ""
+"Go through any **open** Issues and Pull Requests marked with the current "
+"milestone. If there are any, they need to be resolved or bumped to the "
+"next milestone. It's fine to bump issues - they are typically marked with"
+" the earliest feasible milestone, but many such optimistically marked "
+"tasks aren't complete when it's time to release. There's always next "
+"time!"
+msgstr ""
+
+# bb130aa7931f4847b76a34059a9c9d35
+#: ../../source/developer-docs/releasing.rst:25
+msgid ""
+"Check **closed** Issues and Pull Requests, using the milestone filter "
+"\"Issues with no milestone\". There should never be any closed issues or "
+"pull requests without a milestone. If you find any, go through and mark "
+"them with the current milestone or \"no action\" as appropriate."
+msgstr ""
+
+# 405918c188824db7a4ae6128c0016fb5
+#: ../../source/developer-docs/releasing.rst:31
+msgid ""
+"A release may be ready to go when it has zero open issues or pull "
+"requests."
+msgstr ""
+
+# 1e581bc70c1245fa87d458bb6cf9da6f
+#: ../../source/developer-docs/releasing.rst:35
+msgid "Release notes"
+msgstr ""
+
+# cee9ab2013764c5384b4744a1b53fc93
+#: ../../source/developer-docs/releasing.rst:37
+msgid ""
+"Once all of the issues and pull requests are dealt with, it's time to "
+"make release notes. The smaller projects generally have a "
+":file:`changelog.rst` in the docs directory, where you can add a section "
+"for the new release. Look through the pull requests merged for the "
+"current milestone (this is why we use milestones), and write a short "
+"summary of the highlights of the changes in this release. There should "
+"generally be a link to the milestone itself for more details."
+msgstr ""
+
+# 089a6812113341949f101391390ff914
+#: ../../source/developer-docs/releasing.rst:45
+msgid ""
+"Make a pull requests with these notes. It's a good idea to cc @willingc "
+"for review of this PR. Make sure to mark this PR with your release's "
+"milestone!"
+msgstr ""
+
+# cc10475d5ef64e6ba38860fd5de6746d
+#: ../../source/developer-docs/releasing.rst:51
+msgid "Making the release"
+msgstr ""
+
+# df383c7a5c5945838338679952e39cb2
+#: ../../source/developer-docs/releasing.rst:53
+msgid ""
+"Now that your changelog is merged, we can actually build and publish the "
+"release. We'll assume that ``V`` has been declared as a shell variable "
+"containing the release version::"
+msgstr ""
+
+# c3f810a58bec4ab593bd3cb5780a7800
+#: ../../source/developer-docs/releasing.rst:58
+msgid ""
+"Start by making sure you have a clean checkout of master, with no extra "
+"files::"
+msgstr ""
+
+# dfa0fb808869495cb344491a84a9bb95
+#: ../../source/developer-docs/releasing.rst:63
+msgid ""
+"First, update the version of the package, often in the file "
+":file:`<pkg>/_version.py` or similar."
+msgstr ""
+
+# 4bcd13891eac4bb0ba91bbebcf098767
+#: ../../source/developer-docs/releasing.rst:65
+msgid "Commit that change::"
+msgstr ""
+
+# 34263cae40c2473d9fba3a813758b95f
+#: ../../source/developer-docs/releasing.rst:71
+msgid ""
+"At this point, I like to run the tests just to be sure that setting the "
+"version didn't confuse anything."
+msgstr ""
+
+# 5a5e318fddd94e67a6ff324546cf6ea8
+#: ../../source/developer-docs/releasing.rst:74
+msgid "Build the distributions::"
+msgstr ""
+
+# f6f03aad7bdd4be79c7cb7d1d4fd0898
+#: ../../source/developer-docs/releasing.rst:79
+msgid "Tag the commit::"
+msgstr ""
+
+# 83952c3b04f449d8a88e05fdb304dd29
+#: ../../source/developer-docs/releasing.rst:83
+msgid ""
+"And finally, publish everything, to github and PyPI using `twine "
+"<https://github.com/pypa/twine>`_::"
+msgstr ""
+
+# 6aae441e50b747efa6796a94f1d11211
+#: ../../source/developer-docs/releasing.rst:89
+msgid ""
+"We have a release! You can now bump the version to the next '.dev' "
+"version, by editing :file:`<pkg>/_version.py` (or similar) again, and "
+"commit::"
+msgstr ""
+
+# c3cde896bc9041b49e4f3305ec5d2128
+#: ../../source/developer-docs/releasing.rst:97
+msgid ""
+"The pushes assume that `origin` points to the main jupyter/ipython repo. "
+"Depending how you use git, this could be `upstream` or something else."
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/development_guide.po
+++ b/docs/source/locale/es/LC_MESSAGES/development_guide.po
@@ -1,0 +1,3932 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 20:11-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 68594f7b5d5243178cc934fef0ff52ac
+#: ../../source/development_guide/boot2docker.rst:4
+msgid "Setup IPython development environment using boot2docker"
+msgstr ""
+
+# c58a4d9ce362416aa2daee3df0414ffb
+# e672e2de6d6449a29cc141b4ade2eeda
+# da64540a97524eae993335e681c87efe
+# df673bb406394df09796f62b181bc76c
+# c6ccec59d6b24b65b672d2b16e0cfbf3
+# a3791289050546b592649661277f5df9
+# c7c0ad0e79bb413b8d7956188294533b
+# 98a81ea5075b4ea7b5565d6bc0b86a03
+# 8443422c6ee045edbcd483ce2c654348
+# 0a17cb2a8248427c9980b12767b26bf5
+# 53507b55bf0d4779879707534702049f
+# e7da595236724a8c9c3f228d663e0a98
+# fcc87c9518d44372986a025fb70993b6
+# 914169504e1f479db9966697a9c327b4
+# abe35ed53e9544aaba2a10892e50c995
+# 75aa173cd6e349c38f5c305f6c1e8cf6
+#: ../../source/development_guide/boot2docker.rst:7
+#: ../../source/development_guide/closing_prs.rst:7
+#: ../../source/development_guide/coding_style.rst:7
+#: ../../source/development_guide/documenting_ipython.rst:7
+#: ../../source/development_guide/github_workflow.rst:7
+#: ../../source/development_guide/index.rst:7
+#: ../../source/development_guide/js_events.rst:7
+#: ../../source/development_guide/lab_meetings.rst:7
+#: ../../source/development_guide/less.rst:7
+#: ../../source/development_guide/pull_request.rst:7
+#: ../../source/development_guide/py3compat.rst:7
+#: ../../source/development_guide/releasing.rst:7
+#: ../../source/development_guide/rest_api.rst:7
+#: ../../source/development_guide/sphinx_directive.rst:7
+#: ../../source/development_guide/testing.rst:7
+#: ../../source/development_guide/testing_kernels.rst:7
+msgid ""
+"This is copied verbatim from the old IPython wiki and is currently under "
+"development. Much of the information in this part of the development "
+"guide is out of date."
+msgstr ""
+
+# 838ebaf9ef564b538433da5fc636f7f1
+#: ../../source/development_guide/boot2docker.rst:9
+msgid ""
+"The following are instructions on how to get an IPython development "
+"environment up and running without having to install anything on your "
+"host machine, other than ```boot2docker`` "
+"<https://github.com/boot2docker/boot2docker>`__ and ```docker`` "
+"<https://www.docker.com/>`__."
+msgstr ""
+
+# b68287e01b4e44feaa6874beb4f48e33
+#: ../../source/development_guide/boot2docker.rst:16
+msgid "Install ``boot2docker``"
+msgstr ""
+
+# 87465fdbf40840caa1d714143f237347
+#: ../../source/development_guide/boot2docker.rst:18
+msgid ""
+"Install `boot2docker <https://github.com/boot2docker/boot2docker>`__. "
+"There are multiple ways to install, depending on your environment. See "
+"the `boot2docker docs <https://github.com/boot2docker/boot2docker>`__."
+msgstr ""
+
+# 4b5576467cd04ab4addfaf7f2dbc9c8c
+#: ../../source/development_guide/boot2docker.rst:24
+msgid "Mac OS X"
+msgstr ""
+
+# c22634b884c6483ebe67c40611bc9805
+#: ../../source/development_guide/boot2docker.rst:26
+msgid "On a Mac OS X host with `Homebrew <http://brew.sh>`__ installed:"
+msgstr ""
+
+# db5a7fb63dbe455083f8e8e2caed7435
+#: ../../source/development_guide/boot2docker.rst:33
+msgid "Initialize ``boot2docker`` VM"
+msgstr ""
+
+# 54c6a6b598ac43b6aee4cd42e11a47b6
+#: ../../source/development_guide/boot2docker.rst:40
+msgid "Start VM"
+msgstr ""
+
+# 0f0d8f53a4ef40b590afdf1f1dcd8902
+#: ../../source/development_guide/boot2docker.rst:46
+msgid ""
+"The ``boot2docker`` CLI communicates with the docker daemon on the "
+"``boot2docker`` VM. To do this, we must set some environment variables, "
+"e.g. ``DOCKER_HOST``,"
+msgstr ""
+
+# cc1d31d1c4a247378bfcaaad4453050f
+#: ../../source/development_guide/boot2docker.rst:54
+msgid "To view the IP address of the VM:"
+msgstr ""
+
+# 3644c712c8d042deb536906e299d7302
+#: ../../source/development_guide/boot2docker.rst:62
+msgid "Install ``ipython`` from Development Branch"
+msgstr ""
+
+# fb26c1a1c9e64219a9569a2f09491a7c
+#: ../../source/development_guide/boot2docker.rst:69
+msgid "Build Docker Image"
+msgstr ""
+
+# 3186d34726d84139b077dd88cfcfb94a
+#: ../../source/development_guide/boot2docker.rst:71
+msgid ""
+"Use the Dockerfile in the cloned ``ipython`` directory to build a Docker "
+"image."
+msgstr ""
+
+# 07c715242d6d4a7fbf8b07eb27d00c5d
+#: ../../source/development_guide/boot2docker.rst:80
+msgid "Run Docker Container"
+msgstr ""
+
+# 1e5ff76a0da84a9d94587ef29a5ff8d4
+#: ../../source/development_guide/boot2docker.rst:82
+msgid ""
+"Run a container using the new image. We mount the entire ``ipython`` "
+"source tree on the host into the container at ``/srv/ipython`` to enable "
+"changes we make to the source on the host immediately reflected in the "
+"container."
+msgstr ""
+
+# 7169e25c6baf40b8889c6a22f710203e
+#: ../../source/development_guide/boot2docker.rst:93
+msgid "To list the running container from another shell on the host:"
+msgstr ""
+
+# 03945f9ceca44f629ddca27e5a97b97e
+#: ../../source/development_guide/boot2docker.rst:103
+msgid "Install IPython in Editable Mode"
+msgstr ""
+
+# 5a1104a612284812a3ae1bbe1c90fea6
+#: ../../source/development_guide/boot2docker.rst:105
+msgid ""
+"Once in the container, you'll need to uninstall the ``ipython`` package "
+"and re-install in editable mode to enable your dev changes to be "
+"reflected in your environment."
+msgstr ""
+
+# 5ff35ef88252440b9f9b3eb342580672
+#: ../../source/development_guide/boot2docker.rst:120
+msgid "Run Notebook Server"
+msgstr ""
+
+# 4e74c9cf2d184935a6c3a2b096d959b5
+#: ../../source/development_guide/boot2docker.rst:127
+msgid "Visit Notebook Server"
+msgstr ""
+
+# 1c7053580c414a5288a396b9ed7805f8
+#: ../../source/development_guide/boot2docker.rst:129
+msgid ""
+"On your host, run the following command to get the IP of the boot2docker "
+"VM if you forgot:"
+msgstr ""
+
+# 23da7928850040239ef807b7959c0cd9
+#: ../../source/development_guide/boot2docker.rst:138
+msgid "Then visit it in your browser:"
+msgstr ""
+
+# cef8292d861940009dfe37218ea8e00b
+#: ../../source/development_guide/boot2docker.rst:145
+msgid ""
+"As a shortcut on a Mac, you can run the following in a terminal window "
+"(or make it a bash alias):"
+msgstr ""
+
+# dbb1b7b037264b6aa1392abd9a3cc4e8
+#: ../../source/development_guide/closing_prs.rst:4
+msgid "Policy on Closing Pull Requests"
+msgstr ""
+
+# 4457e1e8c0744af2998ef6c8fda5393a
+#: ../../source/development_guide/closing_prs.rst:9
+msgid ""
+"IPython has the following policy on closing pull requests. The goal of "
+"this policy is to keep our pull request queue small and allow us to focus"
+" on code that is being actively developed and has a strong chance of "
+"being merged in master soon."
+msgstr ""
+
+# 6d8ef2f40c884f8485f2555032c90e65
+#: ../../source/development_guide/closing_prs.rst:14
+msgid "A pull request will be closed when:"
+msgstr ""
+
+# 5296d8b1e26d4920b014f007532f13c1
+#: ../../source/development_guide/closing_prs.rst:16
+msgid ""
+"It has been reviewed, but has sat for a month or more waiting for the "
+"submitter to commit more code to address the comments."
+msgstr ""
+
+# 1b189f41fadd4727b9518d4a36cea12e
+#: ../../source/development_guide/closing_prs.rst:18
+msgid ""
+"The review process has uncovered larger design or technical issues that "
+"extend beyond the details of the specific pull request."
+msgstr ""
+
+# 33f62e8f6d374379becff41a3411cfc3
+#: ../../source/development_guide/closing_prs.rst:21
+msgid ""
+"In particular, we do not accept whole large \"cleanup\" changes which do "
+"not address any specific bug. This includes trailing whitespace, PEP8, "
+"etc. One of the reasons is that such massive cleanup provide plenty of "
+"opportunities to introduce new and subtle bugs."
+msgstr ""
+
+# ff27543439ef4ff797a196a8a4e5aed6
+#: ../../source/development_guide/closing_prs.rst:27
+msgid ""
+"In general we will not close pull requests because of a lack of review. "
+"If a pull request has sat for a month or more without review, we need to "
+"kick ourselves and get to reviewing it."
+msgstr ""
+
+# 836a8c8dc6d44c04a337d673fb6fbff0
+#: ../../source/development_guide/closing_prs.rst:31
+msgid "When a pull request is closed we will do the following:"
+msgstr ""
+
+# 266b795ae71e43cc87cddb8286e40a03
+#: ../../source/development_guide/closing_prs.rst:33
+msgid ""
+"Post a github message to the pull request to confirm that everyone is "
+"fine with closing the pull request. This message should cite this policy."
+msgstr ""
+
+# 16ba3fb52f27430f90d7f61930398bb1
+#: ../../source/development_guide/closing_prs.rst:36
+msgid ""
+"Open an issue to track the pull request. This issue should describe what "
+"would be needed in order to reopen the pull request."
+msgstr ""
+
+# 0f58a1256caa4b7192796a5736a382fa
+#: ../../source/development_guide/closing_prs.rst:38
+msgid ""
+"Post a github message to the pull request encouraging the submitter to "
+"continue with the work and detail what issues need to be addressed in "
+"order for the pull request to be reopened."
+msgstr ""
+
+# e69ccb3b0acf4fd084506753d3c24d19
+#: ../../source/development_guide/closing_prs.rst:42
+msgid "This policy was discussed in the following thread:"
+msgstr ""
+
+# 1f3432526f934316b5cc8c24c79373d0
+#: ../../source/development_guide/closing_prs.rst:44
+msgid "https://mail.scipy.org/pipermail/ipython-dev/2012-August/010025.html"
+msgstr ""
+
+# ed7cad128706471b952c27bef1853163
+#: ../../source/development_guide/closing_prs.rst:47
+msgid "Example Message:"
+msgstr ""
+
+# 2ed6aa93ae254842abf6ac9840dcad6b
+#: ../../source/development_guide/coding_style.rst:4
+msgid "Coding Style"
+msgstr ""
+
+# 9dc8aa2c74864d179a5660cf9b835565
+#: ../../source/development_guide/coding_style.rst:9
+msgid ""
+"This document describes our coding style. Coding style refers to the "
+"following:"
+msgstr ""
+
+# 3b823c54355c4add8d1a262896faff88
+#: ../../source/development_guide/coding_style.rst:12
+msgid "How source code is formatted (indentation, spacing, etc.)"
+msgstr ""
+
+# 57c4f53e269a4abc99fb2f32b3c45fbe
+#: ../../source/development_guide/coding_style.rst:13
+msgid "How things are named (variables, functions, classes, modules, etc.)"
+msgstr ""
+
+# c110cd13183f48c3ba04055dc0fe3cd1
+#: ../../source/development_guide/coding_style.rst:16
+msgid "General coding conventions"
+msgstr ""
+
+# 919ed475296f42af850c26db1f5cf22d
+#: ../../source/development_guide/coding_style.rst:18
+msgid ""
+"In general, we follow the standard Python style conventions as described "
+"in Python's `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`__, the "
+"official Python Style Guide."
+msgstr ""
+
+# af906044ad2e45d59473fa93957caf11
+#: ../../source/development_guide/coding_style.rst:22
+msgid "Other general comments:"
+msgstr ""
+
+# a67babfcd44d4b78b92ae38338f1ae72
+#: ../../source/development_guide/coding_style.rst:24
+msgid ""
+"In a large file, top level classes and functions should be separated by 2"
+" lines to make it easier to separate them visually."
+msgstr ""
+
+# 93eb729f53834df789c27c571a413cf3
+#: ../../source/development_guide/coding_style.rst:27
+msgid "Use 4 spaces for indentation, **never** use hard tabs."
+msgstr ""
+
+# 7f266e5248eb4e03b2e6172a78a8192f
+#: ../../source/development_guide/coding_style.rst:29
+msgid ""
+"Keep the ordering of methods the same in classes that have the same "
+"methods. This is particularly true for classes that implement similar "
+"interfaces and for interfaces that are similar."
+msgstr ""
+
+# f0f19b61545e4b3494e24b82a6428eb8
+#: ../../source/development_guide/coding_style.rst:34
+msgid "Naming conventions"
+msgstr ""
+
+# 627a72694cf142f29149585571fe0f00
+#: ../../source/development_guide/coding_style.rst:36
+msgid ""
+"For naming conventions, we also follow the guidelines of `PEP 8 "
+"<https://www.python.org/dev/peps/pep-0008/>`__. Some of the existing code"
+" doesn't honor this perfectly, but for all new and refactored IPython "
+"code, we'll use:"
+msgstr ""
+
+# 01c1d05be01b4ebaa2925993cda05b5e
+#: ../../source/development_guide/coding_style.rst:41
+msgid ""
+"All ``lowercase`` module names. Long module names can have words "
+"separated by underscores (``really_long_module_name.py``), but this is "
+"not required. Try to use the convention of nearby files."
+msgstr ""
+
+# 735af590e2894b84a25c4e014f5668ac
+#: ../../source/development_guide/coding_style.rst:45
+msgid "``CamelCase`` for class names."
+msgstr ""
+
+# 79ba0d92752b4a81a3edd927e5bb04bb
+#: ../../source/development_guide/coding_style.rst:47
+msgid ""
+"``lowercase_with_underscores`` for methods, functions, variables and "
+"attributes."
+msgstr ""
+
+# 8bef511e37924748b1d2e276dbe87e14
+#: ../../source/development_guide/coding_style.rst:50
+msgid ""
+"Implementation-specific *private* methods will use "
+"``_single_underscore_prefix``. Names with a leading double underscore "
+"will *only* be used in special cases, as they makes subclassing difficult"
+" (such names are not easily seen by child classes)."
+msgstr ""
+
+# 91bbe7cbf0a94cfbbbd298eaa6a826eb
+#: ../../source/development_guide/coding_style.rst:55
+msgid ""
+"Occasionally some run-in lowercase names are used, but mostly for very "
+"short names or where we are implementing methods very similar to existing"
+" ones in a base class (like ``runlines()`` where ``runsource()`` and "
+"``runcode()`` had established precedent)."
+msgstr ""
+
+# 7c362e1e2fa444b49046b01386e4deb0
+#: ../../source/development_guide/coding_style.rst:60
+msgid ""
+"The old IPython codebase has a big mix of classes and modules prefixed "
+"with an explicit ``IP`` of ``ip``. This is not necessary and all new code"
+" should not use this prefix. The only case where this approach is "
+"justified is for classes or functions which are expected to be imported "
+"into external namespaces and a very generic name (like Shell) that is "
+"likely to clash with something else. However, if a prefix seems "
+"absolutely necessary the more specific ``IPY`` or ``ipy`` are preferred."
+msgstr ""
+
+# 726f417c6f4f4bd7848b5a4fb6335b48
+#: ../../source/development_guide/coding_style.rst:69
+msgid "All JavaScript code should follow these naming conventions as well."
+msgstr ""
+
+# 45e0d17e22f64edf9c68181820b2598c
+#: ../../source/development_guide/coding_style.rst:72
+msgid "Attribute declarations for objects"
+msgstr ""
+
+# beddc03b335a4e8fb4cd44d441db527b
+#: ../../source/development_guide/coding_style.rst:74
+msgid ""
+"In general, objects should declare, in their *class*, all attributes the "
+"object is meant to hold throughout its life. While Python allows you to "
+"add an attribute to an instance at any point in time, this makes the code"
+" harder to read and requires methods to constantly use checks with "
+"hasattr() or try/except calls. By declaring all attributes of the object "
+"in the class header, there is a single place one can refer to for "
+"understanding the object's data interface, where comments can explain the"
+" role of each variable and when possible, sensible deafaults can be "
+"assigned."
+msgstr ""
+
+# 37f87ca28453415582149435e73f1912
+#: ../../source/development_guide/coding_style.rst:84
+msgid ""
+"If an attribute is meant to contain a mutable object, it should be set to"
+" ``None`` in the class and its mutable value should be set in the "
+"object's constructor. Since class attributes are shared by all instances,"
+" failure to do this can lead to difficult to track bugs. But you should "
+"still set it in the class declaration so the interface specification is "
+"complete and documented in one place."
+msgstr ""
+
+# 608ec84f1ee642bb993c493b2b6c2e9e
+#: ../../source/development_guide/coding_style.rst:91
+msgid "A simple example:"
+msgstr ""
+
+# 5c20ddda84a14bce9bf606623cc93d5c
+#: ../../source/development_guide/coding_style.rst:108
+msgid "New files"
+msgstr ""
+
+# 1cb302a31307483e8d7cbbf0b518efef
+#: ../../source/development_guide/coding_style.rst:110
+msgid ""
+"When starting a new Python file for IPython, you can use the `following "
+"template <./template.py>`__ as a starting point that has a few common "
+"things pre-written for you."
+msgstr ""
+
+# 8dca628763ce406499eb008ec3428735
+#: ../../source/development_guide/documenting_ipython.rst:4
+msgid "Documenting IPython"
+msgstr ""
+
+# 84d33dde8447417eb9e358383a11690f
+#: ../../source/development_guide/documenting_ipython.rst:9
+msgid ""
+"When contributing code to IPython, you should strive for clarity and "
+"consistency, without falling prey to a style straitjacket. Basically, "
+"'document everything, try to be consistent, do what makes sense.'"
+msgstr ""
+
+# 7196603c3de542cea955a86758144197
+#: ../../source/development_guide/documenting_ipython.rst:13
+msgid ""
+"By and large we follow existing Python practices in major projects like "
+"Python itself or NumPy, this document provides some additional detail for"
+" IPython."
+msgstr ""
+
+# 219d53313b744213b12d81b83e8df5e1
+#: ../../source/development_guide/documenting_ipython.rst:18
+msgid "Standalone documentation"
+msgstr ""
+
+# 18573d3352f3414eac2f83f8e1e871b7
+#: ../../source/development_guide/documenting_ipython.rst:20
+msgid ""
+"All standalone documentation should be written in plain text (``.txt``) "
+"files using reStructuredText [reStructuredText]\\_ for markup and "
+"formatting. All such documentation should be placed in the directory "
+"docs/source of the IPython source tree. Or, when appropriate, a suitably "
+"named subdirectory should be used. The documentation in this location "
+"will serve as the main source for IPython documentation."
+msgstr ""
+
+# 5cd39db2efda4df4b349d060d6aa6fed
+#: ../../source/development_guide/documenting_ipython.rst:27
+msgid ""
+"The actual HTML and PDF docs are built using the Sphinx [Sphinx]\\_ "
+"documentation generation tool. Once you have Sphinx installed, you can "
+"build the html docs yourself by doing:"
+msgstr ""
+
+# e998f0d0a6c04b7b8c56c83b9a9f331d
+#: ../../source/development_guide/documenting_ipython.rst:36
+msgid ""
+"Our usage of Sphinx follows that of matplotlib [Matplotlib]\\_ closely. "
+"We are using a number of Sphinx tools and extensions written by the "
+"matplotlib team and will mostly follow their conventions, which are "
+"nicely spelled out in their documentation guide [MatplotlibDocGuide]\\_. "
+"What follows is thus a abridged version of the matplotlib documentation "
+"guide, taken with permission from the matplotlib team."
+msgstr ""
+
+# 8e666fd21967441ea266b6c67f7d3525
+#: ../../source/development_guide/documenting_ipython.rst:43
+msgid ""
+"If you are reading this in a web browser, you can click on the \"Show "
+"Source\" link to see the original reStricturedText for the following "
+"examples."
+msgstr ""
+
+# cc20bf2f388f4367b6ba15ad83d829a0
+#: ../../source/development_guide/documenting_ipython.rst:47
+msgid "A bit of Python code:"
+msgstr ""
+
+# 264cf7c13ba249b89ef7c49f385d7e84
+#: ../../source/development_guide/documenting_ipython.rst:55
+msgid "An interactive Python session:"
+msgstr ""
+
+# 786a003a590a47deb799b41de76c206d
+#: ../../source/development_guide/documenting_ipython.rst:63
+msgid "An IPython session:"
+msgstr ""
+
+# 6b24f490d8474cb2b37153c2af7ce628
+#: ../../source/development_guide/documenting_ipython.rst:75
+msgid "A bit of shell code:"
+msgstr ""
+
+# db00e5ea736140fb9f337702c96a4a8b
+#: ../../source/development_guide/documenting_ipython.rst:84
+msgid "Docstring format"
+msgstr ""
+
+# 4c0a416dddfd49c3a4dd057290418e1a
+#: ../../source/development_guide/documenting_ipython.rst:86
+msgid ""
+"Good docstrings are very important. Unfortunately, Python itself only "
+"provides a rather loose standard for docstrings [PEP257]\\_, and there is"
+" no universally accepted convention for all the different parts of a "
+"complete docstring. However, the NumPy project has established a very "
+"reasonable standard, and has developed some tools to support the smooth "
+"inclusion of such docstrings in Sphinx-generated manuals. Rather than "
+"inventing yet another pseudo-standard, IPython will be henceforth "
+"documented using the NumPy conventions; we carry copies of some of the "
+"NumPy support tools to remain self-contained, but share back upstream "
+"with NumPy any improvements or fixes we may make to the tools."
+msgstr ""
+
+# 55afdecbcdcf4655a4a1524d6a7dd4e8
+#: ../../source/development_guide/documenting_ipython.rst:97
+msgid ""
+"The NumPy documentation guidelines [NumPyDocGuide]\\_ contain detailed "
+"information on this standard, and for a quick overview, the NumPy example"
+" docstring [NumPyExampleDocstring]\\_ is a useful read."
+msgstr ""
+
+# 8b42aebb3a444d4d9b728e9ad4ddd161
+#: ../../source/development_guide/documenting_ipython.rst:101
+msgid ""
+"For user-facing APIs, we try to be fairly strict about following the "
+"above standards (even though they mean more verbose and detailed "
+"docstrings). Wherever you can reasonably expect people to do "
+"introspection with:"
+msgstr ""
+
+# eeec98ec0a6b460f840a0694f95d90ab
+#: ../../source/development_guide/documenting_ipython.rst:110
+msgid "the docstring should follow the NumPy style and be fairly detailed."
+msgstr ""
+
+# ff6b3e20f5bf45a791cbe212c899964c
+#: ../../source/development_guide/documenting_ipython.rst:112
+msgid ""
+"For purely internal methods that are only likely to be read by others "
+"extending IPython itself we are a bit more relaxed, especially for "
+"small/short methods and functions whose intent is reasonably obvious. We "
+"still expect docstrings to be written, but they can be simpler. For very "
+"short functions with a single-line docstring you can use something like:"
+msgstr ""
+
+# 356a512b00f64482a03af0ccb7086cf0
+#: ../../source/development_guide/documenting_ipython.rst:125
+msgid "and for longer multiline strings:"
+msgstr ""
+
+# 317dcb97e87a48df8a65ea5a29ce8171
+#: ../../source/development_guide/documenting_ipython.rst:136
+msgid ""
+"Here are two additional PEPs of interest regarding documentation of code."
+" While both of these were rejected, the ideas therein form much of the "
+"basis of docutils (the machinery to process reStructuredText):"
+msgstr ""
+
+# 3c9e0437ad854754bfefb01141704884
+#: ../../source/development_guide/documenting_ipython.rst:140
+msgid ""
+"`Docstring Processing System Framework "
+"<https://www.python.org/dev/peps/pep-0256/>`__"
+msgstr ""
+
+# 5693f929f2b34d5a8f7e870041bd26e3
+#: ../../source/development_guide/documenting_ipython.rst:142
+msgid ""
+"`Docutils Design Specification "
+"<https://www.python.org/dev/peps/pep-0258/>`__"
+msgstr ""
+
+# a429c37f728d49268eb32174328bbecc
+#: ../../source/development_guide/documenting_ipython.rst:145
+msgid "**note**"
+msgstr ""
+
+# 0115bc4e0feb41acb766d6359b30a749
+#: ../../source/development_guide/documenting_ipython.rst:147
+msgid ""
+"In the past IPython used epydoc so currently many docstrings still use "
+"epydoc conventions. We will update them as we go, but all new code should"
+" be documented using the NumPy standard."
+msgstr ""
+
+# 0a62190ea5ec408199bc8c8de14bb3d5
+#: ../../source/development_guide/documenting_ipython.rst:152
+msgid "Building and uploading"
+msgstr ""
+
+# e6d62b507602420ba1108675bd354123
+#: ../../source/development_guide/documenting_ipython.rst:154
+msgid ""
+"The built docs are stored in a separate repository. Through some github "
+"magic, they're automatically exposed as a website. It works like this:"
+msgstr ""
+
+# 033f18c19fd14b2d850eebfe9c5bff9c
+#: ../../source/development_guide/documenting_ipython.rst:157
+msgid ""
+"You will need to have sphinx and latex installed. In Ubuntu, install "
+"``texlive-latex-recommended texlive-latex-extra texlive-fonts-"
+"recommended``. Install the latest version of sphinx from PyPI (``pip "
+"install sphinx``)."
+msgstr ""
+
+# 76ad90067595421eb7515641ec908c1e
+#: ../../source/development_guide/documenting_ipython.rst:161
+msgid ""
+"Ensure that the development version of IPython is the first in your "
+"system path. You can either use a virtualenv, or modify your PYTHONPATH."
+msgstr ""
+
+# 9a38ef6f51434d2a89b0910cf9abab96
+#: ../../source/development_guide/documenting_ipython.rst:164
+msgid ""
+"Switch into the docs directory, and run ``make gh-pages``. This will "
+"build your updated docs as html and pdf, then automatically check out the"
+" latest version of the docs repository, copy the built docs into it, and "
+"commit your changes."
+msgstr ""
+
+# df5ab19592a5476285b9e7d8eb2afd48
+#: ../../source/development_guide/documenting_ipython.rst:168
+msgid "Open the built docs in a web browser, and check that they're as expected."
+msgstr ""
+
+# 18be1af497b341e2a51dc82023fc53be
+#: ../../source/development_guide/documenting_ipython.rst:170
+msgid ""
+"(When building the docs for a new tagged release, you will have to add "
+"its link to index.rst, then run ``python build_index.py`` to update "
+"index.html. Commit the change.)"
+msgstr ""
+
+# 8e1611ea31854e92a53e904775463bee
+#: ../../source/development_guide/documenting_ipython.rst:173
+msgid ""
+"Upload the docs with ``git push``. This only works if you have write "
+"access to the docs repository."
+msgstr ""
+
+# ec61477d7da4430a9b32d253523f183f
+#: ../../source/development_guide/documenting_ipython.rst:175
+msgid ""
+"If you are building a version that is not the current dev branch, nor a "
+"tagged release, then you must run gh-pages.py directly with ``python gh-"
+"pages.py <version>``, and *not* with ``make gh-pages``."
+msgstr ""
+
+# 1649b48861b04f75bf0ebb94efa60170
+#: ../../source/development_guide/github_workflow.rst:4
+msgid "IPython on GitHub"
+msgstr ""
+
+# 3585ed0c8e314d96a6bb14e72277340e
+#: ../../source/development_guide/github_workflow.rst:9
+msgid "Notes on working with GitHub"
+msgstr ""
+
+# 25cdba5ee7d847f0ac00fc8b042838d5
+#: ../../source/development_guide/github_workflow.rst:14
+msgid "Milestones"
+msgstr ""
+
+# 0f8c5c03390e4297aa264a525fa88975
+#: ../../source/development_guide/github_workflow.rst:16
+#, python-format
+msgid "100% of confirmed issues should have a milestone."
+msgstr ""
+
+# 962e8c858379422dbd3521984486885f
+#: ../../source/development_guide/github_workflow.rst:17
+msgid "An issue should never be closed without a milestone."
+msgstr ""
+
+# 083f524c4a424ba0872df779d2fdd5ac
+#: ../../source/development_guide/github_workflow.rst:18
+msgid "All pull requests should have a milestone."
+msgstr ""
+
+# bbfa916999bf40bf86ac1e57bf98442d
+#: ../../source/development_guide/github_workflow.rst:19
+msgid ""
+"All issues closed should be marked with the next release milestone, next "
+"backport milestone, or **no action**."
+msgstr ""
+
+# a47267eb8fa34a3c95b8d48c20f67475
+#: ../../source/development_guide/github_workflow.rst:21
+msgid "Open issues should only lack a milestone if:"
+msgstr ""
+
+# 2ade481e7b04485bbb5fa1e2edbcff5d
+#: ../../source/development_guide/github_workflow.rst:23
+msgid "more clarification is required (label: ``needs-info``)"
+msgstr ""
+
+# 25a12565438b42c4ade49360ba8d7f5c
+#: ../../source/development_guide/github_workflow.rst:25
+msgid "In general, there will be four milestones with open issues:"
+msgstr ""
+
+# 16bfe5662f274d3580492d27cc15f88c
+#: ../../source/development_guide/github_workflow.rst:27
+msgid ""
+"**next minor release**. This milestone contains issues that should be "
+"backported for the next minor release. See `below <#backporting>`__ for "
+"information on backporting."
+msgstr ""
+
+# 75539ed429124cefbb1a4ca005b58e98
+#: ../../source/development_guide/github_workflow.rst:30
+msgid ""
+"**next major release**. This should be the default milestone of all "
+"issues. As the release approaches, issues can be explicitly bumped to "
+"next release + 1."
+msgstr ""
+
+# e0269932529847bf80bbfb32ef1eb875
+#: ../../source/development_guide/github_workflow.rst:33
+msgid ""
+"**next major release + 1**. Only issues that we are confident will *not* "
+"be included in the next release go here. This milestone should be mostly "
+"empty until relatively close to release."
+msgstr ""
+
+# 03b9b3e660694f1c975ef87b6237cb54
+#: ../../source/development_guide/github_workflow.rst:36
+msgid ""
+"**wishlist**. This is the milestone for issues that we have no immediate "
+"plans to address."
+msgstr ""
+
+# 2d20a33c88384cbd9ac6d2b2853778fb
+#: ../../source/development_guide/github_workflow.rst:39
+msgid ""
+"The remaining milestone is **no action** for open or closed issues that "
+"require no action:"
+msgstr ""
+
+# ac39ba3996a54cdb84c3aabf70f2f42b
+#: ../../source/development_guide/github_workflow.rst:42
+msgid "Not actually an issue (e.g. questions, discussion, etc.)"
+msgstr ""
+
+# 4eb11b0ab81c4186af066494cbf6f880
+#: ../../source/development_guide/github_workflow.rst:43
+msgid "Duplicate of an existing Issue"
+msgstr ""
+
+# e910e40d62ae40ba92ebf2aad4f571f7
+#: ../../source/development_guide/github_workflow.rst:44
+msgid "Closed because we won't fix it"
+msgstr ""
+
+# f7fd1309dbb94e44816ac5f6d3412aae
+#: ../../source/development_guide/github_workflow.rst:45
+msgid ""
+"When an issue is closed with **no action**, it means that the issue will "
+"not be fixed, or it was not an issue at all."
+msgstr ""
+
+# 226b21806c0340128426c701cad68736
+#: ../../source/development_guide/github_workflow.rst:48
+msgid "When closing an issue, it should always have one of these milestones:"
+msgstr ""
+
+# 0b2befff4807419fbd6f84974b7f8c46
+#: ../../source/development_guide/github_workflow.rst:50
+msgid "**next minor release** because the issue has been addressed"
+msgstr ""
+
+# 146a5f43c2c440328ef41b0494c607b1
+#: ../../source/development_guide/github_workflow.rst:51
+msgid "**next major release** because the issue has been addressed"
+msgstr ""
+
+# 8043711c7ac7473390f1aef4d28b1d95
+#: ../../source/development_guide/github_workflow.rst:52
+msgid ""
+"**no action** because the issue *will not* be addressed, or it is a "
+"duplicate/non-issue."
+msgstr ""
+
+# 048050b4c6254852adc7aa6ba6bb05f6
+#: ../../source/development_guide/github_workflow.rst:55
+msgid ""
+"In general: When in doubt, mark with **next release**. We can always push"
+" back when we get closer to a given release."
+msgstr ""
+
+# fd9848b03ee84d5a9624e3483c251a69
+#: ../../source/development_guide/github_workflow.rst:59
+msgid "Labels and issues"
+msgstr ""
+
+# 9b8cd118660a40218ef73c550077249a
+#: ../../source/development_guide/github_workflow.rst:61
+msgid ""
+"Issues should always be labeled once they are confirmed (not necessary "
+"for issues that are still being clarified, or may be duplicates or not "
+"issues at all)."
+msgstr ""
+
+# dcacfa148b804c6db2f154268d88c844
+#: ../../source/development_guide/github_workflow.rst:65
+msgid "Some significant labels:"
+msgstr ""
+
+# 26d8c609c57b43c39115722f0ab20355
+#: ../../source/development_guide/github_workflow.rst:67
+msgid ""
+"``needs-info``: issue needs more information from submitter before "
+"progress can be made"
+msgstr ""
+
+# 6b80d1ff88f84142a5403d8b16fa0239
+#: ../../source/development_guide/github_workflow.rst:69
+msgid "``bug``: errors are raised, or unintended behavior occurs"
+msgstr ""
+
+# fb4b2da07e144e4e9a2a89ed6e2a8309
+#: ../../source/development_guide/github_workflow.rst:70
+msgid "``enhancement``: improvements that are not bugs"
+msgstr ""
+
+# 89c22fbe066c4b50bc24db7569adf9ad
+#: ../../source/development_guide/github_workflow.rst:77
+msgid ""
+"backport-X.Y.Z: Any fix for this issue should be backported to the "
+"maintenance branch. backports are expressed with milestones, starting "
+"with 2.1."
+msgstr ""
+
+# bea030babcf847d59f598000b057b061
+#: ../../source/development_guide/github_workflow.rst:80
+msgid ""
+"``prio-foo``: a priority level for ranking issues - nonessential, but "
+"prio-high/low are useful for explicitly promoting/demoting issues, "
+"particularly when nearing release."
+msgstr ""
+
+# 79d34ec383e549e9ad82a26201e9a3fe
+#: ../../source/development_guide/github_workflow.rst:83
+msgid ""
+"``ClosedPR``: This issue is a reminder for a PR that was closed for going"
+" stale."
+msgstr ""
+
+# ded670b7781b4ff38727ca5925f8fb91
+#: ../../source/development_guide/github_workflow.rst:85
+msgid "``sprint-friendly``: Obvious or easy fixes, where"
+msgstr ""
+
+# f44525ee35164c348398f65d3d5fef6e
+#: ../../source/development_guide/github_workflow.rst:87
+msgid ""
+"All confirmed issues should at least have a ``bug`` or ``enhancement`` "
+"label, and be marked with any affected components (e.g ``parallel``, "
+"``qtconsole``, ``htmlnotebook``), or particular sources of error (e.g. "
+"``py3k`` or ``unicode``) if we have appropriate labels."
+msgstr ""
+
+# 2ecbbea9359e4cffa85607c65b703502
+#: ../../source/development_guide/github_workflow.rst:92
+msgid ""
+"The ``sprint-friendly`` label is probably the best place for new "
+"contributors to start."
+msgstr ""
+
+# f3c4914e879d4e238f14c29a45205179
+#: ../../source/development_guide/github_workflow.rst:96
+msgid "Pull Requests"
+msgstr ""
+
+# 22e663debf3c4bfeacb413987ead6d04
+#: ../../source/development_guide/github_workflow.rst:98
+msgid "All work is submitted via Pull Requests."
+msgstr ""
+
+# 491be18ba00546098911880801ade3fa
+#: ../../source/development_guide/github_workflow.rst:99
+msgid ""
+"Pull Requests can be submitted as soon as there is code worth discussing."
+" Pull Requests track the branch, so you can continue to work after the PR"
+" is submitted. Review and discussion can begin well before the work is "
+"complete, and the more discussion the better. The worst case is that the "
+"PR is closed."
+msgstr ""
+
+# c83bf74d841c41ba803f8f931d0be52d
+#: ../../source/development_guide/github_workflow.rst:104
+msgid ""
+"Pull Requests that have stalled should be closed (see [[our policy on "
+"closing PRs\\|Dev: Closing Pull Requests]])"
+msgstr ""
+
+# 8c5762198389470d8bf22c565df0f764
+#: ../../source/development_guide/github_workflow.rst:106
+msgid ""
+"Pull Requests should always be made against master (backporting PRs is "
+"described below)."
+msgstr ""
+
+# 8ed220b836404a5ba572cd7705267e19
+#: ../../source/development_guide/github_workflow.rst:108
+msgid "Pull Requests should be tested, if feasible:"
+msgstr ""
+
+# c5c2a705421a41f1886242b0d6eefa96
+#: ../../source/development_guide/github_workflow.rst:110
+msgid "bugfixes should include regression tests"
+msgstr ""
+
+# 6cf267c40a434aafb57b42b651fafca1
+#: ../../source/development_guide/github_workflow.rst:111
+msgid "new behavior should at least get minimal exercise"
+msgstr ""
+
+# aefe7e6aeddf40a8a222bde3337d4026
+#: ../../source/development_guide/github_workflow.rst:113
+msgid ""
+"`Travis <https://travis-ci.org/ipython/ipython>`__ does a pretty good job"
+" testing IPython and Pull Requests, but it may make sense to manually "
+"perform tests (possibly with our ``test_pr`` script), particularly for "
+"PRs that affect ``IPython.parallel`` or Windows."
+msgstr ""
+
+# d75b67a07bec499e8881441fa03ce53e
+#: ../../source/development_guide/github_workflow.rst:119
+msgid "Opening an Issue"
+msgstr ""
+
+# 44bde95ec4a44a86a2238a3e3f7c8c2d
+#: ../../source/development_guide/github_workflow.rst:121
+msgid "When opening a new issue, please take the following steps:"
+msgstr ""
+
+# eadd0bf02cea48c49c11fdb30a92cc85
+#: ../../source/development_guide/github_workflow.rst:123
+msgid ""
+"Search GitHub and/or Google for your issue to avoid duplicate reports. "
+"Keyword searches for your error messages are most helpful."
+msgstr ""
+
+# 752323e4c9604015aaff8b37063830c2
+#: ../../source/development_guide/github_workflow.rst:125
+msgid ""
+"If possible, try updating to master and reproducing your issue, because "
+"we may have already fixed it."
+msgstr ""
+
+# b570bdae9b6b4579ac1941165f1f801a
+#: ../../source/development_guide/github_workflow.rst:127
+msgid "Try to include a minimal reproducible test case"
+msgstr ""
+
+# ed1554fe87da45d2a5c64dc0579d52b0
+#: ../../source/development_guide/github_workflow.rst:128
+msgid "Include relevant system information. Start with the output of:"
+msgstr ""
+
+# de41727a9280424c9fcd2c77ca6d7d3c
+#: ../../source/development_guide/github_workflow.rst:134
+msgid ""
+"And include any relevant package versions, depending on the issue, such "
+"as matplotlib, numpy, Qt, Qt bindings (PyQt/PySide), tornado, web "
+"browser, etc."
+msgstr ""
+
+# b69dac6d20d84f4da9aa176b1dca247d
+#: ../../source/development_guide/github_workflow.rst:139
+msgid "Backporting"
+msgstr ""
+
+# 6201a6ddc0724acc9f0aa6e2395950b0
+#: ../../source/development_guide/github_workflow.rst:141
+msgid ""
+"We should keep an ``A.x`` maintenance branch for backporting fixes from "
+"master."
+msgstr ""
+
+# bad96dd4bf104af59b483097f351f7cd
+#: ../../source/development_guide/github_workflow.rst:143
+msgid ""
+"That branch shall be called ``A.x``, e.g. ``2.x``, not ``2.1``. This way,"
+" there is only one maintenance branch per release series."
+msgstr ""
+
+# c8f4a678969e4923818596582284101b
+#: ../../source/development_guide/github_workflow.rst:145
+msgid ""
+"When an Issue is determined to be appropriate for backporting, it should "
+"be marked with the ``A.B`` milestone."
+msgstr ""
+
+# 7b66404e9301456dba12b13f438d61a3
+#: ../../source/development_guide/github_workflow.rst:147
+msgid ""
+"Any Pull Request which addresses a backport issue should also receive the"
+" same milestone."
+msgstr ""
+
+# 9c79bfa009914fafa0019f6e67f48dbf
+#: ../../source/development_guide/github_workflow.rst:149
+msgid ""
+"Patches are backported to the maintenance branch by applying the pull "
+"request patch to the maintenance branch (currently with the "
+"`backport\\_pr "
+"<https://github.com/ipython/ipython/blob/master/tools/backport_pr.py>`__ "
+"script)."
+msgstr ""
+
+# 2a7eba1900684fab9689312035a9dbdc
+#: ../../source/development_guide/index.rst:14
+msgid "Core Documents"
+msgstr ""
+
+# e80a134fe74c41b79acb0093738690ee
+#: ../../source/development_guide/index.rst:23
+msgid "Lab Meetings"
+msgstr ""
+
+# 5d68328888874591905ffd0a0dc08e60
+#: ../../source/development_guide/index.rst:29
+msgid "Development Policies"
+msgstr ""
+
+# 4b19b84c247c45fca67f4925c727048b
+#: ../../source/development_guide/index.rst:35
+msgid "Other Information"
+msgstr ""
+
+# 591c48743b9042228f7607d064abfbb1
+#: ../../source/development_guide/index.rst:4
+msgid "IPython Development Guide (source: old IPython wiki)"
+msgstr ""
+
+# 6289363304d44f5496a77e25f2bf8c1d
+#: ../../source/development_guide/index.rst:9
+msgid ""
+"IPython does all of its development using GitHub. All of our development "
+"information is hosted on this GitHub wiki. This page indexes all of that "
+"information. Developers interested in getting involved with IPython "
+"development should start here."
+msgstr ""
+
+# 12e4517c27a449f48e194515bcda319e
+#: ../../source/development_guide/index.rst:49
+msgid ""
+"A template for new Python files in IPython: `template.py "
+"<./template.py>`__"
+msgstr ""
+
+# 4081c049edfb42229114ea36feec288e
+#: ../../source/development_guide/js_events.rst:4
+msgid "JavaScript Events"
+msgstr ""
+
+# c61b275655c7434c93b6bb942d2ed50e
+#: ../../source/development_guide/js_events.rst:9
+msgid "(Note: this page is not currently consistent with IPython/Jupyter master)"
+msgstr ""
+
+# 47edbb5e6fb747099a83a04e95f7f67e
+#: ../../source/development_guide/js_events.rst:11
+msgid ""
+"Javascript events are used to notify unrelated parts of the notebook "
+"interface when something happens. For example, if the kernel is busy "
+"executing code, it may send an event announcing as such, which can then "
+"be picked up by other services, like the notification area. For details "
+"on how the events themselves work, see the `JQuery documentation "
+"<http://api.jquery.com/on/>`__."
+msgstr ""
+
+# 98fae31d7b944a1da58cc96e0d1a220b
+#: ../../source/development_guide/js_events.rst:18
+msgid ""
+"This page documents the core set of events, and explains when and why "
+"they are triggered."
+msgstr ""
+
+# e86a5f198ce441e9937343199282991b
+#: ../../source/development_guide/js_events.rst:22
+msgid "Cell-related events"
+msgstr ""
+
+# def2f5fa02a743ff9d48c421f82994b3
+#: ../../source/development_guide/js_events.rst:24
+msgid "`command\\_mode.Cell <#command_modecell>`__"
+msgstr ""
+
+# 3a4fd40f4b784920befbe4e8934de8b6
+#: ../../source/development_guide/js_events.rst:25
+msgid "`create.Cell <#createcell>`__"
+msgstr ""
+
+# a53e4f646d3a4c559b61693d04bdddb1
+#: ../../source/development_guide/js_events.rst:26
+msgid "`delete.Cell <#deletecell>`__"
+msgstr ""
+
+# 3d75746bb0c04b4e955c7e1d4dbbcf20
+#: ../../source/development_guide/js_events.rst:27
+msgid "`edit\\_mode.Cell <#edit_modecell>`__"
+msgstr ""
+
+# 0145fa086f07433695ab1dfece970b60
+#: ../../source/development_guide/js_events.rst:28
+msgid "`select.Cell <#selectcell>`__"
+msgstr ""
+
+# 24648c742e394165a105e4acba22fea8
+#: ../../source/development_guide/js_events.rst:29
+msgid "`output\\_appended.OutputArea <#output_appendedoutputarea>`__"
+msgstr ""
+
+# 40072d87d4004a328417903975367ee6
+#: ../../source/development_guide/js_events.rst:32
+msgid "CellToolbar-related events"
+msgstr ""
+
+# 366a5bb76dfb438db5d7533545658e2a
+#: ../../source/development_guide/js_events.rst:34
+msgid "`preset\\_activated.CellToolbar <#preset_activatedcelltoolbar>`__"
+msgstr ""
+
+# 0ad06e30020348f8a58b2db214d1f8b0
+#: ../../source/development_guide/js_events.rst:35
+msgid "`preset\\_added.CellToolbar <#preset_addedcelltoolbar>`__"
+msgstr ""
+
+# baf353e6b30e48d3bc81d5d881a9324a
+#: ../../source/development_guide/js_events.rst:38
+msgid "Dashboard-related events"
+msgstr ""
+
+# a436b7cbd47040b0bc344ad7412951bd
+#: ../../source/development_guide/js_events.rst:40
+msgid "`app\\_initialized.DashboardApp <#app_initializeddashboardapp>`__"
+msgstr ""
+
+# 94c8cba81b564a65b7050479ce437c58
+#: ../../source/development_guide/js_events.rst:41
+msgid "`sessions\\_loaded.Dashboard <#sessions_loadeddashboard>`__"
+msgstr ""
+
+# 7181c050bc5a411a92fb218852db8fe7
+#: ../../source/development_guide/js_events.rst:44
+msgid "app\\_initialized.DashboardApp"
+msgstr ""
+
+# 68fe58e26be54560a352829efd8b9dc8
+#: ../../source/development_guide/js_events.rst:46
+msgid ""
+"When the Jupyter Notebook browser window opens for the first time and "
+"initializes the Dashboard App. The Dashboard App lists the files and "
+"notebooks in the current directory. Additionally, it lets you create and "
+"open new Jupyter Notebooks."
+msgstr ""
+
+# b81706f287f048049876387fb9273ce3
+#: ../../source/development_guide/js_events.rst:52
+msgid "Kernel-related events"
+msgstr ""
+
+# b4874043cb84481095a16e4ccb23b3ed
+#: ../../source/development_guide/js_events.rst:54
+msgid "`execution\\_request.Kernel <#execution_requestkernel>`__"
+msgstr ""
+
+# 3ac81f6c2d4b40aabda9ee264ca363e2
+#: ../../source/development_guide/js_events.rst:55
+msgid "`input\\_reply.Kernel <#input_replykernel>`__"
+msgstr ""
+
+# 6f8eced167314851835ce91f934c2d11
+#: ../../source/development_guide/js_events.rst:56
+msgid "`kernel\\_autorestarting.Kernel <#kernel_autorestartingkernel>`__"
+msgstr ""
+
+# 47a691a1f6bd4f3baa34f121bec16585
+#: ../../source/development_guide/js_events.rst:57
+msgid "`kernel\\_busy.Kernel <#kernel_busykernel>`__"
+msgstr ""
+
+# 80c97c23fa2c40f09bfddee1110217b7
+#: ../../source/development_guide/js_events.rst:58
+msgid "`kernel\\_connected.Kernel <#kernel_connectedkernel>`__"
+msgstr ""
+
+# 70785bb0e881407e9b26806267abb5ee
+#: ../../source/development_guide/js_events.rst:59
+msgid "`kernel\\_connection\\_failed.Kernel <#kernel_connection_failedkernel>`__"
+msgstr ""
+
+# dae8b17088d34805ae776a6c9bc17640
+#: ../../source/development_guide/js_events.rst:60
+msgid "`kernel\\_created.Kernel <#kernel_createdkernel>`__"
+msgstr ""
+
+# 95e5ad5a50454661ac3c028a5896c504
+#: ../../source/development_guide/js_events.rst:61
+msgid "`kernel\\_created.Session <#kernel_createdsession>`__"
+msgstr ""
+
+# 321a1e2d289644f59c756f5095dc7e86
+#: ../../source/development_guide/js_events.rst:62
+msgid "`kernel\\_dead.Kernel <#kernel_deadkernel>`__"
+msgstr ""
+
+# 48e693465ecf4609b40ff7ec7b4c421b
+#: ../../source/development_guide/js_events.rst:63
+msgid "`kernel\\_dead.Session <#kernel_deadsession>`__"
+msgstr ""
+
+# e24e76bda50c4198a90a6b4cc9c7f41c
+#: ../../source/development_guide/js_events.rst:64
+msgid "`kernel\\_disconnected.Kernel <#kernel_disconnectedkernel>`__"
+msgstr ""
+
+# 791e73bc75a14f1d8efeb196576bdcca
+#: ../../source/development_guide/js_events.rst:65
+msgid "`kernel\\_idle.Kernel <#kernel_idlekernel>`__"
+msgstr ""
+
+# 870b93e3cf294b75b3788188a886f91b
+#: ../../source/development_guide/js_events.rst:66
+msgid "`kernel\\_interrupting.Kernel <#kernel_interruptingkernel>`__"
+msgstr ""
+
+# f026b24ce61844a0998a46cc46f712dd
+#: ../../source/development_guide/js_events.rst:67
+msgid "`kernel\\_killed.Kernel <#kernel_killedkernel>`__"
+msgstr ""
+
+# 8c243948993b422e9ce7979e67bf8806
+#: ../../source/development_guide/js_events.rst:68
+msgid "`kernel\\_killed.Session <#kernel_killedsession>`__"
+msgstr ""
+
+# 50229b3359a24ecdaca9c2121b0f7e8e
+#: ../../source/development_guide/js_events.rst:69
+msgid "`kernel\\_ready.Kernel <#kernel_readykernel>`__"
+msgstr ""
+
+# ab8223c68bbe48ee8271e0d69fe60c56
+#: ../../source/development_guide/js_events.rst:70
+msgid "`kernel\\_reconnecting.Kernel <#kernel_reconnectingkernel>`__"
+msgstr ""
+
+# fac3dd7af8514c258e0bf48ff3fea8c3
+#: ../../source/development_guide/js_events.rst:71
+msgid "`kernel\\_restarting.Kernel <#kernel_restartingkernel>`__"
+msgstr ""
+
+# 2a0189d15f2f4cb587ce28f32c98e471
+#: ../../source/development_guide/js_events.rst:72
+msgid "`kernel\\_starting.Kernel <#kernel_startingkernel>`__"
+msgstr ""
+
+# 790b63aed1b04fb0b44083b1531a8a10
+#: ../../source/development_guide/js_events.rst:73
+msgid "`send\\_input\\_reply.Kernel <#send_input_replykernel>`__"
+msgstr ""
+
+# bf0734bc1ee045d7beac313b9b15b5b7
+#: ../../source/development_guide/js_events.rst:74
+msgid "`shell\\_reply.Kernel <#shell_replykernel>`__"
+msgstr ""
+
+# 54b1c3618ccb47aa8e5439b65a594ffe
+#: ../../source/development_guide/js_events.rst:75
+msgid "`spec\\_changed.Kernel <#spec_changedkernel>`__"
+msgstr ""
+
+# a2877fd8d7ad42b28685938bc5f7c1be
+#: ../../source/development_guide/js_events.rst:78
+msgid "kernel\\_created.Kernel"
+msgstr ""
+
+# 3040632873c245529628ae604083e2e8
+#: ../../source/development_guide/js_events.rst:80
+msgid ""
+"The kernel has been successfully created or re-created through "
+"``/api/kernels``, but a connection to it has not necessarily been "
+"established yet."
+msgstr ""
+
+# 7816516d914c4c1eb141b2becc6478b5
+#: ../../source/development_guide/js_events.rst:85
+msgid "kernel\\_created.Session"
+msgstr ""
+
+# 0367845004434dbab781a2552639d4f4
+#: ../../source/development_guide/js_events.rst:87
+msgid ""
+"The kernel has been successfully created or re-created through "
+"``/api/sessions``, but a connection to it has not necessarily been "
+"established yet."
+msgstr ""
+
+# 72a7c504f85e448ca8fe72c0a32b2c4a
+#: ../../source/development_guide/js_events.rst:92
+msgid "kernel\\_reconnecting.Kernel"
+msgstr ""
+
+# 87126ef97bd34214865023e905e33d95
+#: ../../source/development_guide/js_events.rst:94
+msgid ""
+"An attempt is being made to reconnect (via websockets) to the kernel "
+"after having been disconnected."
+msgstr ""
+
+# 1ec32fcfb4ed408bac1e566e8b97aec0
+#: ../../source/development_guide/js_events.rst:98
+msgid "kernel\\_connected.Kernel"
+msgstr ""
+
+# 5acfc372f6f64cdc87c084c55679f892
+#: ../../source/development_guide/js_events.rst:100
+msgid ""
+"A connection has been established to the kernel. This is triggered as "
+"soon as all websockets (e.g. to the shell, iopub, and stdin channels) "
+"have been opened. This does not necessarily mean that the kernel is ready"
+" to do anything yet, though."
+msgstr ""
+
+# 29b6688f9bce412ebbb884ff886068f6
+#: ../../source/development_guide/js_events.rst:106
+msgid "kernel\\_starting.Kernel"
+msgstr ""
+
+# b70c01a2eefc4af2a57708d038debff0
+#: ../../source/development_guide/js_events.rst:108
+msgid ""
+"The kernel is starting. This is triggered once when the kernel process is"
+" starting up, and can be sent as a message by the kernel, or may be "
+"triggered by the frontend if it knows the kernel is starting (e.g., it "
+"created the kernel and is connected to it, but hasn't been able to "
+"communicate with it yet)."
+msgstr ""
+
+# ec64854942e54e16a0fc04bda832f976
+#: ../../source/development_guide/js_events.rst:115
+msgid "kernel\\_ready.Kernel"
+msgstr ""
+
+# b138893ce9964ff6b4347388855c5ade
+#: ../../source/development_guide/js_events.rst:117
+msgid ""
+"Like kernel\\_idle.Kernel, but triggered after the kernel has fully "
+"started up."
+msgstr ""
+
+# 3ad6f65bcbbb4e1ebd1bbd29c253aa85
+#: ../../source/development_guide/js_events.rst:121
+msgid "kernel\\_restarting.Kernel"
+msgstr ""
+
+# 5b6939501d04409d8860c0faf100b222
+#: ../../source/development_guide/js_events.rst:123
+msgid ""
+"The kernel is restarting. This is triggered at the beginning of an "
+"restart call to ``/api/kernels``."
+msgstr ""
+
+# 3bdabb293a8a4cdcb236b8349e518532
+#: ../../source/development_guide/js_events.rst:127
+msgid "kernel\\_autorestarting.Kernel"
+msgstr ""
+
+# a41bf1e6a4284693ba02b1d148163713
+#: ../../source/development_guide/js_events.rst:129
+msgid ""
+"The kernel is restarting on its own, which probably also means that "
+"something happened to cause the kernel to die. For example, running the "
+"following code in the notebook would cause the kernel to autorestart:"
+msgstr ""
+
+# fc34e9d75f1941b3ad2ed2530d2a04e7
+#: ../../source/development_guide/js_events.rst:139
+msgid "kernel\\_interrupting.Kernel"
+msgstr ""
+
+# ffc813b955594063b70bb592d70b548f
+#: ../../source/development_guide/js_events.rst:141
+msgid ""
+"The kernel is being interrupted. This is triggered at the beginning of a "
+"interrupt call to ``/api/kernels``."
+msgstr ""
+
+# ccf8af5eed16478796b627d55f104864
+#: ../../source/development_guide/js_events.rst:145
+msgid "kernel\\_disconnected.Kernel"
+msgstr ""
+
+# 3ab698370f4b46968370a25c425567e8
+#: ../../source/development_guide/js_events.rst:147
+msgid "The connection to the kernel has been lost."
+msgstr ""
+
+# 2802009fc67b490584fbd85d24b2882a
+#: ../../source/development_guide/js_events.rst:150
+msgid "kernel\\_connection\\_failed.Kernel"
+msgstr ""
+
+# 13c1dbef4b9349b0b838a4256d07143b
+#: ../../source/development_guide/js_events.rst:152
+msgid ""
+"Not only was the connection lost, but it was lost due to an error (i.e., "
+"we did not tell the websockets to close)."
+msgstr ""
+
+# ba8926d5bf55416e8aa6ab5ee053e637
+#: ../../source/development_guide/js_events.rst:156
+msgid "kernel\\_idle.Kernel"
+msgstr ""
+
+# d1f3c042055548dab598e2a4b494c115
+#: ../../source/development_guide/js_events.rst:158
+msgid "The kernel's execution state is 'idle'."
+msgstr ""
+
+# 12539ba4f1724ab5bef3dc6922eba206
+#: ../../source/development_guide/js_events.rst:161
+msgid "kernel\\_busy.Kernel"
+msgstr ""
+
+# 88b1443b9d7d4d9a9102d7014d36313a
+#: ../../source/development_guide/js_events.rst:163
+msgid "The kernel's execution state is 'busy'."
+msgstr ""
+
+# 9136374f3b774c08a9acfc0c33fd311a
+#: ../../source/development_guide/js_events.rst:166
+msgid "kernel\\_killed.Kernel"
+msgstr ""
+
+# 67232b97369b4224baec2481ad5f4dd0
+#: ../../source/development_guide/js_events.rst:168
+msgid "The kernel has been manually killed through ``/api/kernels``."
+msgstr ""
+
+# f79f7754a4a94c9ca64eaa9152f7b873
+#: ../../source/development_guide/js_events.rst:171
+msgid "kernel\\_killed.Session"
+msgstr ""
+
+# 2da99d85b9ad4167af4cbf22803c0d84
+#: ../../source/development_guide/js_events.rst:173
+msgid "The kernel has been manually killed through ``/api/sessions``."
+msgstr ""
+
+# b011fd6bcdef4824ac275758512959d7
+#: ../../source/development_guide/js_events.rst:176
+msgid "kernel\\_dead.Kernel"
+msgstr ""
+
+# 58190fd19f3843e7b01f0adedbc72a49
+#: ../../source/development_guide/js_events.rst:178
+msgid ""
+"This is triggered if the kernel dies, and the kernel manager attempts to "
+"restart it, but is unable to. For example, the following code run in the "
+"notebook will cause the kernel to die and for the kernel manager to be "
+"unable to restart it:"
+msgstr ""
+
+# a07a9dcaa9fa414a87e8bb387d584657
+#: ../../source/development_guide/js_events.rst:192
+msgid "kernel\\_dead.Session"
+msgstr ""
+
+# e50094f75e0e4779bdd5bd9cc231672b
+#: ../../source/development_guide/js_events.rst:194
+msgid ""
+"The kernel could not be started through ``/api/sessions``. This might be "
+"because the requested kernel type isn't installed. Another reason for "
+"this message is that the kernel died or was killed, but the session "
+"wasn't."
+msgstr ""
+
+# cdb10a3240634a88bcb5ab603db13223
+#: ../../source/development_guide/js_events.rst:200
+msgid "Notebook-related events"
+msgstr ""
+
+# ff5d6d331e274e01bf17ba723380972d
+#: ../../source/development_guide/js_events.rst:202
+msgid "`app\\_initialized.NotebookApp <#app_initializednotebookapp>`__"
+msgstr ""
+
+# c890a4f26e0743d28633290be51d4ccc
+#: ../../source/development_guide/js_events.rst:203
+msgid "`autosave\\_disabled.Notebook <#autosave_disablednotebook>`__"
+msgstr ""
+
+# 45c56970e40d4a27b4bd50085f013c61
+#: ../../source/development_guide/js_events.rst:204
+msgid "`autosave\\_enabled.Notebook <#autosave_enablednotebook>`__"
+msgstr ""
+
+# 787d5edb4c4e4666b0c1d0b5f194e13a
+#: ../../source/development_guide/js_events.rst:205
+msgid "`checkpoint\\_created.Notebook <#checkpoint_creatednotebook>`__"
+msgstr ""
+
+# 0f4a0e636e6e4b5fb64dc4c2cb14a538
+#: ../../source/development_guide/js_events.rst:206
+msgid ""
+"`checkpoint\\_delete\\_failed.Notebook "
+"<#checkpoint_delete_failednotebook>`__"
+msgstr ""
+
+# 15725ecac791496abcf4ac17f3d8a964
+#: ../../source/development_guide/js_events.rst:207
+msgid "`checkpoint\\_deleted.Notebook <#checkpoint_deletednotebook>`__"
+msgstr ""
+
+# 89e00e136b2f43b6ba5d6ded5606b27b
+#: ../../source/development_guide/js_events.rst:208
+msgid "`checkpoint\\_failed.Notebook <#checkpoint_failednotebook>`__"
+msgstr ""
+
+# 458ba96596ea4f3c8e8760f3ff1bff75
+#: ../../source/development_guide/js_events.rst:209
+msgid ""
+"`checkpoint\\_restore\\_failed.Notebook "
+"<#checkpoint_restore_failednotebook>`__"
+msgstr ""
+
+# 891d9244f3424af0bb816f2d35e8d3a3
+#: ../../source/development_guide/js_events.rst:210
+msgid "`checkpoint\\_restored.Notebook <#checkpoint_restorednotebook>`__"
+msgstr ""
+
+# a087cd1aa32546cdab0c1832cbb53ac2
+#: ../../source/development_guide/js_events.rst:211
+msgid "`checkpoints\\_listed.Notebook <#checkpoints_listednotebook>`__"
+msgstr ""
+
+# afc574cc44784feeba00a72f727b8cce
+#: ../../source/development_guide/js_events.rst:212
+msgid "`command\\_mode.Notebook <#command_modenotebook>`__"
+msgstr ""
+
+# 35231218e930429b84217ae364e1a881
+#: ../../source/development_guide/js_events.rst:213
+msgid "`edit\\_mode.Notebook <#edit_modenotebook>`__"
+msgstr ""
+
+# a4e3da5247db4bd9ac0ff46302355b8e
+#: ../../source/development_guide/js_events.rst:214
+msgid ""
+"`list\\_checkpoints\\_failed.Notebook "
+"<#list_checkpoints_failednotebook>`__"
+msgstr ""
+
+# d54d2621b1d848448d7f51b2c0c4abf9
+#: ../../source/development_guide/js_events.rst:215
+msgid "`notebook\\_load\\_failed.Notebook <#notebook_load_failednotebook>`__"
+msgstr ""
+
+# 297dd5a18c3e491abfbf2fc1d198a746
+#: ../../source/development_guide/js_events.rst:216
+msgid "`notebook\\_loaded.Notebook <#notebook_loadednotebook>`__"
+msgstr ""
+
+# abc6ecf1fc8b499fb2b212b8ec45139a
+#: ../../source/development_guide/js_events.rst:217
+msgid "`notebook\\_loading.Notebook <#notebook_loadingnotebook>`__"
+msgstr ""
+
+# 1ab9c46f713b4011ae03db3d1565aa99
+#: ../../source/development_guide/js_events.rst:218
+msgid "`notebook\\_rename\\_failed.Notebook <#notebook_rename_failednotebook>`__"
+msgstr ""
+
+# 705d0d6e532a47c8acf6a47bb07b3430
+#: ../../source/development_guide/js_events.rst:219
+msgid "`notebook\\_renamed.Notebook <#notebook_renamednotebook>`__"
+msgstr ""
+
+# 9630174248894aa0bb6b67091c37352a
+#: ../../source/development_guide/js_events.rst:220
+msgid "`notebook\\_restoring.Notebook <#notebook_restoringnotebook>`__"
+msgstr ""
+
+# 19d828a32334434482f103cea343d015
+#: ../../source/development_guide/js_events.rst:221
+msgid "`notebook\\_save\\_failed.Notebook <#notebook_save_failednotebook>`__"
+msgstr ""
+
+# d3fcdab1a0ae4813a968084486583389
+#: ../../source/development_guide/js_events.rst:222
+msgid "`notebook\\_saved.Notebook <#notebook_savednotebook>`__"
+msgstr ""
+
+# 1826b5fd328441cd9b281e97e21b8bfc
+#: ../../source/development_guide/js_events.rst:223
+msgid "`notebook\\_saving.Notebook <#notebook_savingnotebook>`__"
+msgstr ""
+
+# 14dc21e830634ecbb3120013d479d6a1
+#: ../../source/development_guide/js_events.rst:224
+msgid "`rename\\_notebook.Notebook <#rename_notebooknotebook>`__"
+msgstr ""
+
+# 545d212ebca44e1898c3d4906ae53fb9
+#: ../../source/development_guide/js_events.rst:225
+msgid ""
+"`selected\\_cell\\_type\\_changed.Notebook "
+"<#selected_cell_type_changednotebook>`__"
+msgstr ""
+
+# bd96bdc9213240ca9c347317afc1bb83
+#: ../../source/development_guide/js_events.rst:226
+msgid "`set\\_dirty.Notebook <#set_dirtynotebook>`__"
+msgstr ""
+
+# 8c289d8ea7d74ff5bd87d081e3c143b3
+#: ../../source/development_guide/js_events.rst:227
+msgid "`set\\_next\\_input.Notebook <#set_next_inputnotebook>`__"
+msgstr ""
+
+# d7f8269d162c425dbce0001d2a0bdffe
+#: ../../source/development_guide/js_events.rst:228
+msgid "`trust\\_changed.Notebook <#trust_changednotebook>`__"
+msgstr ""
+
+# 3be14fb7ddaa44f9898f33c9984781a6
+#: ../../source/development_guide/js_events.rst:231
+msgid "Other"
+msgstr ""
+
+# 28cfc866239f4bb0be2907f27c335b2c
+#: ../../source/development_guide/js_events.rst:233
+msgid "`open\\_with\\_text.Pager <#open_with_textpager>`__"
+msgstr ""
+
+# 9d0f63ac175a4e06b6060c1b5c0589b9
+#: ../../source/development_guide/js_events.rst:234
+msgid "`rebuild.QuickHelp <#rebuildquickhelp>`__"
+msgstr ""
+
+# 052142391c524dbd9cd3b11b73fbdcf4
+#: ../../source/development_guide/lab_meetings.rst:4
+msgid "Lab Meetings on Air"
+msgstr ""
+
+# 655db7d08bf94cb7b434583f46de9302
+#: ../../source/development_guide/lab_meetings.rst:9
+msgid ""
+"Academic labs have long had the tradition of the weekly lab meeting, "
+"where all topics of interest to the lab are discussed. IPython has strong"
+" roots in academia, but it is also an open source project that needs to "
+"engage an active international community. So while our goal with IPython "
+"is not to publish the next paper, we've been thinking about the value "
+"these regular discussions bring to how teams work on sustained efforts "
+"involving difficult problems, and wanted to bring that bit of academic "
+"practice into the open source workflow. So we have decided to conduct "
+"weekly \"lab meetings\" for IPython, that will be held publicly using a "
+"Google Hangout on Air."
+msgstr ""
+
+# b7e924ebaa1442abb4ce8579e7dfb513
+#: ../../source/development_guide/lab_meetings.rst:21
+msgid "Logistics"
+msgstr ""
+
+# 07e6cc2da96b4754b66212a9314e3eb2
+#: ../../source/development_guide/lab_meetings.rst:23
+msgid ""
+"We are trying to keep things simple and with a minimum of new moving "
+"parts:"
+msgstr ""
+
+# a6bfaf8f74724ff792320a67ceb36788
+#: ../../source/development_guide/lab_meetings.rst:26
+msgid ""
+"Meetings happen on Tuesdays at 10am California time (i.e. UTC-8 or -7 "
+"depending on the time of year)."
+msgstr ""
+
+# 2872a2e95c9c4eca8e795423ba1dbc40
+#: ../../source/development_guide/lab_meetings.rst:28
+msgid ""
+"We broadcast the meeting as it happens via G+ and leave the public "
+"YouTube link afterwards."
+msgstr ""
+
+# cb7960e779de46a393549f9b14437b25
+#: ../../source/development_guide/lab_meetings.rst:30
+msgid ""
+"During the meeting, all chat that needs to happen by typing can be done "
+"on our `Gitter chat room <https://gitter.im/ipython/ipython>`__."
+msgstr ""
+
+# 75e889a166a94bb3a0358a1465121a4b
+#: ../../source/development_guide/lab_meetings.rst:33
+msgid ""
+"We keep a running document with `minutes of the meeting on HackPad "
+"<https://ipython.hackpad.com/>`__ where we summarize main points. (`2015 "
+"part 1 <https://ipython.hackpad.com/3YJG5lv2Hws>`__)"
+msgstr ""
+
+# 7ee9bd48be064c18b6f1c952e070a66d
+#: ../../source/development_guide/lab_meetings.rst:37
+msgid ""
+"We welcome and encourage help from others in updating these minutes "
+"during the meeting, but we'll make no major effort in ensuring that they "
+"are a detailed and accurate record of the whole discussion. We simply "
+"don't have the time for that."
+msgstr ""
+
+# 425913e731c54469be844019d93a0581
+#: ../../source/development_guide/lab_meetings.rst:43
+msgid "Prior meetings"
+msgstr ""
+
+# 05fd7d7f121346c290fd8ce8550118bf
+#: ../../source/development_guide/lab_meetings.rst:45
+msgid ""
+"You can find a list of the videos on the `ipythondev YouTube user page "
+"<https://www.youtube.com/user/ipythondev>`__."
+msgstr ""
+
+# d512e27aff344444aae5dfaf62a1a9c2
+#: ../../source/development_guide/less.rst:4
+msgid "How to Compile .less Files"
+msgstr ""
+
+# ad2b306908b048c6bdec64929c3d6c15
+#: ../../source/development_guide/less.rst:9
+msgid ""
+"For testing your development work in CSS, you'll need to compile the "
+".less files to CSS. Make sure you have dependencies that LESS requires, "
+"including fabric, node, and lessc. Follow the below steps to compile the "
+".less files:"
+msgstr ""
+
+# 515ed293377b44b88d86fd11e6cb76f8
+#: ../../source/development_guide/less.rst:18
+msgid "Alternatively, you can:"
+msgstr ""
+
+# f66d911ce52644939f54e1c4cfa7cdd0
+#: ../../source/development_guide/pull_request.rst:4
+msgid "The Perfect Pull Request"
+msgstr ""
+
+# 89a81be294c9411c8f07631085687f58
+#: ../../source/development_guide/pull_request.rst:9
+msgid "A brief guide to making and reviewing pull requests."
+msgstr ""
+
+# 223a61361a9d42d19e8f544bbed9ede8
+#: ../../source/development_guide/pull_request.rst:12
+msgid "1. It works"
+msgstr ""
+
+# ee97d94a227d426a91e8cf8eb7fac5fd
+#: ../../source/development_guide/pull_request.rst:14
+msgid "The code does what it's supposed to!"
+msgstr ""
+
+# 7191fb41b3f446c2b047ca063a5e4356
+#: ../../source/development_guide/pull_request.rst:17
+msgid "2. It works on all of the platforms that IPython officially supports"
+msgstr ""
+
+# 88d94c97480c46a98e8ee9c20f7d521c
+#: ../../source/development_guide/pull_request.rst:19
+msgid "IPython has to work on:"
+msgstr ""
+
+# a330b995df754c6db1c6d675a7f71ec2
+#: ../../source/development_guide/pull_request.rst:21
+msgid "Linux of various kinds, Windows & Mac"
+msgstr ""
+
+# 0982b10a11ac4969ad699d4c552c26a2
+#: ../../source/development_guide/pull_request.rst:22
+msgid "Python 2 & 3"
+msgstr ""
+
+# dae2ad7446ea4d9daade79e4c60bc60a
+#: ../../source/development_guide/pull_request.rst:25
+msgid "3. Handles unicode issues properly"
+msgstr ""
+
+# fd066b3664f148a6b16e1cec798ad3ca
+#: ../../source/development_guide/pull_request.rst:27
+msgid ""
+"Much of our code base deals with strings and unicode. This needs to be "
+"done in a manner that is unicode aware and works on Python 2 and 3. [This"
+" article] (http://www.joelonsoftware.com/articles/Unicode.html) is a good"
+" intro to unicode."
+msgstr ""
+
+# 2e6a238797d34b35a2e3ccd7363775d8
+#: ../../source/development_guide/pull_request.rst:33
+msgid "4. Adheres to our coding style"
+msgstr ""
+
+# 6cf5f6068ddc420d91eef5c6aac49a51
+#: ../../source/development_guide/pull_request.rst:35
+msgid ""
+"Coding style refers to how source code is formatted and how variables, "
+"functions, methods and classes are named. Your code should follow our "
+"coding style, which is described [[here\\|Dev: Coding style]]."
+msgstr ""
+
+# 414e07fca966418d833f8e539fa75dd5
+#: ../../source/development_guide/pull_request.rst:40
+msgid "5. Clean & commented"
+msgstr ""
+
+# 3fd8703e90d14aff80b997e371af9e5b
+#: ../../source/development_guide/pull_request.rst:42
+msgid ""
+"The code should be well organized, and have inline comments where "
+"appropriate. When we look at the code, it should be clear what it's doing"
+" and why. It should not break abstractions that we have established in "
+"the project."
+msgstr ""
+
+# 755c8ba81fe34db1a85d015bb87412f2
+#: ../../source/development_guide/pull_request.rst:48
+msgid "6. Tested"
+msgstr ""
+
+# b74b1c16fc754989b663b171b313d43d
+#: ../../source/development_guide/pull_request.rst:50
+msgid ""
+"If it fixes a bug, the pull request should ideally add an automated test "
+"that fails without the fix, and passes with it. Normally it should be "
+"sufficient to copy an existing test and tweak it. New functionality "
+"should come with its own tests as well. Details about testing IPython can"
+" be found [[here\\|Dev: Testing]]."
+msgstr ""
+
+# 16f7363d77e5489f9ce488ca4a26f71d
+#: ../../source/development_guide/pull_request.rst:57
+msgid "7. Well documented"
+msgstr ""
+
+# ba75b92346094faa90b2e78c95c69a98
+#: ../../source/development_guide/pull_request.rst:59
+msgid ""
+"Don't forget to update docstrings, and any relevant parts of `the "
+"official documentation <https://ipython.readthedocs.io/en/stable/>`__. "
+"New features or significant changes warrant an entry in the *What's New* "
+"section too. Details about documenting IPython can be found [[here\\|Dev:"
+" Documenting IPython]]."
+msgstr ""
+
+# d854f6fc89a64ddcb42f0a9a55973b77
+#: ../../source/development_guide/py3compat.rst:4
+msgid "Python 3 Compatibility Module"
+msgstr ""
+
+# c004d43c8f534c84a82ec4fef2b5b1df
+#: ../../source/development_guide/py3compat.rst:9
+msgid ""
+"The ``IPython.utils.py3compat`` module provides a number of functions to "
+"make it easier to write code for Python 2 and 3. We also use 2to3 in the "
+"setup process to change syntax, and the ``io.open()`` function, which is "
+"essentially the built in open function from Python 3."
+msgstr ""
+
+# b192dadb5475442db1b2a0490e225483
+#: ../../source/development_guide/py3compat.rst:11
+msgid "The names provided are:"
+msgstr ""
+
+# 30de9621716043538db5664d131cb897
+#: ../../source/development_guide/py3compat.rst:13
+msgid "**PY3**: True in Python 3, False in Python 2."
+msgstr ""
+
+# 8f5c3e60ac0747f2b79902da7a2bdae3
+#: ../../source/development_guide/py3compat.rst:16
+msgid "Unicode related"
+msgstr ""
+
+# b6a2d35346a64709aa527b4abda7d7ee
+#: ../../source/development_guide/py3compat.rst:17
+msgid ""
+"**decode**, **encode**: Shortcuts to decode or encode strings, using "
+"``sys.stdin.encoding`` by default, and using replacement characters on "
+"errors."
+msgstr ""
+
+# 73ee89f9102a4788baa41e5b229a9562
+#: ../../source/development_guide/py3compat.rst:18
+msgid ""
+"**str_to_unicode**, **unicode_to_str**, **str_to_bytes**, "
+"**bytes_to_str**: Convert to/from the platform's standard ``str`` type "
+"(bytes in Python 2, unicode in Python 3). Each function is a no-op on one"
+" of the two platforms."
+msgstr ""
+
+# a1dee6dc1a2c46c8a5ec2956070e3a10
+#: ../../source/development_guide/py3compat.rst:19
+msgid ""
+"**cast_unicode**, **cast_bytes**: Accept unknown unicode or byte strings,"
+" and convert them accordingly."
+msgstr ""
+
+# 47bc77989e70427ba4a7cc1cafd7915b
+#: ../../source/development_guide/py3compat.rst:20
+msgid ""
+"**cast_bytes_py2**: Casts unicode to byte strings on Python 2, but "
+"doesn't do anything on Python 3."
+msgstr ""
+
+# 4e8dd403d59b46b9bdb3d5a502311b1b
+# 80822ca0571045df983fab67282f3c6d
+#: ../../source/development_guide/py3compat.rst:23
+#: ../../source/development_guide/rest_api.rst:20
+msgid "Miscellaneous"
+msgstr ""
+
+# cb19d92f73c243b89006254015d4035b
+#: ../../source/development_guide/py3compat.rst:24
+msgid ""
+"**input**: Refers to ``raw_input`` on Python 2, ``input`` on Python 3 "
+"(needed because 2to3 only converts calls to raw_input, not assignments to"
+" other names)."
+msgstr ""
+
+# f998ff129b49488897a174f56cf0a528
+#: ../../source/development_guide/py3compat.rst:25
+msgid ""
+"**builtin_mod_name**: The string name you import to get the builtins "
+"(``__builtin__`` --> ``builtins``)."
+msgstr ""
+
+# 59da6755c02d48118c18d89fce1aa672
+#: ../../source/development_guide/py3compat.rst:26
+msgid "**isidentifier**: Checks if a string is a valid Python identifier."
+msgstr ""
+
+# 871668c2bc504ea298b8e5b945f27fad
+#: ../../source/development_guide/py3compat.rst:27
+msgid ""
+"**open**: Simple wrapper for Python 3 unicode-enabled open. Similar to "
+"``codecs.open``, but allows universal newlines. The current "
+"implementation only supports the very simplest use."
+msgstr ""
+
+# 43c6fddb42a946f0b38d44892e529478
+#: ../../source/development_guide/py3compat.rst:28
+msgid ""
+"**MethodType**: ``types.MethodType`` from Python 3. Takes only two "
+"arguments: function, instance. The class argument for Python 2 is filled "
+"automatically."
+msgstr ""
+
+# d94ea732977d42438b860b989f2a313c
+#: ../../source/development_guide/py3compat.rst:29
+msgid ""
+"**doctest_refactor_print**: Can be called on a string or a function (or "
+"used as a decorator). In Python 3, it converts print statements in "
+"doctests to print() calls. 2to3 does this for real doctests, but we need "
+"it in several other places. It simply uses a regex, which is good enough "
+"for the current cases."
+msgstr ""
+
+# e25ce2b110e44536a7af4a448c4eaa6f
+#: ../../source/development_guide/py3compat.rst:30
+msgid ""
+"**u_format**: Where tests use the repr() of a unicode string, it should "
+"be written ``'{u}\"thestring\"'``, and fed to this function, which will "
+"produce ``'u\"thestring\"'`` for Python 2, and ``'\"thestring\"'`` for "
+"Python 3. Can also be used as a decorator, to work on a docstring."
+msgstr ""
+
+# 679faf609998417083db36b8e8a04382
+#: ../../source/development_guide/py3compat.rst:31
+msgid ""
+"**execfile**: Makes a return on Python 3 (where it's no longer a "
+"builtin), and upgraded to handle Unicode filenames on Python 2."
+msgstr ""
+
+# 6070e9e6628b4aa09ed6655604054931
+#: ../../source/development_guide/releasing.rst:4
+msgid "Steps for Releasing IPython"
+msgstr ""
+
+# 474fc1460c5b4777abee30aa86907ed6
+#: ../../source/development_guide/releasing.rst:9
+msgid ""
+"This document contains notes about the process that is used to release "
+"IPython. Our release process is currently not very formal and could be "
+"improved."
+msgstr ""
+
+# c1f41e0fa6da4994b9b19379eb2bc23f
+#: ../../source/development_guide/releasing.rst:13
+msgid ""
+"Most of the release process is automated by the ``release`` script in the"
+" ``tools`` directory of our main repository. This document is just a "
+"handy reminder for the release manager."
+msgstr ""
+
+# a9b95a6e657e46b28c6e52dbcc201a18
+#: ../../source/development_guide/releasing.rst:18
+msgid "0. Environment variables"
+msgstr ""
+
+# 8d5be193613e4256b862d9f8e07041fa
+#: ../../source/development_guide/releasing.rst:20
+msgid ""
+"You can set some env variables to note previous release tag and current "
+"release milestone, version, and git tag:"
+msgstr ""
+
+# de9c9247cc124e2893d9ec0f227a643d
+#: ../../source/development_guide/releasing.rst:31
+msgid ""
+"These will be used later if you want to copy/paste, or you can just type "
+"the appropriate command when the time comes. These variables are not used"
+" by scripts (hence no ``export``)."
+msgstr ""
+
+# 6c0a769309184688b2fb014ff2f8c796
+#: ../../source/development_guide/releasing.rst:36
+msgid "1. Finish release notes"
+msgstr ""
+
+# e869e1ec6f9742c8bf23bacb602a60b9
+#: ../../source/development_guide/releasing.rst:38
+msgid "If a major release:"
+msgstr ""
+
+# 666b2be953434d93bb878827050ab63d
+#: ../../source/development_guide/releasing.rst:40
+msgid "merge any pull request notes into what's new:"
+msgstr ""
+
+# 3724968cf84e4e99b20121379514a4e0
+#: ../../source/development_guide/releasing.rst:46
+msgid ""
+"update ``docs/source/whatsnew/development.rst``, to ensure it covers the "
+"major points."
+msgstr ""
+
+# 75183279a5dc4eba93af2a9c26039722
+#: ../../source/development_guide/releasing.rst:48
+msgid "move the contents of ``development.rst`` to ``versionX.rst``"
+msgstr ""
+
+# c24f0f091e7949f3bf48de122e6334af
+#: ../../source/development_guide/releasing.rst:49
+msgid "generate summary of GitHub contributions, which can be done with:"
+msgstr ""
+
+# 4b8b45a7487a4bd4b31ae0b9d16bd8d0
+#: ../../source/development_guide/releasing.rst:55
+msgid ""
+"which may need some manual cleanup. Add the cleaned up result and add it "
+"to ``docs/source/whatsnew/github-stats-X.rst`` (make a new file, or add "
+"it to the top, depending on whether it is a major release). You can use:"
+msgstr ""
+
+# 843c53e7f17142a09ae961e46c0cfa4d
+#: ../../source/development_guide/releasing.rst:63
+msgid ""
+"to find duplicates and update ``.mailmap``. Before generating the GitHub "
+"stats, verify that all closed issues and pull requests :ref:`have "
+"appropriate milestones <github_workflow_milestones>`. `This search "
+"<https://github.com/ipython/ipython/issues?q=is%3Aclosed+no%3Amilestone+is%3Aissue>`__"
+" should return no results."
+msgstr ""
+
+# 73753e8a58e34787817ed3238ed82716
+#: ../../source/development_guide/releasing.rst:71
+msgid "2. Run the ``tools/build_release`` script"
+msgstr ""
+
+# 16ac313a93e049638a7f863d317ce63f
+#: ../../source/development_guide/releasing.rst:73
+msgid ""
+"This does all the file checking and building that the real release script"
+" will do. This will let you do test installations, check that the build "
+"procedure runs OK, etc. You may want to also do a test build of the docs."
+msgstr ""
+
+# e7ffacc8c81a4834a14d0b314e17690b
+#: ../../source/development_guide/releasing.rst:79
+msgid "3. Create and push the new tag"
+msgstr ""
+
+# b8b0871867cd4fcc80b3e368e4d95844
+#: ../../source/development_guide/releasing.rst:81
+msgid "Edit ``IPython/core/release.py`` to have the current version."
+msgstr ""
+
+# 3c370bad39e746c39111430ccc936310
+#: ../../source/development_guide/releasing.rst:83
+msgid "Commit the changes to release.py and jsversion:"
+msgstr ""
+
+# 76be04383e184e9da329e3aa0d098a3c
+#: ../../source/development_guide/releasing.rst:90
+msgid "Create and push the tag:"
+msgstr ""
+
+# 507ccfbc828145e9b0d1d4dfee83d563
+#: ../../source/development_guide/releasing.rst:97
+msgid "Update release.py back to ``x.y-dev`` or ``x.y-maint``, and push:"
+msgstr ""
+
+# 4877cb8b2c564ce5bd36962492de8d10
+#: ../../source/development_guide/releasing.rst:105
+msgid "4. Get a fresh clone of the tag for building the release:"
+msgstr ""
+
+# f52cc49dec9346f1b0c98b00a01785d9
+#: ../../source/development_guide/releasing.rst:113
+msgid "5. Run the ``release`` script"
+msgstr ""
+
+# cec8d17770c84efca03630775ab98d9d
+#: ../../source/development_guide/releasing.rst:119
+msgid ""
+"This makes the tarballs, zipfiles, and wheels. It posts them to "
+"archive.ipython.org and registers the release with PyPI."
+msgstr ""
+
+# f1685ede7c474aac941535883e418b17
+#: ../../source/development_guide/releasing.rst:122
+msgid "This will require that you have current wheel, Python 3.4 and Python 2.7."
+msgstr ""
+
+# 9a7908665a6b48459d926aaf5bde37ef
+#: ../../source/development_guide/releasing.rst:126
+msgid "7. Update the IPython website"
+msgstr ""
+
+# 84184061981f4f93a42f63d827dc1374
+#: ../../source/development_guide/releasing.rst:128
+msgid "release announcement (news, announcements)"
+msgstr ""
+
+# 107c03099a624fa686299b8bd37f9f80
+#: ../../source/development_guide/releasing.rst:129
+msgid "update current version and download links"
+msgstr ""
+
+# ee281737c90c44458452d4dceae0f9ad
+#: ../../source/development_guide/releasing.rst:130
+msgid "(If major release) update links on the documentation page"
+msgstr ""
+
+# 7e0ab94df3f949269ccc4e70aa69f593
+#: ../../source/development_guide/releasing.rst:133
+msgid "8. Drafting a short release announcement"
+msgstr ""
+
+# 36d7bb70789c43c8b561212dfb878412
+#: ../../source/development_guide/releasing.rst:135
+msgid ""
+"This should include i) highlights and ii) a link to the html version of "
+"the *What's new* section of the documentation."
+msgstr ""
+
+# 8182a6c415a44cedb150dcf452395ea9
+#: ../../source/development_guide/releasing.rst:138
+msgid "Post to mailing list, and link from Twitter."
+msgstr ""
+
+# 5b55b0e918cc4d15a5f839aea3cb8a98
+#: ../../source/development_guide/releasing.rst:141
+msgid "9. Update milestones on GitHub"
+msgstr ""
+
+# 816cc83ee1b345a78effb459097dc99e
+#: ../../source/development_guide/releasing.rst:143
+msgid "close the milestone you just released"
+msgstr ""
+
+# 5f3da01008e84e7aaf469cda8e6b8899
+#: ../../source/development_guide/releasing.rst:144
+msgid "open new milestone for (x, y+1), if it doesn't exist already"
+msgstr ""
+
+# 00455207637744b5a45442f59ea981a9
+#: ../../source/development_guide/releasing.rst:147
+msgid "10. Celebrate!"
+msgstr ""
+
+# 8cfab3dcdbf94612acc47b332d1b3feb
+#: ../../source/development_guide/rest_api.rst:4
+msgid "Architecture of IPython notebook's Dashboard"
+msgstr ""
+
+# e1e8a4f3cb2e41ac8593e4fc18d62d01
+#: ../../source/development_guide/rest_api.rst:9
+msgid ""
+"The tables below show the current RESTful web service architecture "
+"implemented in IPython notebook. The listed URL's use the HTTP verbs to "
+"return representations of the desired resource."
+msgstr ""
+
+# 2bc47a02cbd945568fb33dc9224b0f07
+#: ../../source/development_guide/rest_api.rst:13
+msgid ""
+"We are in the process of creating a new dashboard architecture for the "
+"IPython notebook, which will allow the user to navigate through multiple "
+"directory files to find desired notebooks."
+msgstr ""
+
+# 4fdebc16479d422b8922fb8f9fce7cc5
+#: ../../source/development_guide/rest_api.rst:18
+msgid "Current Architecture"
+msgstr ""
+
+# fe498a404e0a4c30ae3e620b1d10cc34
+# 9ec2dc9f4138483bb35b689d665d6639
+# b3c5e3a8af40456783a930038b3c4809
+# 98e0a158be994fd88c0bedf17a6b36ae
+# 6e16b609a4ed40f7a2290b0eb520d729
+# fb83ef26d0b44c429af002716f4abdc7
+# 9b2ccd8da72441869fea8111af33760c
+# 96da17585dfd4826bffb704c0793263d
+#: ../../source/development_guide/rest_api.rst:23
+#: ../../source/development_guide/rest_api.rst:38
+#: ../../source/development_guide/rest_api.rst:112
+#: ../../source/development_guide/rest_api.rst:145
+#: ../../source/development_guide/rest_api.rst:169
+#: ../../source/development_guide/rest_api.rst:189
+#: ../../source/development_guide/rest_api.rst:212
+#: ../../source/development_guide/rest_api.rst:242
+msgid "HTTP verb"
+msgstr ""
+
+# e82c6c0b009d44669ddc88b336f64581
+# 7bd84f2c31bb407293fcfa5046887b9d
+# 96d32c89f5ca4ab8a563425ba6b8065e
+# 1fbabf44108c41ddb9ed1872f64855c7
+# 229067f6b1ff4d939c63260bd2e3fe20
+# 7ddac55fc7ea4abda4866b2bf48d8019
+# 74921be61dbf48f8a7c10d2ea8bfcdea
+#: ../../source/development_guide/rest_api.rst:23
+#: ../../source/development_guide/rest_api.rst:38
+#: ../../source/development_guide/rest_api.rst:145
+#: ../../source/development_guide/rest_api.rst:169
+#: ../../source/development_guide/rest_api.rst:189
+#: ../../source/development_guide/rest_api.rst:212
+#: ../../source/development_guide/rest_api.rst:242
+msgid "URL"
+msgstr ""
+
+# de2ab75d45694fb984403d78fddeaca2
+# deb3e95c78574322a84329ee678366dd
+# 9361819f0837429babf92f04c4595287
+# 7a06c5af6c6f4f8cb20893c23c5936f3
+# 32c8b21b1d474f68acf0742198d18634
+# f0d3556b5b834db28df348b1f153db64
+# b9924939f4d34b9eab2effd17d29121b
+# 2eb6a4f4943d48fea7dab628f14d222e
+#: ../../source/development_guide/rest_api.rst:23
+#: ../../source/development_guide/rest_api.rst:38
+#: ../../source/development_guide/rest_api.rst:112
+#: ../../source/development_guide/rest_api.rst:145
+#: ../../source/development_guide/rest_api.rst:169
+#: ../../source/development_guide/rest_api.rst:189
+#: ../../source/development_guide/rest_api.rst:212
+#: ../../source/development_guide/rest_api.rst:242
+msgid "Action"
+msgstr ""
+
+# 763401d3039247d79e58ce1ec12fd518
+# 5afcd411ddb747738c3352f5189e036e
+# 78df1bb43b284a90a495991bf9d3e890
+# ab0547f84b784914bedd133e870b0057
+# 6cecf55719c145c9ae0796cbb378ac92
+# 4c4b2d742a8e4ea19985b66a37bb67a7
+# d27bb38bd52b4a6593a520840121b7ac
+# 5d1afd0c0a934b6bbd21eb57e7e7cbc7
+# fe6be4c15d914e3bbbf61432eee841ad
+# c487a63b691042b59b1f83490001ce47
+# 14c8617aa9b3490ab38b80f37f3fcf4c
+# 08f7c8eb565445b180c2fd363fa0f054
+# 50663441342e4b959bceae65ee26c8f6
+# 741a15dfa12a4f38b3f93bfb536647fb
+# f1181df2b3154c76bc292c53aa05391e
+# 91931ae80d9f490c850685d2db412081
+# 6037f22576504cb3a6fc7c3010dc2192
+# bd10507b0d50427782417823e54cd3be
+# cb2f272b24ce45bc894c2946f1267dcc
+# 480cf3b73cc148d7ad7bf74c6c263c55
+# 23b5ee04c60745ddbdcdf2cfd2219e93
+# 73c5e9f321b34b6abd5421f2b40285a1
+# 51cbcb5b73ea4c19ab76aef565c16595
+# b488e84daab844beb51647a2057fc030
+# bf3bc78ec5ab439d9c8d693b0f0491f5
+# de5dc5031a1e4aa4be45a7414af059b0
+# be05eeb20901486d80386c7ee69aa827
+# 5e2686db0ed743cdba7ef66620ee9939
+# 657ece27d618456b8c1d6c33ddf1f800
+# 3428328645e242ea89296246917f99f4
+# b72e3436c8de4d38ae7000fabba5d221
+# 33784dfc6de24eea92bd419c1a486195
+# 5386f0dbdf2c4ec99c19ff3369bd4a78
+#: ../../source/development_guide/rest_api.rst:26
+#: ../../source/development_guide/rest_api.rst:28
+#: ../../source/development_guide/rest_api.rst:32
+#: ../../source/development_guide/rest_api.rst:41
+#: ../../source/development_guide/rest_api.rst:44
+#: ../../source/development_guide/rest_api.rst:48
+#: ../../source/development_guide/rest_api.rst:88
+#: ../../source/development_guide/rest_api.rst:115
+#: ../../source/development_guide/rest_api.rst:117
+#: ../../source/development_guide/rest_api.rst:134
+#: ../../source/development_guide/rest_api.rst:137
+#: ../../source/development_guide/rest_api.rst:148
+#: ../../source/development_guide/rest_api.rst:155
+#: ../../source/development_guide/rest_api.rst:172
+#: ../../source/development_guide/rest_api.rst:174
+#: ../../source/development_guide/rest_api.rst:192
+#: ../../source/development_guide/rest_api.rst:199
+#: ../../source/development_guide/rest_api.rst:215
+#: ../../source/development_guide/rest_api.rst:218
+#: ../../source/development_guide/rest_api.rst:220
+#: ../../source/development_guide/rest_api.rst:224
+#: ../../source/development_guide/rest_api.rst:227
+#: ../../source/development_guide/rest_api.rst:231
+#: ../../source/development_guide/rest_api.rst:235
+#: ../../source/development_guide/rest_api.rst:245
+#: ../../source/development_guide/rest_api.rst:248
+#: ../../source/development_guide/rest_api.rst:251
+#: ../../source/development_guide/rest_api.rst:255
+#: ../../source/development_guide/rest_api.rst:259
+#: ../../source/development_guide/rest_api.rst:263
+#: ../../source/development_guide/rest_api.rst:266
+#: ../../source/development_guide/rest_api.rst:268
+#: ../../source/development_guide/rest_api.rst:276
+msgid "``GET``"
+msgstr ""
+
+# dffd12ae712b43ce8d6cf80d826c8017
+#: ../../source/development_guide/rest_api.rst:26
+msgid "/.\\*/\\"
+msgstr ""
+
+# 5ce071fb24d14854b986d15e69e2114e
+#: ../../source/development_guide/rest_api.rst:26
+msgid "Strips trailing slashes."
+msgstr ""
+
+# 1a776f1e82e44612aa2fdec9644afe9e
+#: ../../source/development_guide/rest_api.rst:28
+msgid "\\/api\\"
+msgstr ""
+
+# cbed5e8bbde04a74aa860b0dbf7e4880
+#: ../../source/development_guide/rest_api.rst:28
+msgid "Returns api version information."
+msgstr ""
+
+# 486f00bc379041ddb7f6fcdbd9e95e7d
+#: ../../source/development_guide/rest_api.rst:30
+msgid "``*``"
+msgstr ""
+
+# feff0224746046688e5c25ff5c3c6171
+#: ../../source/development_guide/rest_api.rst:30
+msgid "\\/api/notebooks"
+msgstr ""
+
+# 01a8e34b3a694b098bb91525785b7e36
+#: ../../source/development_guide/rest_api.rst:30
+msgid "Deprecated: redirect to /api/contents"
+msgstr ""
+
+# d8dabd59231844c6ad324fc4d271e6af
+#: ../../source/development_guide/rest_api.rst:32
+msgid "\\/api/nbconvert"
+msgstr ""
+
+# dacbd2c6987f42409c2feb109d0dde44
+#: ../../source/development_guide/rest_api.rst:35
+msgid "Notebook contents API."
+msgstr ""
+
+# aef631b0aed447688207bd806340cd63
+#: ../../source/development_guide/rest_api.rst:41
+msgid "/api/contents"
+msgstr ""
+
+# f5cde97e47e548379614ab3affbdddf0
+#: ../../source/development_guide/rest_api.rst:41
+msgid "Return a model for the base directory. See /api/contents/<path>/<file>."
+msgstr ""
+
+# 1448b28828454b7d9d1ed2853bcaf819
+#: ../../source/development_guide/rest_api.rst:44
+msgid "/api/contents/ <file>"
+msgstr ""
+
+# 3c765646a94f4d75a4d7c5ad89e8fe42
+#: ../../source/development_guide/rest_api.rst:44
+msgid ""
+"Return a model for the given file in the base directory. See "
+"/api/contents/<path>/<file>."
+msgstr ""
+
+# a4605641dd4f4cfebfe87b0155e422b2
+# 1e7d59f407dd49099f7351c0553beac9
+# 712b8ef05e294ee0b1b61e14ac733a19
+# 13225189dbd94717a156bab23927b5a1
+# 1d9baa4d593b4548af6606a84a2d2731
+#: ../../source/development_guide/rest_api.rst:48
+#: ../../source/development_guide/rest_api.rst:53
+#: ../../source/development_guide/rest_api.rst:70
+#: ../../source/development_guide/rest_api.rst:73
+#: ../../source/development_guide/rest_api.rst:85
+msgid "/api/contents/ <path>/<file>"
+msgstr ""
+
+# ed7bc4dabc754ad697cb7d97b98947f9
+#: ../../source/development_guide/rest_api.rst:48
+msgid ""
+"Return a model for a file or directory. A directory model contains a list"
+" of models (without content) of the files and directories it contains."
+msgstr ""
+
+# dfd73d904a7d4864aacd914ec6e2d4a3
+# 6eed25236c154ee7af6ba6c83fb8edaf
+#: ../../source/development_guide/rest_api.rst:53
+#: ../../source/development_guide/rest_api.rst:202
+msgid "``PUT``"
+msgstr ""
+
+# eb1c17f460184abe9577e7513ecd048e
+#: ../../source/development_guide/rest_api.rst:53
+msgid ""
+"Saves the file in the location specified by name and path. PUT is very "
+"similar to POST, but the requester specifies the name, where as with "
+"POST, the server picks the name. PUT /api/contents/path/Name.ipynb Save "
+"notebook at ``path/Name.ipynb``. Notebook structure is specified in "
+"``content`` key of JSON request body. If content is not specified, create"
+" a new empty notebook. PUT /api/contents/path/Name.ipynb with JSON body "
+"{\"copy\\_from\" : \"[path/to/] OtherNotebook.ipynb\"} Copy OtherNotebook"
+" to Name"
+msgstr ""
+
+# ceb6808281824129852733d7c9e4eeb5
+# 5625ae0380c34bc090c776621551f97e
+#: ../../source/development_guide/rest_api.rst:70
+#: ../../source/development_guide/rest_api.rst:158
+msgid "``PATCH``"
+msgstr ""
+
+# 75933adea4084527b478230d805980a3
+#: ../../source/development_guide/rest_api.rst:70
+msgid "Renames a notebook without re-uploading content."
+msgstr ""
+
+# 17c634548eb74c01a0dc92e4f58f49b4
+# caf03f3932b148388a33c42c74810505
+# fa50085f68ac4687be99cc75d2422897
+# 9d82e240de48406fa0d56bf23cc5c36c
+# d10b01d8ba9242d28457c629dba7ab6a
+# aaced630d1a043d7aed4dcba55b355e1
+# db725a152cba4888803919aec39c9ec6
+# 1fae8fe1e28345118a5d9c21b4b17854
+# 9961f9c83d9d4eceb9c2d7c49f3dfe62
+#: ../../source/development_guide/rest_api.rst:73
+#: ../../source/development_guide/rest_api.rst:92
+#: ../../source/development_guide/rest_api.rst:96
+#: ../../source/development_guide/rest_api.rst:120
+#: ../../source/development_guide/rest_api.rst:126
+#: ../../source/development_guide/rest_api.rst:150
+#: ../../source/development_guide/rest_api.rst:177
+#: ../../source/development_guide/rest_api.rst:195
+#: ../../source/development_guide/rest_api.rst:271
+msgid "``POST``"
+msgstr ""
+
+# 0536f641b6934319af698bda9cedf4e7
+#: ../../source/development_guide/rest_api.rst:73
+msgid ""
+"Creates a new file or directory in the specified path. POST creates new "
+"files or directories. The server always decides on the name. POST "
+"/api/contents/path New untitled notebook in path. If content specified, "
+"upload a notebook, otherwise start empty. POST /api/contents/path with "
+"body {\"copy\\_from\":\"OtherNotebook.ipynb\"} New copy of OtherNotebook "
+"in path"
+msgstr ""
+
+# d44cc798e58e4cad9b54269ba21156ad
+# ef7cfa1704f143d092483ccd5da72212
+# 30b3b06e66a24d61a5b24a611ccc0230
+# 9e98d4862452477c8ce4249aac75162e
+# 6c47ab0a66b644d28ac57748a4937e45
+#: ../../source/development_guide/rest_api.rst:85
+#: ../../source/development_guide/rest_api.rst:102
+#: ../../source/development_guide/rest_api.rst:123
+#: ../../source/development_guide/rest_api.rst:162
+#: ../../source/development_guide/rest_api.rst:205
+msgid "``DELETE``"
+msgstr ""
+
+# 9ceef3bacd5340ad8d5aeec1466a076b
+#: ../../source/development_guide/rest_api.rst:85
+msgid "delete a file in the given path."
+msgstr ""
+
+# 202361a1c09e47c2ad83579b433f5f4f
+# 15dde1b4832b42e7ad20afa5bee4e930
+#: ../../source/development_guide/rest_api.rst:88
+#: ../../source/development_guide/rest_api.rst:92
+msgid "/api/contents/ <path>/<file> /checkpoints"
+msgstr ""
+
+# 05ec1d01737d4688a6567dbaa710c7c3
+#: ../../source/development_guide/rest_api.rst:88
+msgid "get lists checkpoint for a file."
+msgstr ""
+
+# ca6e8400ef244624b6839870077fd6e3
+#: ../../source/development_guide/rest_api.rst:92
+msgid "post creates a new checkpoint."
+msgstr ""
+
+# 992ccde95573448aa6f41302d413bb40
+# a8be10f1246244ed965f085222bf11ff
+#: ../../source/development_guide/rest_api.rst:96
+#: ../../source/development_guide/rest_api.rst:102
+msgid "/api/contents/ <path>/<file> /checkpoints/ <checkpoint\\_ id>"
+msgstr ""
+
+# 2cd3d316ad3441c7b0d552eb718b6d28
+#: ../../source/development_guide/rest_api.rst:96
+msgid "post restores a file from a checkpoint."
+msgstr ""
+
+# 5bfe5a66d89d446fb55eb87325c487f3
+#: ../../source/development_guide/rest_api.rst:102
+msgid "delete clears a checkpoint for a given file."
+msgstr ""
+
+# a15416a2e61a4aaab583905d4af0963f
+#: ../../source/development_guide/rest_api.rst:109
+msgid "Kernel API"
+msgstr ""
+
+# c83393dead364609ba046887ad58eda4
+#: ../../source/development_guide/rest_api.rst:112
+msgid "URI"
+msgstr ""
+
+# a22a8dde569a49fdaabee69c4c8a4922
+# 9ce37afd4749427b86a9bdb405154753
+#: ../../source/development_guide/rest_api.rst:115
+#: ../../source/development_guide/rest_api.rst:120
+msgid "/api/kernels"
+msgstr ""
+
+# 61ec1cbf32c64bbfb1ea3eaa0d19192c
+#: ../../source/development_guide/rest_api.rst:115
+msgid "Return a model of all kernels."
+msgstr ""
+
+# ef7ea762242943969ec5c1e7cea1eada
+# 31cfc33080984d38b979a875687f4a62
+#: ../../source/development_guide/rest_api.rst:117
+#: ../../source/development_guide/rest_api.rst:123
+msgid "/api/kernels /<kernel\\_id>"
+msgstr ""
+
+# 3547722485614d43b0f8342ef19860bd
+#: ../../source/development_guide/rest_api.rst:117
+msgid "Return a model of kernel with given kernel id."
+msgstr ""
+
+# 50a8cf2db9a44b2d8bd1229939621a61
+#: ../../source/development_guide/rest_api.rst:120
+msgid "Start a new kernel with default or given name."
+msgstr ""
+
+# 5e1f9fc90a784841ac614c10dc3516db
+#: ../../source/development_guide/rest_api.rst:123
+msgid "Shutdown the given kernel."
+msgstr ""
+
+# aba500823d0a4193996e93e699a48012
+#: ../../source/development_guide/rest_api.rst:126
+msgid "/api/kernels /<kernel\\_id> /<action>"
+msgstr ""
+
+# f15d513346c34e96b482db11c73ebe2f
+#: ../../source/development_guide/rest_api.rst:126
+msgid ""
+"Perform action on kernel with given kernel id. Actions can be "
+"\"interrupt\" or \"restart\"."
+msgstr ""
+
+# 60b68955ab9746548149c88070e09d1b
+#: ../../source/development_guide/rest_api.rst:130
+msgid "``WS``"
+msgstr ""
+
+# e8e11e0467134d0c9c7792aa498d65dd
+#: ../../source/development_guide/rest_api.rst:130
+msgid "/api/kernels /<kernel\\_id> /channels"
+msgstr ""
+
+# de4521b7a70a4a78987145e026a49607
+#: ../../source/development_guide/rest_api.rst:130
+msgid "Websocket stream"
+msgstr ""
+
+# 70afdc93b80448788de5ee906115a591
+#: ../../source/development_guide/rest_api.rst:134
+msgid "/api/kernel specs"
+msgstr ""
+
+# e18bed8d78d245a4a5c2973178a7528e
+#: ../../source/development_guide/rest_api.rst:134
+msgid "Return a spec model of all available kernels."
+msgstr ""
+
+# a611384ba3e146aab1d36ad045577752
+#: ../../source/development_guide/rest_api.rst:137
+msgid "/api/kernel specs/ <kernel\\_name>"
+msgstr ""
+
+# 7505bc902e344212856aab8a1be8f17a
+#: ../../source/development_guide/rest_api.rst:137
+msgid "Return a spec model of all available kernels with a given kernel name."
+msgstr ""
+
+# 81461b43739140fc8fc0ad640eb498d5
+#: ../../source/development_guide/rest_api.rst:142
+msgid "Sessions API"
+msgstr ""
+
+# 08e4e18abc2244ceb8abf296ca974619
+#: ../../source/development_guide/rest_api.rst:148
+msgid "/api/sesions"
+msgstr ""
+
+# 6a2b019dacde41fba26edae7451aa2e5
+#: ../../source/development_guide/rest_api.rst:148
+msgid "Return model of active sessions."
+msgstr ""
+
+# e56fef54527d48dc8ba3b121cd264e40
+#: ../../source/development_guide/rest_api.rst:150
+msgid "/api/sessions"
+msgstr ""
+
+# f76c7178430e4df4884d2e39182e9c8b
+#: ../../source/development_guide/rest_api.rst:150
+msgid ""
+"If session does not already exist, create a new session with given "
+"notebook name and path and given kernel name. Return active sesssion."
+msgstr ""
+
+# 5a4883c124374c5badd2612c1995b17e
+# 62a139f0726b4521b1217f734f0a7a3c
+# 58e922b4809b4ef6a9c622a81b6e8037
+#: ../../source/development_guide/rest_api.rst:155
+#: ../../source/development_guide/rest_api.rst:158
+#: ../../source/development_guide/rest_api.rst:162
+msgid "/api/sessions /<session\\_id>"
+msgstr ""
+
+# 1a7b5abb09a84f49a0fe343a7f667a61
+#: ../../source/development_guide/rest_api.rst:155
+msgid "Return model of active session with given session id."
+msgstr ""
+
+# b5c11a8bffec49dca8bfc9c581d9bf4f
+#: ../../source/development_guide/rest_api.rst:158
+msgid ""
+"Return model of active session with notebook name or path of session with"
+" given session id."
+msgstr ""
+
+# 83e67dff5c6c4c4282abc35a809886d6
+#: ../../source/development_guide/rest_api.rst:162
+msgid "Delete model of active session with given session id."
+msgstr ""
+
+# ce880e4d63aa4f60b1cde75c9f07ec78
+#: ../../source/development_guide/rest_api.rst:166
+msgid "Clusters API"
+msgstr ""
+
+# 57b49bd43c8946b885d05a550d10998b
+#: ../../source/development_guide/rest_api.rst:172
+msgid "/api/clusters"
+msgstr ""
+
+# d597dde5def54af390dfb8c068248ad8
+#: ../../source/development_guide/rest_api.rst:172
+msgid "Return model of clusters."
+msgstr ""
+
+# 8dcc8aa616184ff39f7509a2821ba18c
+#: ../../source/development_guide/rest_api.rst:174
+msgid "/api/clusters <cluster\\_id>"
+msgstr ""
+
+# b7c8e1591a6d4ffe8c6fccfd070ec56f
+#: ../../source/development_guide/rest_api.rst:174
+msgid "Return model of given cluster."
+msgstr ""
+
+# 67a870b779114a1e8b55bc3682417ea9
+#: ../../source/development_guide/rest_api.rst:177
+msgid "/api/clusters <cluster\\_id> <action>"
+msgstr ""
+
+# 985c28ae15c543afb7ad154db3b46f50
+#: ../../source/development_guide/rest_api.rst:177
+msgid ""
+"Perform action with given clusters. Valid actions are \"start\" and "
+"\"stop\""
+msgstr ""
+
+# 819cb4187e2d4cc6a0e7107dc259977b
+#: ../../source/development_guide/rest_api.rst:183
+msgid "Old Architecture"
+msgstr ""
+
+# b0cef61ad6954909ac7f0e849285224f
+#: ../../source/development_guide/rest_api.rst:185
+msgid ""
+"This chart shows the web-services in the single directory IPython "
+"notebook."
+msgstr ""
+
+# fdeb7827a6d343a9a6066a8165be18d4
+# c2ec6a32978841179b74bed14bbd3ea1
+#: ../../source/development_guide/rest_api.rst:192
+#: ../../source/development_guide/rest_api.rst:195
+msgid "/notebooks"
+msgstr ""
+
+# af756cf6dda9437e9945475459ef4e5f
+#: ../../source/development_guide/rest_api.rst:192
+msgid "return list of dicts with each notebook's info"
+msgstr ""
+
+# 944132b8c9934cab857e811235689f40
+#: ../../source/development_guide/rest_api.rst:195
+msgid ""
+"if sending a body, saving that body as a new notebook; if no body, create"
+" a a new notebook."
+msgstr ""
+
+# 903e8f3495274ef5bd24dafa8c5004dd
+# c6e1a714498f409eabce7a39a40568aa
+# e4621bb9f8c34d9ab8d60469bac19bd2
+#: ../../source/development_guide/rest_api.rst:199
+#: ../../source/development_guide/rest_api.rst:202
+#: ../../source/development_guide/rest_api.rst:205
+msgid "/notebooks /<notebook\\_id>"
+msgstr ""
+
+# fa3253b06f424c3fa9827596beeb038e
+#: ../../source/development_guide/rest_api.rst:199
+msgid "get JSON data for notebook"
+msgstr ""
+
+# 3ac66b01afa544639b6e56e520fcf336
+#: ../../source/development_guide/rest_api.rst:202
+msgid "saves an existing notebook with body data"
+msgstr ""
+
+# f2d62f8edd154a1694c266cb01d161da
+#: ../../source/development_guide/rest_api.rst:205
+msgid "deletes the notebook with the given ID"
+msgstr ""
+
+# 76792199079742d7ba728bfd36c6e12b
+#: ../../source/development_guide/rest_api.rst:209
+msgid "This chart shows the architecture for the IPython notebook website."
+msgstr ""
+
+# 4b327f0782284c11bffe95726ba3d093
+#: ../../source/development_guide/rest_api.rst:215
+msgid "/"
+msgstr ""
+
+# 8f2f602d40da4dc693e34cfbfdf8f3b7
+#: ../../source/development_guide/rest_api.rst:215
+msgid "navigates user to dashboard of notebooks and clusters."
+msgstr ""
+
+# 29f4821c5000491d8ff30a06d4a649b5
+#: ../../source/development_guide/rest_api.rst:218
+msgid "/<notebook\\_id>"
+msgstr ""
+
+# 6d09e8fe05b141529561184b06fe4678
+#: ../../source/development_guide/rest_api.rst:218
+msgid "go to wepage for that notebook"
+msgstr ""
+
+# 24836333d48d47d3986688ce667283a7
+#: ../../source/development_guide/rest_api.rst:220
+msgid "/new"
+msgstr ""
+
+# 4a85061aeca048fd9010b52afc06f83b
+#: ../../source/development_guide/rest_api.rst:220
+msgid ""
+"creates a new notebook with profile (or default, if no profile exists) "
+"setings"
+msgstr ""
+
+# ff97d5e191354ac49a2e70163427c4c2
+#: ../../source/development_guide/rest_api.rst:224
+msgid "/<notebook\\_id> /copy"
+msgstr ""
+
+# 0589cdc545964cf0926fa8eb459123b5
+#: ../../source/development_guide/rest_api.rst:224
+msgid "opens a duplicate copy or the notebook with the given ID in a new tab"
+msgstr ""
+
+# ff517ea185b049dfa1f37f0135487226
+#: ../../source/development_guide/rest_api.rst:227
+msgid "/<notebook\\_id> /print"
+msgstr ""
+
+# 70ade4f0505d436c949d0a14cea03ce6
+#: ../../source/development_guide/rest_api.rst:227
+msgid ""
+"prints the notebook with the given ID; if notebook doesn't exist, "
+"displays error message"
+msgstr ""
+
+# ef1e03a67e434bcebb694721b956c0a4
+#: ../../source/development_guide/rest_api.rst:231
+msgid "/login"
+msgstr ""
+
+# 54945e6f06af47a3948156bb62efe0f2
+#: ../../source/development_guide/rest_api.rst:231
+msgid ""
+"navigates to login page; if no user profile is defined, it navigates user"
+" to dashboard"
+msgstr ""
+
+# 7b8ee796640a4c1a86cd204b274f42d6
+#: ../../source/development_guide/rest_api.rst:235
+msgid "/logout"
+msgstr ""
+
+# 2f224f13e6a5446bb8683b23cf41436a
+#: ../../source/development_guide/rest_api.rst:235
+msgid "logs out of current profile, and navigates user to login page"
+msgstr ""
+
+# 461cac9f248140918942166ba0e0b01d
+#: ../../source/development_guide/rest_api.rst:239
+msgid "This chart shows the Web services that act on the kernels and clusters."
+msgstr ""
+
+# de02268e21c94de3a4759a55773c3ea2
+#: ../../source/development_guide/rest_api.rst:245
+msgid "/kernels"
+msgstr ""
+
+# d5845cac753b4c1abdc62104632c17c5
+#: ../../source/development_guide/rest_api.rst:245
+msgid "return the list of kernel IDs currently running"
+msgstr ""
+
+# 2bb5311d7d954a3f9c8f4ca85472bf76
+#: ../../source/development_guide/rest_api.rst:248
+msgid "/kernels /<kernel\\_id>"
+msgstr ""
+
+# 77fd3900942741b09303446a7004120a
+# c7c4420e0aa341a2af83c24a2d1767fe
+# 13d18f18fab7449d9f5a9ebbb3bd0724
+# f9521b40d2cc4a8caf50dc7788d4d135
+# 2a226c3f624349ae9a76a4adef40b2a8
+#: ../../source/development_guide/rest_api.rst:248
+#: ../../source/development_guide/rest_api.rst:255
+#: ../../source/development_guide/rest_api.rst:259
+#: ../../source/development_guide/rest_api.rst:263
+#: ../../source/development_guide/rest_api.rst:266
+msgid "---"
+msgstr ""
+
+# e136d989d52e439e8e6d924f02a1268b
+#: ../../source/development_guide/rest_api.rst:251
+msgid "/kernels /<kernel\\_id> <action>"
+msgstr ""
+
+# 59d771a7602d4cf0aba2314257cb6ac8
+#: ../../source/development_guide/rest_api.rst:251
+msgid "performs action (restart/kill) kernel with given ID"
+msgstr ""
+
+# e70044bc6b954eb5982a61f2d9f35fc4
+#: ../../source/development_guide/rest_api.rst:255
+msgid "/kernels /<kernel\\_id> /iopub"
+msgstr ""
+
+# 368154e364f94b5b9f449a21c01529e5
+#: ../../source/development_guide/rest_api.rst:259
+msgid "/kernels /<kernel\\_id> /shell"
+msgstr ""
+
+# 562e776b3fbb4f7e91b6208e783b6a15
+#: ../../source/development_guide/rest_api.rst:263
+msgid "/rstservice/ render"
+msgstr ""
+
+# 05a3c48c4b62422eb4d4079b522f3f99
+#: ../../source/development_guide/rest_api.rst:266
+msgid "/files/(.\\*)"
+msgstr ""
+
+# 569ac69c0a2c4b75b0e0de52468cbc7e
+#: ../../source/development_guide/rest_api.rst:268
+msgid "/clusters"
+msgstr ""
+
+# 84144edf06b64ad8bd71aa7cf35943f3
+#: ../../source/development_guide/rest_api.rst:268
+msgid "returns a list of dicts with each cluster's information"
+msgstr ""
+
+# 081da73e88514f32b9fbd6e610569422
+#: ../../source/development_guide/rest_api.rst:271
+msgid "/clusters /<profile\\_id> /<cluster\\_ action>"
+msgstr ""
+
+# ed0932c1d56548e598921efeeb5cc74b
+#: ../../source/development_guide/rest_api.rst:271
+msgid "performs action (start/stop) on cluster with given profile ID"
+msgstr ""
+
+# 4499cb69e075466ca0738fe9600eac8f
+#: ../../source/development_guide/rest_api.rst:276
+msgid "/clusters /<profile\\_id>"
+msgstr ""
+
+# 5144fcfdab6143b1975f8e8837e184db
+#: ../../source/development_guide/rest_api.rst:276
+msgid "returns the JSON data for cluster with given profile ID"
+msgstr ""
+
+# ecaf0b8eb09146c1990b346ac4c12ea8
+#: ../../source/development_guide/sphinx_directive.rst:4
+msgid "IPython Sphinx Directive"
+msgstr ""
+
+# 1a6af3d02129462689efcf761c98db39
+#: ../../source/development_guide/sphinx_directive.rst:9
+msgid ""
+"The ipython directive is a stateful ipython shell for embedding in sphinx"
+" documents.  It knows about standard ipython prompts, and extracts the "
+"input and output lines.  These prompts will be renumbered starting at "
+"``1``.  The inputs will be fed to an embedded ipython interpreter and the"
+" outputs from that interpreter will be inserted as well.  For example, "
+"code blocks like the following::"
+msgstr ""
+
+# be1f1c5ba2854ae9abcec8403c98b857
+#: ../../source/development_guide/sphinx_directive.rst:23
+msgid "will be rendered as"
+msgstr ""
+
+# 95d3f01bb5da46e7b1fc259b1f68fd9b
+#: ../../source/development_guide/sphinx_directive.rst:34
+msgid ""
+"This tutorial should be read side-by-side with the Sphinx source for this"
+" document because otherwise you will see only the rendered output and not"
+" the code that generated it.  Excepting the example above, we will not in"
+" general be showing the literal ReST in this document that generates the "
+"rendered output."
+msgstr ""
+
+# 7a9bcf56e253423cbc1c6256b5c4501e
+#: ../../source/development_guide/sphinx_directive.rst:41
+msgid ""
+"The state from previous sessions is stored, and standard error is "
+"trapped. At doc build time, ipython's output and std err will be "
+"inserted, and prompts will be renumbered. So the prompt below should be "
+"renumbered in the rendered docs, and pick up where the block above left "
+"off."
+msgstr ""
+
+# 8661fbdc92ab401b81044a193e9cdead
+#: ../../source/development_guide/sphinx_directive.rst:66
+msgid ""
+"The embedded interpreter supports some limited markup.  For example, you "
+"can put comments in your ipython sessions, which are reported verbatim.  "
+"There are some handy \"pseudo-decorators\" that let you doctest the "
+"output.  The inputs are fed to an embedded ipython session and the "
+"outputs from the ipython session are inserted into your doc.  If the "
+"output in your doc and in the ipython session don't match on a doctest "
+"assertion, an error will be"
+msgstr ""
+
+# 3f187933d2ca4ee8a3754fca19ba9c27
+#: ../../source/development_guide/sphinx_directive.rst:92
+msgid "Multi-line input is supported."
+msgstr ""
+
+# 2f404b366a7c4e33a08ad3536a33b782
+#: ../../source/development_guide/sphinx_directive.rst:103
+msgid ""
+"You can do doctesting on multi-line output as well.  Just be careful when"
+" using non-deterministic inputs like random numbers in the ipython "
+"directive, because your inputs are ruin through a live interpreter, so if"
+" you are doctesting random output you will get an error.  Here we "
+"\"seed\" the random number generator for deterministic output, and we "
+"suppress the seed line so it doesn't show up in the rendered output"
+msgstr ""
+
+# cd769347eca441e6ae41012cbd6c3368
+#: ../../source/development_guide/sphinx_directive.rst:132
+msgid "Another demonstration of multi-line input and output"
+msgstr ""
+
+# e25d68950302401aab1b4a8efbca2b28
+#: ../../source/development_guide/sphinx_directive.rst:156
+msgid ""
+"Most of the \"pseudo-decorators\" can be used an options to ipython mode."
+"  For example, to setup matplotlib pylab but suppress the output, you can"
+" do.  When using the matplotlib ``use`` directive, it should occur before"
+" any import of pylab.  This will not show up in the rendered docs, but "
+"the commands will be executed in the embedded interpreter and subsequent "
+"line numbers will be incremented to reflect the inputs::"
+msgstr ""
+
+# d512e1317bf34899ba98769e96504ffc
+#: ../../source/development_guide/sphinx_directive.rst:177
+msgid ""
+"Likewise, you can set ``:doctest:`` or ``:verbatim:`` to apply these "
+"settings to the entire block.  For example,"
+msgstr ""
+
+# 750e9c6085cb47f494525d6d700016eb
+#: ../../source/development_guide/sphinx_directive.rst:211
+msgid ""
+"You can create one or more pyplot plots and insert them with the "
+"``@savefig`` decorator."
+msgstr ""
+
+# 7e0cba55af2c4726b80908fc11bd87d4
+#: ../../source/development_guide/sphinx_directive.rst:223
+msgid ""
+"In a subsequent session, we can update the current figure with some text,"
+" and then resave"
+msgstr ""
+
+# 26224a89dd6b4104993adddc105e30d2
+#: ../../source/development_guide/sphinx_directive.rst:236
+msgid "You can also have function definitions included in the source."
+msgstr ""
+
+# 4fee5a90c5924503a796fe31c61836cd
+#: ../../source/development_guide/sphinx_directive.rst:250
+msgid "Then call it from a subsequent section."
+msgstr ""
+
+# 40f4c170c68d465ebd0facc61091d74c
+#: ../../source/development_guide/sphinx_directive.rst:262
+msgid "Writing Pure Python Code"
+msgstr ""
+
+# 27b06e32117148dd9ac27196ea17cff7
+#: ../../source/development_guide/sphinx_directive.rst:264
+msgid ""
+"Pure python code is supported by the optional argument `python`. In this "
+"pure python syntax you do not include the output from the python "
+"interpreter. The following markup::"
+msgstr ""
+
+# 9bfc9399e7344f47aeee6b108d4c80c8
+#: ../../source/development_guide/sphinx_directive.rst:275
+msgid "Renders as"
+msgstr ""
+
+# 143dfd8c90d640d1ae379cff861c53fc
+#: ../../source/development_guide/sphinx_directive.rst:284
+msgid ""
+"We can even plot from python, using the savefig decorator, as well as, "
+"suppress output with a semicolon"
+msgstr ""
+
+# 4e5f8f65f700433da3aa7c77aff0b8e8
+#: ../../source/development_guide/sphinx_directive.rst:292
+msgid "Similarly, std err is inserted"
+msgstr ""
+
+# be359198a34747a2a02d4ec1202f60f7
+#: ../../source/development_guide/sphinx_directive.rst:299
+msgid "Comments are handled and state is preserved"
+msgstr ""
+
+# 26da84518202409ebcf6b00f0d273bb8
+#: ../../source/development_guide/sphinx_directive.rst:306
+msgid "If you don't see the next code block then the options work."
+msgstr ""
+
+# 9e1cb6242761493abd5e4b9f305f73c6
+#: ../../source/development_guide/sphinx_directive.rst:313
+msgid "Multi-line input is handled."
+msgstr ""
+
+# 91f37105015c41d79b3605f85c3c69f5
+#: ../../source/development_guide/sphinx_directive.rst:323
+msgid "Functions definitions are correctly parsed"
+msgstr ""
+
+# 09192d72a72842c1af4869ff794d0c94
+#: ../../source/development_guide/sphinx_directive.rst:336
+msgid "And persist across sessions"
+msgstr ""
+
+# 8df88447cc244a0e98ada814e7bb2c75
+#: ../../source/development_guide/sphinx_directive.rst:343
+msgid ""
+"Pretty much anything you can do with the ipython code, you can do with a "
+"simple python script. Obviously, though it doesn't make sense to use the "
+"doctest option."
+msgstr ""
+
+# 078e5ad91f7e496e8f8551f9d8447521
+#: ../../source/development_guide/sphinx_directive.rst:348
+msgid "Pseudo-Decorators"
+msgstr ""
+
+# 8496e2e10f8249f8a0889c63bc0bdc01
+#: ../../source/development_guide/sphinx_directive.rst:350
+msgid ""
+"Here are the supported decorators, and any optional arguments they take."
+"  Some of the decorators can be used as options to the entire block (eg "
+"``verbatim`` and ``suppress``), and some only apply to the line just "
+"below them (eg ``savefig``)."
+msgstr ""
+
+# 46581c1b4489455a9401ef030eb19f7e
+#: ../../source/development_guide/sphinx_directive.rst:355
+msgid "@suppress"
+msgstr ""
+
+# 78c15d5d9d2148f1b24d668c8bbf3a12
+#: ../../source/development_guide/sphinx_directive.rst:357
+msgid ""
+"execute the ipython input block, but suppress the input and output block "
+"from the rendered output.  Also, can be applied to the entire "
+"``..ipython`` block as a directive option with ``:suppress:``."
+msgstr ""
+
+# f80914b7f9d84a0cb2269c32131f57c5
+#: ../../source/development_guide/sphinx_directive.rst:361
+msgid "@verbatim"
+msgstr ""
+
+# 7581a6ec4f3340009ea650860d1a4e87
+#: ../../source/development_guide/sphinx_directive.rst:363
+msgid ""
+"insert the input and output block in verbatim, but auto-increment the "
+"line numbers. Internally, the interpreter will be fed an empty string, so"
+" it is a no-op that keeps line numbering consistent. Also, can be applied"
+" to the entire ``..ipython`` block as a directive option with "
+"``:verbatim:``."
+msgstr ""
+
+# 5c4589b166cc4f8bbfc0ac493852cbba
+#: ../../source/development_guide/sphinx_directive.rst:369
+msgid "@savefig OUTFILE [IMAGE_OPTIONS]"
+msgstr ""
+
+# 3527e86c071e4a66b28c3634d27c12f7
+#: ../../source/development_guide/sphinx_directive.rst:371
+msgid ""
+"save the figure to the static directory and insert it into the document, "
+"possibly binding it into a minipage and/or putting code/figure "
+"label/references to associate the code and the figure. Takes args to pass"
+" to the image directive (*scale*, *width*, etc can be kwargs); see `image"
+" options "
+"<http://docutils.sourceforge.net/docs/ref/rst/directives.html#image>`_ "
+"for details."
+msgstr ""
+
+# 9bb837c64a9f47b09c9e6cdd748149cc
+#: ../../source/development_guide/sphinx_directive.rst:379
+msgid "@doctest"
+msgstr ""
+
+# a7c37652b27f49259655b5e77a94f2f1
+#: ../../source/development_guide/sphinx_directive.rst:381
+msgid ""
+"Compare the pasted in output in the ipython block with the output "
+"generated at doc build time, and raise errors if they donâ€™t match. "
+"Also, can be applied to the entire ``..ipython`` block as a directive "
+"option with ``:doctest:``."
+msgstr ""
+
+# 981a1d3bd1774d75893718ec6fc08f09
+#: ../../source/development_guide/sphinx_directive.rst:387
+msgid "Configuration Options"
+msgstr ""
+
+# 3df1f28cd6bf45acade20f5d1517e6f6
+#: ../../source/development_guide/sphinx_directive.rst:389
+msgid "ipython_savefig_dir"
+msgstr ""
+
+# 792602678601404a8d3ac21aa40be6b1
+#: ../../source/development_guide/sphinx_directive.rst:391
+msgid ""
+"The directory in which to save the figures. This is relative to the "
+"Sphinx source directory. The default is `html_static_path`."
+msgstr ""
+
+# 140a2c7a2b9d402cad12d5a024cb3e60
+#: ../../source/development_guide/sphinx_directive.rst:394
+msgid "ipython_rgxin"
+msgstr ""
+
+# bd034db7665a47e8b4d9368ff619aafa
+#: ../../source/development_guide/sphinx_directive.rst:396
+msgid ""
+"The compiled regular expression to denote the start of IPython input "
+"lines. The default is re.compile('In \\[(\\d+)\\]:\\s?(.*)\\s*'). You "
+"shouldn't need to change this."
+msgstr ""
+
+# f7c5465041ba48c2850106f6e9e94697
+#: ../../source/development_guide/sphinx_directive.rst:400
+msgid "ipython_rgxout"
+msgstr ""
+
+# 77908add9c29480690fd25915d879634
+#: ../../source/development_guide/sphinx_directive.rst:402
+msgid ""
+"The compiled regular expression to denote the start of IPython output "
+"lines. The default is re.compile('Out\\[(\\d+)\\]:\\s?(.*)\\s*'). You "
+"shouldn't need to change this."
+msgstr ""
+
+# 3201a8e59323478684c80a3454c2f8df
+#: ../../source/development_guide/sphinx_directive.rst:407
+msgid "ipython_promptin"
+msgstr ""
+
+# d057091b1f274838b754082ae5624619
+#: ../../source/development_guide/sphinx_directive.rst:409
+#, python-format
+msgid ""
+"The string to represent the IPython input prompt in the generated ReST. "
+"The default is 'In [%d]:'. This expects that the line numbers are used in"
+" the prompt."
+msgstr ""
+
+# 7b8b46b701f441eabf3e9e4bd61d6ff1
+#: ../../source/development_guide/sphinx_directive.rst:413
+msgid "ipython_promptout"
+msgstr ""
+
+# 890612f5be0b41c4aa95fbf2df2106b7
+#: ../../source/development_guide/sphinx_directive.rst:415
+#, python-format
+msgid ""
+"The string to represent the IPython prompt in the generated ReST. The "
+"default is 'Out [%d]:'. This expects that the line numbers are used in "
+"the prompt."
+msgstr ""
+
+# 27a6f000767e4d5ca50192bbba9a45cb
+#: ../../source/development_guide/testing.rst:4
+msgid "Testing IPython for users and developers"
+msgstr ""
+
+# e1c007bdd68b49d897c585eb20430783
+#: ../../source/development_guide/testing.rst:10
+msgid "Overview"
+msgstr ""
+
+# 844d10e3be9a4277aa773c204884291a
+#: ../../source/development_guide/testing.rst:12
+msgid ""
+"It is extremely important that all code contributed to IPython has tests."
+" Tests should be written as unittests, doctests or other entities that "
+"the IPython test system can detect. See below for more details on this."
+msgstr ""
+
+# 821bcb831c114683b15276dc6ec5899f
+#: ../../source/development_guide/testing.rst:17
+msgid ""
+"Each subpackage in IPython should have its own ``tests`` directory that "
+"contains all of the tests for that subpackage. All of the files in the "
+"``tests`` directory should have the word \"tests\" in them to enable the "
+"testing framework to find them."
+msgstr ""
+
+# 570ccbdb6bbf4d93bca65ee6004cbf20
+#: ../../source/development_guide/testing.rst:22
+msgid ""
+"In docstrings, examples (either using IPython prompts like ``In [1]:`` or"
+" 'classic' python ``>>>`` ones) can and should be included. The testing "
+"system will detect them as doctests and will run them; it offers control "
+"to skip parts or all of a specific doctest if the example is meant to be "
+"informative but shows non-reproducible information (like filesystem "
+"data)."
+msgstr ""
+
+# eb5ea7f7c4bd4149b910b6e7fdc90548
+#: ../../source/development_guide/testing.rst:29
+msgid ""
+"If a subpackage has any dependencies beyond the Python standard library, "
+"the tests for that subpackage should be skipped if the dependencies are "
+"not found. This is very important so users don't get tests failing simply"
+" because they don't have dependencies."
+msgstr ""
+
+# 1bae5608051d4014aaf1bdd3fea06df1
+#: ../../source/development_guide/testing.rst:34
+msgid ""
+"The testing system we use is an extension of the `nose "
+"<https://code.google.com/archive/p/python-nose>`__ test runner. In "
+"particular we've developed a nose plugin that allows us to paste verbatim"
+" IPython sessions and test them as doctests, which is extremely important"
+" for us."
+msgstr ""
+
+# f197bc1384eb4e908a7315e7a18894cd
+#: ../../source/development_guide/testing.rst:41
+msgid "Running the test suite"
+msgstr ""
+
+# d4eb05e8dab545a8bc155c101920e037
+#: ../../source/development_guide/testing.rst:43
+msgid ""
+"You can run IPython from the source download directory without even "
+"installing it system-wide or having configure anything, by typing at the "
+"terminal:"
+msgstr ""
+
+# 8aff3ac30add49aa91a752e8b3ae02b8
+#: ../../source/development_guide/testing.rst:51
+msgid "To start the webbased notebook you can use:"
+msgstr ""
+
+# 5786563b0bdd48439fa3dc0295306ac5
+#: ../../source/development_guide/testing.rst:57
+msgid ""
+"In order to run the test suite, you must at least be able to import "
+"IPython, even if you haven't fully installed the user-facing scripts yet "
+"(common in a development environment). You can then run the tests with:"
+msgstr ""
+
+# 14fb987065c2432dba155af720fe2bb1
+#: ../../source/development_guide/testing.rst:65
+msgid "Once you have installed IPython either via a full install or using:"
+msgstr ""
+
+# 71ac67c588434e1590c51a6eb7173c8a
+#: ../../source/development_guide/testing.rst:71
+msgid ""
+"you will have available a system-wide script called ``iptest`` that runs "
+"the full test suite. You can then run the suite with:"
+msgstr ""
+
+# 4f379e62ed0a48ebb0b34290233f8743
+#: ../../source/development_guide/testing.rst:78
+msgid ""
+"By default, this excludes the relatively slow tests for "
+"``IPython.parallel``. To run these, use ``iptest --all``."
+msgstr ""
+
+# b953130e61dd46fea865b2f3db368b9e
+#: ../../source/development_guide/testing.rst:81
+msgid ""
+"Please note that the iptest tool will run tests against the code imported"
+" by the Python interpreter. If the command ``python setup.py symlink`` "
+"has been previously run then this will always be the test code in the "
+"local directory via a symlink. However, if this command has not been run "
+"for the version of Python being tested, there is the possibility that "
+"iptest will run the tests against an installed version of IPython."
+msgstr ""
+
+# 9710816ba7b2484ea640d3a6b1b99c31
+#: ../../source/development_guide/testing.rst:89
+msgid ""
+"Regardless of how you run things, you should eventually see something "
+"like:"
+msgstr ""
+
+# 614b34f2ec5b4490a5e840f9d501ba70
+#: ../../source/development_guide/testing.rst:114
+msgid ""
+"If not, there will be a message indicating which test group failed and "
+"how to rerun that group individually. For example, this tests the "
+"``IPython.utils`` subpackage, the ``-v`` option shows progress "
+"indicators:"
+msgstr ""
+
+# 472241ea528a4474bf852a4a2b3192bf
+#: ../../source/development_guide/testing.rst:129
+msgid ""
+"Because the IPython test machinery is based on nose, you can use all nose"
+" syntax. Options after ``--`` are passed to nose. For example, this lets "
+"you run the specific test ``test_rehashx`` inside the ``test_magic`` "
+"module:"
+msgstr ""
+
+# a8b75c70816c4171995e1b3d69bc62af
+#: ../../source/development_guide/testing.rst:145
+msgid ""
+"When developing, the ``--pdb`` and ``--pdb-failures`` of nose are "
+"particularly useful, these drop you into an interactive pdb session at "
+"the point of the error or failure respectively: ``iptest mymodule -- "
+"--pdb``."
+msgstr ""
+
+# cc865cad5eff4c63bde73d0e5ed83c27
+#: ../../source/development_guide/testing.rst:150
+msgid ""
+"The system information summary printed above is accessible from the top "
+"level package. If you encounter a problem with IPython, it's useful to "
+"include this information when reporting on the mailing list; use::"
+msgstr ""
+
+# 89f6b6f7135644de883cfe881958da37
+#: ../../source/development_guide/testing.rst:156
+msgid "from IPython import sys_info print sys_info()"
+msgstr ""
+
+# 1ad64a55fae24664865a1daa9546bc92
+#: ../../source/development_guide/testing.rst:159
+msgid "and include the resulting information in your query."
+msgstr ""
+
+# 5c0493f32ba34c32a7f7a26b75a45b3c
+#: ../../source/development_guide/testing.rst:162
+msgid "Testing pull requests"
+msgstr ""
+
+# 56dccf1edc7d42ba97235fc0909a286b
+#: ../../source/development_guide/testing.rst:164
+msgid ""
+"We have a script that fetches a pull request from Github, merges it with "
+"master, and runs the test suite on different versions of Python. This "
+"uses a separate copy of the repository, so you can keep working on the "
+"code while it runs. To run it:"
+msgstr ""
+
+# 5f6f81a06a5548aa92e363c518a23423
+#: ../../source/development_guide/testing.rst:173
+msgid ""
+"The number is the pull request number from Github; the ``-p`` flag makes "
+"it post the results to a comment on the pull request. Any further "
+"arguments are passed to ``iptest``."
+msgstr ""
+
+# e9bf9d2d0d9e464d8c84e83b6ecea186
+#: ../../source/development_guide/testing.rst:177
+msgid ""
+"This requires the `requests <https://pypi.python.org/pypi/requests>`__ "
+"and `keyring <https://pypi.python.org/pypi/keyring>`__ packages."
+msgstr ""
+
+# cb70af2a41f444c19d09ba4052f15034
+#: ../../source/development_guide/testing.rst:181
+msgid "For developers: writing tests"
+msgstr ""
+
+# 94aeb6cea2674d37b05d9ec68916a4c7
+#: ../../source/development_guide/testing.rst:183
+msgid ""
+"By now IPython has a reasonable test suite, so the best way to see what's"
+" available is to look at the ``tests`` directory in most subpackages. But"
+" here are a few pointers to make the process easier."
+msgstr ""
+
+# d5cf58b941044fde967b425c2e2952a2
+#: ../../source/development_guide/testing.rst:188
+msgid "Main tools: ``IPython.testing``"
+msgstr ""
+
+# 473653eaf4104a50a6472b679f60cc7a
+#: ../../source/development_guide/testing.rst:190
+msgid ""
+"The ``IPython.testing`` package is where all of the machinery to test "
+"IPython (rather than the tests for its various parts) lives. In "
+"particular, the ``iptest`` module in there has all the smarts to control "
+"the test process. In there, the ``make_exclude`` function is used to "
+"build a blacklist of exclusions, these are modules that do not get even "
+"imported for tests. This is important so that things that would fail to "
+"even import because of missing dependencies don't give errors to end "
+"users, as we stated above."
+msgstr ""
+
+# 40dbcdef36d64128ad582781f05c660b
+#: ../../source/development_guide/testing.rst:199
+msgid ""
+"The ``decorators`` module contains a lot of useful decorators, especially"
+" useful to mark individual tests that should be skipped under certain "
+"conditions (rather than blacklisting the package altogether because of a "
+"missing major dependency)."
+msgstr ""
+
+# 8c1c005edf93476a8ae62b269d4404a6
+#: ../../source/development_guide/testing.rst:205
+msgid "Our nose plugin for doctests"
+msgstr ""
+
+# bfb15655ad094c51b4473555ba6ceb28
+#: ../../source/development_guide/testing.rst:207
+msgid ""
+"The ``plugin`` subpackage in testing contains a nose plugin called "
+"``ipdoctest`` that teaches nose about IPython syntax, so you can write "
+"doctests with IPython prompts. You can also mark doctest output with ``# "
+"random`` for the output corresponding to a single input to be ignored "
+"(stronger than using ellipsis and useful to keep it as an example). If "
+"you want the entire docstring to be executed but none of the output from "
+"any input to be checked, you can use the ``# all-random`` marker. The "
+"``IPython.testing.plugin.dtexample`` module contains examples of how to "
+"use these; for reference here is how to use ``# random``:"
+msgstr ""
+
+# 1292a78c838b4a9caeca2665510d1b04
+#: ../../source/development_guide/testing.rst:249
+msgid "and an example of ``# all-random``:"
+msgstr ""
+
+# 2d557c51b55e49a693c25acd171eb9bc
+#: ../../source/development_guide/testing.rst:279
+msgid ""
+"When writing docstrings, you can use the ``@skip_doctest`` decorator to "
+"indicate that a docstring should *not* be treated as a doctest at all. "
+"The difference between ``# all-random`` and ``@skip_doctest`` is that the"
+" former executes the example but ignores output, while the latter doesn't"
+" execute any code. ``@skip_doctest`` should be used for docstrings whose "
+"examples are purely informational."
+msgstr ""
+
+# 70efd2988ecf430f99d724409ed8cec0
+#: ../../source/development_guide/testing.rst:286
+msgid ""
+"If a given docstring fails under certain conditions but otherwise is a "
+"good doctest, you can use code like the following, that relies on the "
+"'null' decorator to leave the docstring intact where it works as a test:"
+msgstr ""
+
+# 3878be7f250c4ca5ba17f9028f5309a5
+#: ../../source/development_guide/testing.rst:304
+msgid ""
+"With our nose plugin that understands IPython syntax, an extremely "
+"effective way to write tests is to simply copy and paste an interactive "
+"session into a docstring. You can writing this type of test, where your "
+"docstring is meant *only* as a test, by prefixing the function name with "
+"``doctest_`` and leaving its body *absolutely empty* other than the "
+"docstring. In ``IPython.core.tests.test_magic`` you can find several "
+"examples of this, but for completeness sake, your code should look like "
+"this (a simple case):"
+msgstr ""
+
+# f2323f599c37435999518cd691eb254f
+#: ../../source/development_guide/testing.rst:322
+msgid ""
+"This function is only analyzed for its docstring but it is not considered"
+" a separate test, which is why its body should be empty."
+msgstr ""
+
+# a1a31cd900144f6498b312df387bf326
+#: ../../source/development_guide/testing.rst:326
+msgid "JavaScript Tests"
+msgstr ""
+
+# 55e925644bbf42f18fea76e793e5f7ea
+#: ../../source/development_guide/testing.rst:328
+msgid ""
+"We currently use `casperjs <http://casperjs.org/>`__ for testing the "
+"notebook javascript user interface."
+msgstr ""
+
+# 86ed51fe4d284284812995f9c2aa800d
+#: ../../source/development_guide/testing.rst:331
+msgid ""
+"To run the JS test suite by itself, you can either use ``iptest js``, "
+"which will start up a new notebook server and test against it, or you can"
+" open up a notebook server yourself, and then:"
+msgstr ""
+
+# 10ef19ece8954410aa7023ae524cfe0e
+#: ../../source/development_guide/testing.rst:340
+msgid ""
+"If your testing notebook server uses something other than the default "
+"port (8888), you will have to pass that as a parameter to the test suite "
+"as well."
+msgstr ""
+
+# d4dd9155cfc741168d07245a00e7449e
+#: ../../source/development_guide/testing.rst:349
+msgid "Running individual tests"
+msgstr ""
+
+# 27e768bba3f64ba7b12e8e7225779467
+#: ../../source/development_guide/testing.rst:351
+msgid ""
+"To speed up development, you usually are working on getting one test "
+"passing at a time. To do this, just pass the filename directly to the "
+"``casperjs test`` command like so:"
+msgstr ""
+
+# 11f7653601b84925a2ec145e210d7da0
+#: ../../source/development_guide/testing.rst:360
+msgid "Wrapping your head around the javascript within javascript:"
+msgstr ""
+
+# ed4f3f26b8dc4b3eaba4975661c195c3
+#: ../../source/development_guide/testing.rst:362
+msgid ""
+"CasperJS is a browser that's written in javascript, so we write "
+"javascript code to drive it. The Casper browser itself also has a "
+"javascript implementation (like the ones that come with Firefox and "
+"Chrome), and in the test suite we get access to those using "
+"``this.evaluate``, and it's cousins (``this.theEvaluate``, etc). "
+"Additionally, because of the asynchronous / callback nature of "
+"everything, there are plenty of ``this.then`` calls which define steps in"
+" test suite. Part of the reason for this is that each step has a timeout "
+"(default of 5 or 10 seconds). Additionally, there are already convenience"
+" functions in ``util.js`` to help you wait for output in a given cell, "
+"etc. In our javascript tests, if you see functions which "
+"``look_like_pep8_naming_convention``, those are probably coming from "
+"``util.js``, whereas functions that come with casper "
+"``haveCamelCaseNamingConvention``"
+msgstr ""
+
+# b834615955564a74a7c34b4071190cdc
+#: ../../source/development_guide/testing.rst:377
+msgid ""
+"Each file in ``test_cases`` looks something like this (this is "
+"``test_cases/check_interrupt.js``):"
+msgstr ""
+
+# 52615ee776ef4a71bf05c26f46670d28
+#: ../../source/development_guide/testing.rst:419
+msgid ""
+"For an example of how to pass parameters to the client-side javascript "
+"from casper test suite, see the ``casper.wait_for_output`` implementation"
+" in ``IPython/html/tests/casperjs/util.js``"
+msgstr ""
+
+# fae96465d4094630ac562426a0003dbc
+#: ../../source/development_guide/testing.rst:424
+msgid "Testing system design notes"
+msgstr ""
+
+# 58335def9eaa4f669f9521490ecbaa26
+#: ../../source/development_guide/testing.rst:426
+msgid ""
+"This section is a set of notes on the key points of the IPython testing "
+"needs, that were used when writing the system and should be kept for "
+"reference as it eveolves."
+msgstr ""
+
+# 4b0a9eccc5924a96aae6703bb568a450
+#: ../../source/development_guide/testing.rst:430
+msgid ""
+"Testing IPython in full requires modifications to the default behavior of"
+" nose and doctest, because the IPython prompt is not recognized to "
+"determine Python input, and because IPython admits user input that is not"
+" valid Python (things like ``%magics`` and ``!system commands``."
+msgstr ""
+
+# 800dc52e25ed4b7c91a299d5226f21ef
+#: ../../source/development_guide/testing.rst:435
+msgid "We basically need to be able to test the following types of code:"
+msgstr ""
+
+# b91ada24535c4452b163e02c66844461
+#: ../../source/development_guide/testing.rst:439
+msgid ""
+"Pure Python files containing normal tests. These are not a problem, since"
+" Nose will pick them up as long as they conform to the (flexible) "
+"conventions used by nose to recognize tests."
+msgstr ""
+
+# 62b8a60a8b14443ebfc3ca1dba0de170
+#: ../../source/development_guide/testing.rst:445
+msgid "Python files containing doctests. Here, we have two possibilities:"
+msgstr ""
+
+# 6324a400853c4860abf99f4cbd08a59c
+#: ../../source/development_guide/testing.rst:448
+msgid "The prompts are the usual ``>>>`` and the input is pure Python."
+msgstr ""
+
+# 65fa6dd816c24f4e9b84f6d0920c5756
+#: ../../source/development_guide/testing.rst:449
+msgid ""
+"The prompts are of the form ``In [1]:`` and the input can contain "
+"extended IPython expressions."
+msgstr ""
+
+# 9ad1cecfc10347bfac60314688c8dba6
+#: ../../source/development_guide/testing.rst:452
+msgid ""
+"In the first case, Nose will recognize the doctests as long as it is "
+"called with the ``--with-doctest`` flag. But the second case will likely "
+"require modifications or the writing of a new doctest plugin for Nose "
+"that is IPython-aware."
+msgstr ""
+
+# 200c3b0361b1483fabdf8735413bdd04
+#: ../../source/development_guide/testing.rst:459
+msgid ""
+"ReStructuredText files that contain code blocks. For this type of file, "
+"we have three distinct possibilities for the code blocks:"
+msgstr ""
+
+# 1886e7b95147471b9c70104d4bb51db6
+#: ../../source/development_guide/testing.rst:462
+msgid "They use ``>>>`` prompts."
+msgstr ""
+
+# 09bac740954c4fdca7173fafa7ff0716
+#: ../../source/development_guide/testing.rst:463
+msgid "They use ``In [1]:`` prompts."
+msgstr ""
+
+# 4b346c61197a47b2b1be0d95b8afa113
+#: ../../source/development_guide/testing.rst:464
+msgid "They are standalone blocks of pure Python code without any prompts."
+msgstr ""
+
+# 15b043cc6fa14b5687221a1c8176794e
+#: ../../source/development_guide/testing.rst:466
+msgid ""
+"The first two cases are similar to the situation #2 above, except that in"
+" this case the doctests must be extracted from input code blocks using "
+"docutils instead of from the Python docstrings."
+msgstr ""
+
+# 66f66893cec8416fbf35c58a4d7a6a28
+#: ../../source/development_guide/testing.rst:470
+msgid ""
+"In the third case, we must have a convention for distinguishing code "
+"blocks that are meant for execution from others that may be snippets of "
+"shell code or other examples not meant to be run. One possibility is to "
+"assume that all indented code blocks are meant for execution, but to have"
+" a special docutils directive for input that should not be executed."
+msgstr ""
+
+# 31b72bf0802e45aabd969ed1ee4de26f
+#: ../../source/development_guide/testing.rst:476
+msgid ""
+"For those code blocks that we will execute, the convention used will "
+"simply be that they get called and are considered successful if they run "
+"to completion without raising errors. This is similar to what Nose does "
+"for standalone test functions, and by putting asserts or other forms of "
+"exception-raising statements it becomes possible to have literate "
+"examples that double as lightweight tests."
+msgstr ""
+
+# 4656af2388f0464ba9945c046148ce4c
+#: ../../source/development_guide/testing.rst:485
+msgid ""
+"Extension modules with doctests in function and method docstrings. "
+"Currently Nose simply can't find these docstrings correctly, because the "
+"underlying doctest DocTestFinder object fails there. Similarly to #2 "
+"above, the docstrings could have either pure python or IPython prompts."
+msgstr ""
+
+# b81efc4dc4b94b3bbb7f5d2ec96ce033
+#: ../../source/development_guide/testing.rst:491
+msgid ""
+"Of these, only 3-c (reST with standalone code blocks) is not implemented "
+"at this point."
+msgstr ""
+
+# f838da91fa8045d89293ced7d8692fc2
+#: ../../source/development_guide/testing_kernels.rst:4
+msgid "Testing Kernels"
+msgstr ""
+
+# ac92e155007c43bc80418b77b9a0cf88
+#: ../../source/development_guide/testing_kernels.rst:9
+msgid ""
+"IPython makes it very easy to create wrapper kernels using its kernel "
+"framework. It requires extending the Kernel class and implementing a set "
+"of methods for the core functions like execute, history etc. Its also "
+"possible to write a full blown kernel in a language of your choice "
+"implementing listeners for all the zmq ports."
+msgstr ""
+
+# f736b303e5ac4f49bbc8a3f25e509692
+#: ../../source/development_guide/testing_kernels.rst:15
+msgid ""
+"The key problem for any kernel implemented by these methods is to ensure "
+"that it meets the message specification. The kerneltest command is a "
+"means to test the installed kernel against the message spec and validate "
+"the results."
+msgstr ""
+
+# 91370782e52f4012abf6b8acf0a5bc16
+#: ../../source/development_guide/testing_kernels.rst:21
+msgid "The kerneltest tool"
+msgstr ""
+
+# 0e98a93a5d064fdabde647dc8406ff87
+#: ../../source/development_guide/testing_kernels.rst:23
+msgid ""
+"The kerneltest tool is part of IPython.testing and is also included in "
+"the scripts similar to iptest. This takes 2 parameters - the name of the "
+"kernel to test and the test script file. The test script file should be "
+"in json format as described in the next section."
+msgstr ""
+
+# 3ce7cd1696494c4eae12a69ea3b741ee
+#: ../../source/development_guide/testing_kernels.rst:32
+msgid ""
+"You can also pass in an optional message spec version to the command. At "
+"the moment only the version 5 is supported, but as newer versions are "
+"released this can be used to test the kernel against a specific version "
+"of the kernel."
+msgstr ""
+
+# d2b4dcfce0e84905b4c9bfc15f589e93
+#: ../../source/development_guide/testing_kernels.rst:41
+msgid ""
+"The kernel to be tested needs to be installed and the kernelspec "
+"available in the user IPython directory. The tool will instantiate the "
+"kernel and send the commands over ZMQ. For each command executed on the "
+"kernel, the tool will validate the reply to ensure that it matches the "
+"message specification. In some cases the output is also checked, but the "
+"reply is always returned and printed out on the console. This can be used"
+" to validate that apart from meeting the message spec the kernel also "
+"produced the correct output."
+msgstr ""
+
+# 810f483237f74986bf01858b41067f9a
+#: ../../source/development_guide/testing_kernels.rst:51
+msgid "The test script file"
+msgstr ""
+
+# a645935aa17a44a3924eac56c4b49160
+#: ../../source/development_guide/testing_kernels.rst:53
+msgid ""
+"The test script file is a simple json file that specifies the command to "
+"execute and the test code to execute for the command."
+msgstr ""
+
+# 1d1a27261190419b852cc9ddc37c4615
+#: ../../source/development_guide/testing_kernels.rst:64
+msgid ""
+"For some commands in the message specification like kernel\\_info there "
+"is no need to specify the test\\_code parameter. The tool validates if it"
+" has all the inputs needed to execute the command and will print out an "
+"error to the console if it finds a missing parameter. Since the "
+"validation is built in, and only required parameters are passed, it is "
+"possible to add additional fields in the json file for test "
+"documentation."
+msgstr ""
+
+# ecab2837ce3b434db96892386181204c
+#: ../../source/development_guide/testing_kernels.rst:82
+msgid "A sample test script for the redis kernel will look like this"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/glossary.po
+++ b/docs/source/locale/es/LC_MESSAGES/glossary.po
@@ -1,0 +1,145 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 938cb2236c5e4a24a0d1cd9f80149b27
+#: ../../source/glossary.rst:5
+msgid "Glossary"
+msgstr ""
+
+# 9d41e58ffa16468b8e023a9712b29b3b
+#: ../../source/glossary.rst:8
+msgid "command line"
+msgstr ""
+
+# 5f6a8ec0ea1d4dad93821e3a29a9e5a5
+#: ../../source/glossary.rst:10
+msgid "The terminal or console window where you type commands."
+msgstr ""
+
+# a9505efde187467c88289d5b5c57bc92
+#: ../../source/glossary.rst:11
+msgid "Command Prompt"
+msgstr ""
+
+# fb1bf6539f8d4152a96bbfff01ede6bb
+#: ../../source/glossary.rst:13
+msgid ""
+"On Windows, this is the application where commands are typed into a "
+"window for execution."
+msgstr ""
+
+# a53402578c0c4ec4aef323352f576b9c
+#: ../../source/glossary.rst:15
+msgid "conda"
+msgstr ""
+
+# 48aea7fb60ea46b48b9d5cecc6b7c9f6
+#: ../../source/glossary.rst:17
+msgid "The package manager for Anaconda."
+msgstr ""
+
+# 9144299b6c03438697d2df100f252f0c
+#: ../../source/glossary.rst:18
+msgid "config"
+msgstr ""
+
+# af39f4ba81f8473f919ef55fefc8023c
+#: ../../source/glossary.rst:20
+msgid "Refers to the configuration files and process."
+msgstr ""
+
+# 7621f3badf974780adee77534f946e48
+#: ../../source/glossary.rst:21
+msgid "kernel"
+msgstr ""
+
+# ac15ce043620490d8fc7a9d46fc5d4ae
+#: ../../source/glossary.rst:23
+msgid ""
+"A kernel provides programming language support in Jupyter. IPython is the"
+" default kernel. Additional kernels include R, Julia, and many more."
+msgstr ""
+
+# 6c87a739094e41f5b1ab517a786e0376
+#: ../../source/glossary.rst:25
+msgid "Notebook Dashboard"
+msgstr ""
+
+# f5dc136dc22c4ea5bf8f382048d69acd
+#: ../../source/glossary.rst:27
+msgid ""
+"The notebook user interface which shows a list of the notebooks, files, "
+"and subdirectories in the directory where the notebook server is started."
+msgstr ""
+
+# 9d4b3fafd38844b3913fef20c976aea2
+#: ../../source/glossary.rst:30
+msgid "pip"
+msgstr ""
+
+# dde7ae79c1cd4295989a3d816c0d9106
+#: ../../source/glossary.rst:32
+msgid "Python package manager."
+msgstr ""
+
+# 025167dfb0b849158f1433aafcc4b7c3
+#: ../../source/glossary.rst:33
+msgid "profiles"
+msgstr ""
+
+# 4f1bce8c1652475c9e8c7313bdcc0155
+#: ../../source/glossary.rst:35
+msgid ""
+"Not available in Jupyter. In IPython 3, profiles are collections of "
+"configuration and runtime files."
+msgstr ""
+
+# 98ba4c37a4704f0a84921a8a7f14b8cb
+#: ../../source/glossary.rst:37
+msgid "REPL"
+msgstr ""
+
+# 1127a9c1dee04fc18f0af7e6d4087e5b
+#: ../../source/glossary.rst:39
+msgid "read-eval-print-loop."
+msgstr ""
+
+# dbf08896a556455faf46a74c9049cdc4
+#: ../../source/glossary.rst:40
+msgid "terminal"
+msgstr ""
+
+# fb3383cb17244feba592bcdc60f6bdeb
+#: ../../source/glossary.rst:42
+msgid "A window used to type in commands to be executed (Linux and OS X)."
+msgstr ""
+
+# ec11c3cf781043bcb094685869a6fd12
+#: ../../source/glossary.rst:43
+msgid "widget"
+msgstr ""
+
+# 204b394a671c4318ad854b78304049d8
+#: ../../source/glossary.rst:45
+msgid ""
+"A user interface component, similar to a plugin, that allows customized "
+"input, such as a slider."
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/install-kernel.po
+++ b/docs/source/locale/es/LC_MESSAGES/install-kernel.po
@@ -1,0 +1,108 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# efdc3f834e74419fa6a4b57c74ee4fcd
+#: ../../source/install-kernel.rst:3
+msgid "*Optional:* Installing Kernels"
+msgstr ""
+
+# a8453d1a49ac44b1a666c35084a9ae4d
+#: ../../source/install-kernel.rst:7
+msgid "Contents"
+msgstr ""
+
+# da930aecf67d4103b678a613f2b8f9ae
+#: ../../source/install-kernel.rst:9
+msgid ""
+"This information gives a high-level view of using Jupyter Notebook with "
+"different programming languages (kernels)."
+msgstr ""
+
+# 0b4e24aa51dd400782dfff162b605bb3
+#: ../../source/install-kernel.rst:13
+msgid "Are any languages pre-installed?"
+msgstr ""
+
+# ea86f10aa988483fbc44ed6fc2ed5c1c
+#: ../../source/install-kernel.rst:15
+msgid ""
+"Yes, installing the Jupyter Notebook will also install the `IPython "
+"<https://ipython.readthedocs.io/en/latest/>`_ :term:`kernel`. This allows"
+" working on notebooks using the Python programming language."
+msgstr ""
+
+# 94ea0ff4960049e8bffc34755b0c57d0
+#: ../../source/install-kernel.rst:20
+msgid "How do I install Python 2 and Python 3?"
+msgstr ""
+
+# 9e28ab95796d4facb934d8a06dbaf56c
+#: ../../source/install-kernel.rst:22
+msgid ""
+"To install an additional version of Python, i.e. to have both Python 2 "
+"and 3 available, see the IPython docs on `installing kernels "
+"<https://ipython.readthedocs.io/en/latest/install/kernel_install.html>`_."
+msgstr ""
+
+# fc0d1726d8ff4504922a6164a4841b27
+#: ../../source/install-kernel.rst:27
+msgid "How do I install other languages like R or Julia?"
+msgstr ""
+
+# 3eff7ec0dacb45dc9198c7dc21af8e4e
+#: ../../source/install-kernel.rst:29
+msgid ""
+"To run notebooks in languages other than Python, such as R or Julia, you "
+"will need to install additional kernels. For more information, see the "
+"full `list of available kernels`_."
+msgstr ""
+
+# a15c5c1d7def408f8bf85bb8b39608f6
+#: ../../source/install-kernel.rst:37
+msgid ":ref:`Jupyter Projects <subprojects>`"
+msgstr ""
+
+# 8a2af66f6aa14ac2ae3d77f3214ed281
+#: ../../source/install-kernel.rst:36
+msgid ""
+"Detailed installation instructions for individual Jupyter or IPython "
+"projects."
+msgstr ""
+
+# ea589c0dbe5d4f7a8f61edf4c78fa86b
+#: ../../source/install-kernel.rst:40
+msgid ":ref:`Kernels <kernels-langs>`"
+msgstr ""
+
+# 0bd2cf28af6e4107a801fb8e3d0e0ac3
+#: ../../source/install-kernel.rst:40
+msgid "Information about additional programming language kernels."
+msgstr ""
+
+# 8ce58b34c6cb4505ae83e5359e506a04
+#: ../../source/install-kernel.rst:42
+msgid ":ref:`Kernels documentation for Jupyter client <kernels>`"
+msgstr ""
+
+# 9d06f59e323b40d497adf08f5a3c677f
+#: ../../source/install-kernel.rst:43
+msgid "Technical information about kernels."
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/install.po
+++ b/docs/source/locale/es/LC_MESSAGES/install.po
@@ -1,0 +1,145 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# ffbb37b4a6064c4293bd70b5fddb96e4
+#: ../../source/install.rst:5
+msgid "Installing Jupyter Notebook"
+msgstr ""
+
+# 7ab1cb39403041899fd89e70ec072c36
+#: ../../source/install.rst:9
+msgid "Contents"
+msgstr ""
+
+# 24944b561f924ddd911096f48f136f64
+#: ../../source/install.rst:11
+msgid ""
+"This information explains how to install the Jupyter Notebook and the "
+"IPython kernel."
+msgstr ""
+
+# 9adca524080f4c91b4eb73369181cac7
+#: ../../source/install.rst:15
+msgid "Prerequisite: Python"
+msgstr ""
+
+# d169910c38f948b7ac2952e799e585d5
+#: ../../source/install.rst:17
+msgid ""
+"While Jupyter runs code in many programming languages, **Python** is a "
+"requirement (Python 3.3 or greater, or Python 2.7) for installing the "
+"Jupyter Notebook."
+msgstr ""
+
+# 085979bf68e84b0e9b15d137d1234a8b
+#: ../../source/install.rst:21
+msgid ""
+"We recommend using the `Anaconda <https://www.anaconda.com/download>`_ "
+"distribution to install Python and Jupyter. We'll go through its "
+"installation in the next section."
+msgstr ""
+
+# 16c5366b626b4d39b19b501cccb27142
+#: ../../source/install.rst:28
+msgid "Installing Jupyter using Anaconda and conda"
+msgstr ""
+
+# 767eb05028794e92bc704d599083862d
+#: ../../source/install.rst:30
+msgid ""
+"For new users, we **highly recommend** `installing Anaconda "
+"<https://www.anaconda.com/download>`_. Anaconda conveniently installs "
+"Python, the Jupyter Notebook, and other commonly used packages for "
+"scientific computing and data science."
+msgstr ""
+
+# 05c5808a5e0148158765958378b90b6f
+#: ../../source/install.rst:35
+msgid "Use the following installation steps:"
+msgstr ""
+
+# 54686805017a467b9a216e0a7704ce74
+#: ../../source/install.rst:37
+msgid ""
+"Download `Anaconda <https://www.anaconda.com/download>`_. We recommend "
+"downloading Anaconda's latest Python 3 version (currently Python 3.5)."
+msgstr ""
+
+# 4a21fbaf720541fda995cb60551befb4
+#: ../../source/install.rst:40
+msgid ""
+"Install the version of Anaconda which you downloaded, following the "
+"instructions on the download page."
+msgstr ""
+
+# d5a47880420642eaba90590b54097b26
+#: ../../source/install.rst:43
+msgid "Congratulations, you have installed Jupyter Notebook. To run the notebook:"
+msgstr ""
+
+# 6227c09c5e6b4a59be669bfb1c4c2fdc
+#: ../../source/install.rst:49
+msgid "See :ref:`Running the Notebook <running>` for more details."
+msgstr ""
+
+# a57622d290e3435084627a34b100ce79
+#: ../../source/install.rst:54
+msgid "*Alternative for experienced Python users:* Installing Jupyter with pip"
+msgstr ""
+
+# 4ff159ed555344a5b35b67086a401fda
+#: ../../source/install.rst:58
+msgid ""
+"Jupyter installation requires Python 3.3 or greater, or Python 2.7. "
+"IPython 1.x, which included the parts that later became Jupyter, was the "
+"last version to support Python 3.2 and 2.6."
+msgstr ""
+
+# dbff8577777040db8c06790617420c29
+#: ../../source/install.rst:62
+msgid ""
+"As an existing Python user, you may wish to install Jupyter using "
+"Python's package manager, :term:`pip`, instead of Anaconda."
+msgstr ""
+
+# ef9257faebfd4ba4bbf41fda5f195413
+#: ../../source/install.rst:67
+msgid ""
+"First, ensure that you have the latest pip; older versions may have "
+"trouble with some dependencies:"
+msgstr ""
+
+# bc2ec7faaa854a36bd339cbebc78741c
+#: ../../source/install.rst:74
+msgid "Then install the Jupyter Notebook using:"
+msgstr ""
+
+# cc79a3bf6e1a46b4bb1ab37da05e643d
+#: ../../source/install.rst:80
+msgid "(Use ``pip`` if using legacy Python 2.)"
+msgstr ""
+
+# bedb9ecab9554259ae2a7d28ea48e972
+#: ../../source/install.rst:82
+msgid ""
+"Congratulations. You have installed Jupyter Notebook. See :ref:`Running "
+"the Notebook <running>` for more details."
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/ipython.po
+++ b/docs/source/locale/es/LC_MESSAGES/ipython.po
@@ -1,0 +1,87 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# e06aa197a71b41eeaf94dfe9f0caaca2
+#: ../../source/ipython/content-ipython.rst:2
+msgid "IPython"
+msgstr ""
+
+# 93415afba3654a1c904000d9a30c7b04
+#: ../../source/ipython/content-ipython.rst:5
+msgid "Contents"
+msgstr ""
+
+# 0fb8abaae6d6439eb2d541d1cc83182b
+#: ../../source/ipython/content-ipython.rst:13
+msgid "Description"
+msgstr ""
+
+# 0ffa752b43e04a8f84cf0772fdeeda3b
+#: ../../source/ipython/content-ipython.rst:15
+msgid "IPython provides a rich architecture for interactive computing with:"
+msgstr ""
+
+# c81ecc03613b4623a05ae0b069bfc6a8
+#: ../../source/ipython/content-ipython.rst:17
+msgid "A powerful interactive shell."
+msgstr ""
+
+# cfe69331de214e0f9492f7cdde2deeff
+#: ../../source/ipython/content-ipython.rst:18
+msgid "A kernel for Jupyter."
+msgstr ""
+
+# 405d110fdb06459f97fd470b08f9b45a
+#: ../../source/ipython/content-ipython.rst:19
+msgid "Support for interactive data visualization and use of GUI toolkits."
+msgstr ""
+
+# 198111746308470bb460f4eff0187c9c
+#: ../../source/ipython/content-ipython.rst:20
+msgid "Flexible, embeddable interpreters to load into your own projects."
+msgstr ""
+
+# cc784dedd7924d66b116dc0cee97b0ca
+#: ../../source/ipython/content-ipython.rst:21
+msgid "Easy to use, high performance tools for parallel computing."
+msgstr ""
+
+# 2807f7be8ea5430caabaadf467ac3d28
+#: ../../source/ipython/content-ipython.rst:24
+msgid "Background"
+msgstr ""
+
+# 3735a8ce15d6486f90b2e6150041cf39
+#: ../../source/ipython/content-ipython.rst:26
+msgid ""
+"IPython is a growing project, with increasingly language-agnostic "
+"components. IPython 3.x was the last monolithic release of IPython, "
+"containing the notebook server, qtconsole, etc. As of IPython 4.0, the "
+"language-agnostic parts of the project: the notebook format, message "
+"protocol, qtconsole, notebook web application, etc. have moved to new "
+"projects under the name Jupyter. IPython itself is focused on interactive"
+" Python, part of which is providing a Python kernel for Jupyter."
+msgstr ""
+
+# a902c3e9aab34a9bb26248bf4ebffc1b
+#: ../../source/ipython/content-ipython.rst:35
+msgid "Resources"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/migrating.po
+++ b/docs/source/locale/es/LC_MESSAGES/migrating.po
@@ -1,0 +1,562 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 8f5cd3c486474d4b8a13ff41c24e3e75
+#: ../../source/migrating.rst:5
+msgid "Migrating from IPython Notebook"
+msgstr ""
+
+# a0bf9b469b3d41b486c705edbe1a32d3
+#: ../../source/migrating.rst:8
+msgid "Contents"
+msgstr ""
+
+# 661d74638f8e402c8844e1dae8178361
+#: ../../source/migrating.rst:11
+msgid "Abstract"
+msgstr ""
+
+# 7b16ca89f25647868cf204d88a1e4d29
+#: ../../source/migrating.rst:13
+msgid ""
+"`The Big Split <https://blog.jupyter.org/the-big-split-9d7b88a031a7>`__ "
+"moved IPython's various language-agnostic components under the Jupyter "
+"umbrella. Going forward, Jupyter will contain the language-agnostic "
+"projects that serve many languages. IPython will continue to focus on "
+"Python and its use with Jupyter."
+msgstr ""
+
+# 06bf34e702fa456e9ce4f7b616eb546e
+#: ../../source/migrating.rst:19
+msgid ""
+"This document describes what has changed, and how you may need to modify "
+"your code or configuration when migrating from IPython version 3 to "
+"Jupyter."
+msgstr ""
+
+# 3b23232adf694c6cb4998078211d9109
+#: ../../source/migrating.rst:24
+msgid "Understanding the Migration Process"
+msgstr ""
+
+# aa9fcadf57d549aa8a6d3f4126d60ca4
+#: ../../source/migrating.rst:27
+msgid "Automatic migration of files"
+msgstr ""
+
+# f5ec35e6c2494acbac3e543734ba12f2
+#: ../../source/migrating.rst:29
+msgid ""
+"The first time you run any ``jupyter`` command, it will perform an "
+"automatic migration of files. The automatic migration process **copies** "
+"files, instead of moving files, leaving the originals in place and the "
+"copies in the Jupyter file locations. You can re-run the migration, if "
+"needed, by calling ``jupyter migrate``. Your custom configuration will be"
+" migrated automatically and should work with Jupyter without further "
+"editing. When you update or modify your configuration in the future, "
+"please keep in mind that the file locations may have changed."
+msgstr ""
+
+# 2284d903d20c49b7acf289fede63d7e7
+#: ../../source/migrating.rst:39
+msgid "Where have my configuration files gone?"
+msgstr ""
+
+# 14350789ee634cb3a07a1f7564d87294
+#: ../../source/migrating.rst:41
+msgid "Also known as: \"Why isn't my configuration having any effect anymore?\""
+msgstr ""
+
+# 07d5f3408f704edfb54df3fd57924e6e
+#: ../../source/migrating.rst:43
+msgid ""
+"Jupyter splitting out from IPython means that the locations of some files"
+" have moved, and Jupyter projects have not inherited everything from how "
+"IPython did it."
+msgstr ""
+
+# cec706b3328f4024bf9b8cac2bd78686
+#: ../../source/migrating.rst:47
+msgid ""
+"When you start your first Jupyter application, the relevant configuration"
+" files are automatically copied to their new Jupyter locations. The "
+"original configuration files in the IPython locations have no effect on "
+"Jupyter's execution. If you accidentally edit your original IPython "
+"config file, you may not see the desired effect with Jupyter now. You "
+"should check that you are editing Jupyter's configuration file, and you "
+"should see the expected effect after restarting the Jupyter server."
+msgstr ""
+
+# 35761bdec57845c5956afcbd2518fcb2
+#: ../../source/migrating.rst:56
+msgid "Finding the Location of Important Files"
+msgstr ""
+
+# 0e91703834714ff8a450c3e1f4e19183
+#: ../../source/migrating.rst:58
+msgid ""
+"This section provides quick reference for common locations of IPython 3 "
+"files and the migrated Jupyter files."
+msgstr ""
+
+# b3066e3c9a824483918e9feabfddd439
+#: ../../source/migrating.rst:62
+msgid "Configuration files"
+msgstr ""
+
+# d1be8dd7d028443bab89581071668b40
+#: ../../source/migrating.rst:64
+msgid ""
+"Configuration files customize Jupyter to the user's preferences. The "
+"migrated files should all be **automatically copied** to their new "
+"Jupyter locations. Here are the location changes:"
+msgstr ""
+
+# e5dc4b2fb1b2448a9fa739dddd5fdfdc
+#: ../../source/migrating.rst:69
+msgid "IPython location"
+msgstr ""
+
+# 716d92fb1fa94db28397bdfddd9c29f0
+#: ../../source/migrating.rst:69
+msgid "Jupyter location"
+msgstr ""
+
+# 9678737a7e6342c7bb833a2c8242b625
+#: ../../source/migrating.rst:71
+msgid ":file:`~/.ipython/profile_default/static/custom`"
+msgstr ""
+
+# 1008e78186164ff2adcc4c0a92dae223
+# 72fe30c2d0404ee59bde125a2de1e38f
+# d91efb208eae4ad7b4965599aa9fb65e
+# a7a49c506f0e42f19e6f5d03cdbc5096
+# af9332d2f5a34982a36a9bb2cdcd0473
+# e8415a6ea7a14ab9bdc8dd7fbab6d67d
+# 9e046db52de3436fa30a19e5d1d9b045
+# e853fee326ff469da5a56f61d7a961a8
+# 56b6aa8cb49b41c19612910e3afb2563
+# c1d9598dce504f2380373045dfdc7625
+# 128040d623434edb9bbeda55c9507f00
+# 1fe82a47a7eb4b06a73d941d6d5ee283
+#: ../../source/migrating.rst:71 ../../source/migrating.rst:72
+#: ../../source/migrating.rst:73 ../../source/migrating.rst:74
+#: ../../source/migrating.rst:75 ../../source/migrating.rst:241
+#: ../../source/migrating.rst:242 ../../source/migrating.rst:243
+#: ../../source/migrating.rst:244 ../../source/migrating.rst:245
+#: ../../source/migrating.rst:246 ../../source/migrating.rst:247
+msgid "→"
+msgstr ""
+
+# 3305847c2b3c4dd597ec3b649ca0feb4
+#: ../../source/migrating.rst:71
+msgid ":file:`~/.jupyter/custom`"
+msgstr ""
+
+# 8a5dbaf9bbb24302b7f8c44d5c70d748
+#: ../../source/migrating.rst:72
+msgid ":file:`~/.ipython/profile_default/ipython_notebook_config.py`"
+msgstr ""
+
+# 44d5bf8302184c91ab5ea2642ff4b0af
+#: ../../source/migrating.rst:72
+msgid ":file:`~/.jupyter/jupyter_notebook_config.py`"
+msgstr ""
+
+# f17f8f9f52884c2bbc2fce452120161a
+#: ../../source/migrating.rst:73
+msgid ":file:`~/.ipython/profile_default/ipython_nbconvert_config.py`"
+msgstr ""
+
+# 6e8948fba80a4d329cf88b88e14f34a3
+#: ../../source/migrating.rst:73
+msgid ":file:`~/.jupyter/jupyter_nbconvert_config.py`"
+msgstr ""
+
+# 3e89a17fc5b24bdb8db5e054e654b496
+#: ../../source/migrating.rst:74
+msgid ":file:`~/.ipython/profile_default/ipython_qtconsole_config.py`"
+msgstr ""
+
+# 272ac1f228084a03ac2d2114a6412072
+#: ../../source/migrating.rst:74
+msgid ":file:`~/.jupyter/jupyter_qtconsole_config.py`"
+msgstr ""
+
+# 2e3a6302c7924ba29ba73e7c4a68be2f
+#: ../../source/migrating.rst:75
+msgid ":file:`~/.ipython/profile_default/ipython_console_config.py`"
+msgstr ""
+
+# 2ecee964e7b24a10bef99b7524da7344
+#: ../../source/migrating.rst:75
+msgid ":file:`~/.jupyter/jupyter_console_config.py`"
+msgstr ""
+
+# 4d628b8f2fd64ed883e979d8ba54112c
+#: ../../source/migrating.rst:78
+msgid ""
+"To choose a directory location other than the default :file:`~/.jupyter`,"
+" set the ``JUPYTER_CONFIG_DIR`` environment variable. You may need to run"
+" ``jupyter migrate`` after setting the environment variable for files to "
+"be copied to the desired directory."
+msgstr ""
+
+# 6441364aeb0d4174b78105a74f688c16
+#: ../../source/migrating.rst:84
+msgid "Data files: kernelspecs and notebook extensions"
+msgstr ""
+
+# e2924a8235fd431b9f9fd56ae0f39d23
+#: ../../source/migrating.rst:86
+msgid ""
+"Data files include files, other than configuration files, which are user "
+"installed. Examples include kernelspecs and notebook extensions. Like the"
+" configuration files, data files are also **automatically migrated** to "
+"their new Jupyter locations."
+msgstr ""
+
+# ec6e2b0e388b4bafbefdc42d92b69ab1
+#: ../../source/migrating.rst:91
+msgid "In **IPython 3**, data files lived in ``~/.ipython``."
+msgstr ""
+
+# db9667c61df04f03b389007dde80592b
+#: ../../source/migrating.rst:93
+msgid "In **Jupyter**, data files use platform-appropriate locations:"
+msgstr ""
+
+# 6ec16f9359924bcaad831b990915ac81
+#: ../../source/migrating.rst:95
+msgid "OS X: ``~/Library/Jupyter``"
+msgstr ""
+
+# 06b69be6aab34415a18b114a688ef046
+#: ../../source/migrating.rst:96
+msgid "Windows: the location specified in ``%APPDATA%`` environment variable"
+msgstr ""
+
+# b8aa64d12c084a09a9caf7f0997b9694
+#: ../../source/migrating.rst:97
+msgid ""
+"Elsewhere, ``$XDG_DATA_HOME`` is respected, with the default of "
+"``~/.local/share/jupyter``"
+msgstr ""
+
+# bcf6cf06fa7849d5adb27a36bb68475a
+#: ../../source/migrating.rst:100
+msgid ""
+"In all cases, the ``JUPYTER_DATA_DIR`` environment variable can be used "
+"to set a location explicitly."
+msgstr ""
+
+# 5ff8200b58f0422aab90ae5013d1bc60
+#: ../../source/migrating.rst:103
+msgid ""
+"Data files installed system-wide (e.g. in ``/usr/local/share/jupyter``) "
+"have not changed. Per-user installation of data files has changed "
+"location from ``.ipython`` to the platform-appropriate Jupyter location."
+msgstr ""
+
+# 8fc50bfd17e74c08aaee715d4df0aa28
+#: ../../source/migrating.rst:108
+msgid "Since Jupyter does not have profiles, how do I customize it?"
+msgstr ""
+
+# f21e1f21ab634dfeae67d57a810af7e8
+#: ../../source/migrating.rst:110
+msgid ""
+"While IPython has the concept of :term:`profiles`, **Jupyter does not "
+"have profiles**."
+msgstr ""
+
+# fbab5d83e70641b58ba8d8c25a1b5505
+#: ../../source/migrating.rst:113
+msgid ""
+"In IPython, profiles are collections of configuration and runtime files. "
+"Inside the IPython directory (``~/.ipython``), there are directories with"
+" names like ``profile_default`` or ``profile_demo``. In each of these are"
+" configuration files (``ipython_config.py``, "
+"``ipython_notebook_config.py``) and runtime files (``history.sqlite``, "
+"``security/kernel-*.json``). Profiles could be used to switch between "
+"configurations of IPython."
+msgstr ""
+
+# df3baa2e23de4665a1ba0a95d9bd1d53
+#: ../../source/migrating.rst:120
+msgid ""
+"Previously, people could use commands like ``ipython notebook --profile "
+"demo`` to set the profile for *both* the notebook server and the IPython "
+"kernel. This is no longer possible in one go with Jupyter, just like it "
+"wasn't possible in IPython 3 for any other kernels."
+msgstr ""
+
+# 900e8e17d08548eabeaa79549d4aa98b
+#: ../../source/migrating.rst:126
+msgid "Changing the Jupyter notebook configuration directory"
+msgstr ""
+
+# 6e7aba03567842fdb5bcd279d8cf35dd
+#: ../../source/migrating.rst:128
+msgid ""
+"If you want to change the notebook configuration, you can set the "
+"``JUPYTER_CONFIG_DIR``:"
+msgstr ""
+
+# b29b24c9af764ad4a280ddc011a49965
+#: ../../source/migrating.rst:137
+msgid "Changing the Jupyter notebook configuration file"
+msgstr ""
+
+# a7614ee085ba47d488cafe7699656792
+#: ../../source/migrating.rst:139
+msgid "If you just want to change the config file, you can do:"
+msgstr ""
+
+# a6aac6dd2d4943659e18520f5d392cf9
+#: ../../source/migrating.rst:146
+msgid "Changing IPython's profile using custom kernelspecs"
+msgstr ""
+
+# 9563bde765c14e3690a51f73d7c92cf7
+#: ../../source/migrating.rst:148
+msgid ""
+"If you do want to change the IPython kernel's profile, you can't do this "
+"at the server command-line anymore. Kernel arguments must be changed by "
+"modifying the kernelspec. You can do this without relaunching the server."
+" Kernelspec changes take effect every time you start a new kernel. "
+"However, there isn't a great way to modify the kernelspecs. One approach "
+"uses ``jupyter kernelspec list`` to find the ``kernel.json`` file and "
+"then modifies it, e.g. ``kernels/python3/kernel.json``, by hand. "
+"Alternatively, `a2km <https://github.com/minrk/a2km>`__ is an "
+"experimental project that tries to make these things easier."
+msgstr ""
+
+# 45d3b19664bd49fea20a62ec0e77c3ad
+#: ../../source/migrating.rst:158
+msgid ""
+"For example, add the ``--profile`` option to a custom kernelspec under "
+"``kernels/mycustom/kernel.json`` (see the Jupyter kernelspec directions "
+"`here <https://jupyter-client.readthedocs.io/en/latest/kernels.html"
+"#kernel-specs>`__):"
+msgstr ""
+
+# 2a98d819b7e04e5bbfc60ef439b635e2
+#: ../../source/migrating.rst:172
+msgid ""
+"You can then run Jupyter with the ``--kernel=mycustom`` command-line "
+"option and IPython will find the appropriate profile."
+msgstr ""
+
+# df14211cf90e4c57a5fa18626c872c72
+#: ../../source/migrating.rst:176
+msgid "Understanding Installation Changes"
+msgstr ""
+
+# b8d826a3ba3345abbedf16171c095d5c
+#: ../../source/migrating.rst:178
+msgid ""
+"See the :ref:`install` page for more information about installing "
+"Jupyter. Jupyter automatically migrates some things, like Notebook "
+"extensions and kernels."
+msgstr ""
+
+# fa33a2f4f8f94829a7c473d7071b0f43
+#: ../../source/migrating.rst:183
+msgid "Notebook extensions"
+msgstr ""
+
+# 51d5f0d804f442a9a97c7655e580e79b
+#: ../../source/migrating.rst:185
+msgid ""
+"Any IPython notebook extensions should be **automatically migrated** as "
+"part of the data files migration."
+msgstr ""
+
+# 5fd92d1027fb4b85ae426a42c82fe947
+#: ../../source/migrating.rst:188
+msgid "Notebook extensions were installed with:"
+msgstr ""
+
+# 91ab0eeefe084c70a44650fbd51644b7
+#: ../../source/migrating.rst:194
+msgid "Now, extensions are installed with:"
+msgstr ""
+
+# 5b197ef97efc43b5bbd741f814a6ee64
+#: ../../source/migrating.rst:200
+msgid ""
+"The notebook extensions will be installed in a system-wide location (e.g."
+" ``/usr/local/share/jupyter/nbextensions``). If doing a ``--user`` "
+"install, the notebook extensions will go in the ``JUPYTER_DATA_DIR`` "
+"location. Installation **SHOULD NOT** be done manually by guessing where "
+"the files should go."
+msgstr ""
+
+# 8f205aaaf5ee46de8e9d0522c240dc83
+#: ../../source/migrating.rst:207
+msgid "Kernels"
+msgstr ""
+
+# 6835584aca814c54909e4f5519afbf77
+#: ../../source/migrating.rst:209
+msgid ""
+"Kernels are installed in much the same way as notebook extensions. They "
+"will also be **automatically migrated**."
+msgstr ""
+
+# 221543b8255b44c6a970364430b396b9
+#: ../../source/migrating.rst:212
+msgid "Kernel specs used to be installed with:"
+msgstr ""
+
+# 7c691c23e0594313a3eade3815aa8c3f
+#: ../../source/migrating.rst:218
+msgid "They are now installed with:"
+msgstr ""
+
+# 7300ff40baec4daa85964d98a508f28c
+#: ../../source/migrating.rst:224
+msgid ""
+"By default, kernel specs will go in a system-wide location (e.g. "
+"``/usr/local/share/jupyter/kernels``). If doing a ``--user`` install, the"
+" kernel specs will go in the ``JUPYTER_DATA_DIR`` location. Installation "
+"**SHOULD NOT** be done manually by guessing where the files should go."
+msgstr ""
+
+# 7347a7230ab645599d5be543b3b019d0
+#: ../../source/migrating.rst:230
+msgid "Understanding Changes in imports"
+msgstr ""
+
+# e84b04296df74f698d561ee40d3355cc
+#: ../../source/migrating.rst:232
+msgid ""
+"IPython 4.0 includes shims to manage dependencies; so, all imports that "
+"work on IPython 3 should continue to work on IPython 4. If you find any "
+"differences, please `let us know "
+"<https://github.com/ipython/ipython/issues>`__."
+msgstr ""
+
+# 56813b80163249d3b2a3e603b904015d
+#: ../../source/migrating.rst:236
+msgid "Some changes include:"
+msgstr ""
+
+# 4f027d18d7bd44c7a354068d322e7b32
+#: ../../source/migrating.rst:239
+msgid "IPython 3"
+msgstr ""
+
+# 126977d37c5a49c09790822aabadb9fe
+#: ../../source/migrating.rst:239
+msgid "Jupyter and IPython 4.0"
+msgstr ""
+
+# 4243295b32bd48229e2f24ac3feb22c2
+#: ../../source/migrating.rst:241
+msgid "``IPython.html``"
+msgstr ""
+
+# 07dcd5f404274ab0b1593a89a10eda12
+#: ../../source/migrating.rst:241
+msgid "``notebook``"
+msgstr ""
+
+# eb1f964c367445f19d1aebc8b52fa46a
+#: ../../source/migrating.rst:242
+msgid "``IPython.html.widgets``"
+msgstr ""
+
+# 75653597f60c4e2facecc6342d4ee141
+#: ../../source/migrating.rst:242
+msgid "``ipywidgets``"
+msgstr ""
+
+# 2e80aada7b9b4fbfbd8bc21f683b5a33
+#: ../../source/migrating.rst:243
+msgid "``IPython.kernel``"
+msgstr ""
+
+# ee6c0d3100a0430887bc2ec59c836066
+#: ../../source/migrating.rst:243
+msgid "``jupyter_client``, ``ipykernel``"
+msgstr ""
+
+# 6ef0dd165dd9439b869e08965c69222a
+#: ../../source/migrating.rst:244
+msgid "``IPython.parallel``"
+msgstr ""
+
+# 282f79d57dc84378a575ad9037ceda9f
+#: ../../source/migrating.rst:244
+msgid "``ipyparallel``"
+msgstr ""
+
+# 0d2d805e0ebc4d1ca6e714416e5ba544
+#: ../../source/migrating.rst:245
+msgid "``IPython.qt.console``"
+msgstr ""
+
+# 3d9ae3c27ca949228f137c7099ff4dac
+#: ../../source/migrating.rst:245
+msgid "``qtconsole``"
+msgstr ""
+
+# d7fbddb811bc4e4ba54deb111b3f0a87
+#: ../../source/migrating.rst:246
+msgid "``IPython.utils.traitlets``"
+msgstr ""
+
+# e051da2ba487485eb14be36b1cbc0c02
+#: ../../source/migrating.rst:246
+msgid "``traitlets``"
+msgstr ""
+
+# 417499484a6241a5ba01fa609cf782f2
+#: ../../source/migrating.rst:247
+msgid "``IPython.config``"
+msgstr ""
+
+# 5686f8ec952f403bb20dad55c84bd2e7
+#: ../../source/migrating.rst:247
+msgid "``traitlets.config``"
+msgstr ""
+
+# 1069489e11e54f5683906ef69dd939f4
+#: ../../source/migrating.rst:252
+msgid "The ``IPython.kernel`` Split"
+msgstr ""
+
+# b3e32d27b5ec43d8b46b37ab774c3713
+#: ../../source/migrating.rst:254
+msgid "``IPython.kernel`` became two packages:"
+msgstr ""
+
+# 37e65f7a48a049849c032d103355c88c
+#: ../../source/migrating.rst:256
+msgid "``jupyter_client`` for the Jupyter client-side APIs."
+msgstr ""
+
+# daef865437274272bfbf0f835bab4a68
+#: ../../source/migrating.rst:257
+msgid "``ipykernel`` for Jupyter's IPython kernel"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/projects.po
+++ b/docs/source/locale/es/LC_MESSAGES/projects.po
@@ -1,0 +1,1285 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 92339a9a41b542e298b60cdb6f6cbf61
+#: ../../source/projects/config.rst:4
+msgid "Jupyter's Common Configuration Approach"
+msgstr ""
+
+# 90da53f4dfa74557a08b864016016453
+# e79e0aed79164105ba0c59db1e7cc25f
+# f3a563b080c148449967e4dfb0c0c397
+# 4670de024ca342e0ae42d85db75b0b47
+# d8a293acd5814a1d8797cdf904961a54
+# bb604039b6df48aeb10f4bfd47611399
+# 79fb4da0ecf7403f8bdf26c7e5200dea
+#: ../../source/projects/config.rst:7
+#: ../../source/projects/doc-proj-categories.rst:6
+#: ../../source/projects/incubator.rst:5
+#: ../../source/projects/ipython_projects.rst:5
+#: ../../source/projects/jupyter-directories.rst:7
+#: ../../source/projects/subprojects.rst:8
+#: ../../source/projects/upgrade-notebook.rst:5
+msgid "Contents"
+msgstr ""
+
+# 50ef143cd1864073a32ebb2bebdb1498
+# 4e98dda3ce1c4ddb8e35780e8e7651a6
+#: ../../source/projects/config.rst:10
+#: ../../source/projects/jupyter-directories.rst:100
+msgid "Summary"
+msgstr ""
+
+# 67c9b078874340d2a7434509d80b1dcb
+#: ../../source/projects/config.rst:12
+msgid ""
+"**Common Jupyter configuration system** The Jupyter applications have a "
+"common config system, and a common :ref:`config directory <config_dir>`. "
+"By default, this directory is :file:`~/.jupyter`."
+msgstr ""
+
+# 631c35d8d9ea49129b1a252a853e4683
+#: ../../source/projects/config.rst:17
+msgid ""
+"**Kernel configuration directories** If kernels use config files, these "
+"will normally be organised in separate directories for each kernel. For "
+"instance, the IPython kernel looks for files in the :ref:`IPython "
+"directory <ipythondir>` instead of the default Jupyter directory "
+":file:`~/.jupyter`."
+msgstr ""
+
+# c275e83d19c14b30a5fed2db4d317a77
+#: ../../source/projects/config.rst:24
+msgid "The Python config file"
+msgstr ""
+
+# 883c3694cddb4a79b753d056967b392f
+#: ../../source/projects/config.rst:26
+msgid "To create a default config file, run:"
+msgstr ""
+
+# 249e9606296f42fd9d3d746ce2e2e818
+#: ../../source/projects/config.rst:32
+msgid "The generated file will be named :file:`jupyter_{application}_config.py`."
+msgstr ""
+
+# 5885d077ef0c4a399da2fd455a465fca
+#: ../../source/projects/config.rst:34
+msgid ""
+"By editing the :file:`jupyter_{application}_config.py` file, you can "
+"configure class attributes like this::"
+msgstr ""
+
+# 5b49864fb34346d38f53ab5c5cc396dc
+#: ../../source/projects/config.rst:39
+msgid ""
+"Be careful with spelling. Incorrect names will simply be ignored, with no"
+" error message."
+msgstr ""
+
+# ab038bbb09b648e59a1f74f6d2a58d7a
+#: ../../source/projects/config.rst:42
+msgid ""
+"To add to a collection which may have already been defined elsewhere, you"
+" can use methods like those found on lists, dicts and sets: ``append``, "
+"``extend``, :meth:`~traitlets.config.LazyConfigValue.prepend` (like "
+"extend, but at the front), ``add``, and ``update`` (which works both for "
+"dicts and sets)::"
+msgstr ""
+
+# ee2b6c90ccd04fe4b948fcc54a29816f
+#: ../../source/projects/config.rst:52
+msgid "Command line options for configuration"
+msgstr ""
+
+# e9fa04aaf42e49cbb4d8262ce23da43d
+#: ../../source/projects/config.rst:54
+msgid ""
+"Every configurable value can also be set from the command line and passed"
+" as an argument, using this syntax:"
+msgstr ""
+
+# 4ab9825a5d064abb8181c8eecc58c8aa
+#: ../../source/projects/config.rst:61
+msgid ""
+"Frequently used options will also have short aliases and flags, such as "
+"``--port 8754`` or ``--no-browser``."
+msgstr ""
+
+# b4439d388ac44302a41c3f75677822ef
+#: ../../source/projects/config.rst:64
+msgid ""
+"To see the abbreviated options, pass ``--help`` or ``--help-all`` as "
+"follows:"
+msgstr ""
+
+# 2029a2c8cf304fc1a83b1903b362fe7e
+#: ../../source/projects/config.rst:72
+msgid ""
+"Command line options **will override** options set within a configuration"
+" file."
+msgstr ""
+
+# 36415b5e588946969565a4a22179fb99
+#: ../../source/projects/config.rst:77
+msgid ":mod:`traitlets:traitlets.config`"
+msgstr ""
+
+# ae0cd4a04e9e4835a145e80ea304ec17
+#: ../../source/projects/config.rst:78
+msgid "The low-level architecture of this config system."
+msgstr ""
+
+# 97d7c73abdeb4f0389a7e650d037fc10
+#: ../../source/projects/content-projects.rst:4
+msgid "Installation, Configuration, and Usage"
+msgstr ""
+
+# b3daae6ac8b8407d9311cebd6b0cd982
+#: ../../source/projects/content-projects.rst:7
+msgid "Installation"
+msgstr ""
+
+# 25e5f9f40ad84a3183e46a0701c5d083
+#: ../../source/projects/content-projects.rst:17
+msgid "How do I decide which packages I need?"
+msgstr ""
+
+# c96ce8e348c543bfbb7beb3622bd7d3b
+#: ../../source/projects/content-projects.rst:136
+msgid "Configuration"
+msgstr ""
+
+# 54d90121c5e24975be1c0cb3350e3a0b
+#: ../../source/projects/content-projects.rst:146
+msgid "Usage and Projects"
+msgstr ""
+
+# 878b87f3b5334557964db57fe6ecfc00
+#: ../../source/projects/doc-proj-categories.rst:3
+msgid "Project Documentation"
+msgstr ""
+
+# da1412ca76794532b4409e1da1d6a9c6
+#: ../../source/projects/doc-proj-categories.rst:8
+msgid ""
+"Links to **information on usage, configuration and development** hosted "
+"on Read The Docs or in the GitHub project repo."
+msgstr ""
+
+# 05e0c934a6004550a2bbc836a9f8241e
+# fc0cfc8377c448dd87f57ad3d7faf590
+#: ../../source/projects/doc-proj-categories.rst:12
+#: ../../source/projects/subprojects.rst:14
+msgid "Jupyter User Interfaces"
+msgstr ""
+
+# 67a117c7d3874a8b9183c9c321d6a4a0
+#: ../../source/projects/doc-proj-categories.rst:13
+msgid "`Jupyter Notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# f0f7ba9f5be24319a67f3822fdca4e63
+#: ../../source/projects/doc-proj-categories.rst:14
+msgid "`jupyter_console <http://jupyter-console.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# d11bac142e77476e8ed00dbc47d8cca4
+#: ../../source/projects/doc-proj-categories.rst:15
+msgid "`qtconsole <https://qtconsole.readthedocs.io/en/stable/>`_"
+msgstr ""
+
+# 2c1b9d78c1164045b7e3ee67011405cb
+#: ../../source/projects/doc-proj-categories.rst:18
+msgid "JupyterHub"
+msgstr ""
+
+# fed298a75504421993d6e9e5bc630551
+#: ../../source/projects/doc-proj-categories.rst:19
+msgid "`JupyterHub <http://jupyterhub.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 7572a9cc7da44692b9f3bc4386564364
+#: ../../source/projects/doc-proj-categories.rst:20
+msgid ""
+"`configurable-http-proxy <https://github.com/jupyterhub/configurable-"
+"http-proxy>`_"
+msgstr ""
+
+# 5c5566158224426295e9e97bb73ecc46
+#: ../../source/projects/doc-proj-categories.rst:21
+msgid "`dockerspawner <https://github.com/jupyterhub/dockerspawner>`_"
+msgstr ""
+
+# bb55cce340ef4ea4892839cbd8337e8f
+#: ../../source/projects/doc-proj-categories.rst:22
+msgid "`ldapauthenticator <https://github.com/jupyterhub/ldapauthenticator>`_"
+msgstr ""
+
+# f7d54f483595450fa4b37781fd887452
+#: ../../source/projects/doc-proj-categories.rst:23
+msgid "`oauthenticator <https://github.com/jupyterhub/oauthenticator>`_"
+msgstr ""
+
+# dc23452377da44edbe127d34cd305a19
+#: ../../source/projects/doc-proj-categories.rst:24
+msgid "`sudospawner <https://github.com/jupyterhub/sudospawner>`_"
+msgstr ""
+
+# fec520fc2c8a4b7aa8f54bda8447e976
+# e31418dae87748369b4fa4826b428dfc
+#: ../../source/projects/doc-proj-categories.rst:27
+#: ../../source/projects/subprojects.rst:91
+msgid "Education"
+msgstr ""
+
+# e8ecf2b2e0e240438b897616cb0d1cec
+#: ../../source/projects/doc-proj-categories.rst:28
+msgid "`nbgrader <http://nbgrader.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# bcf3e08d367944c39c38201049663273
+#: ../../source/projects/doc-proj-categories.rst:31
+msgid "Notebook Conversion and Formatting"
+msgstr ""
+
+# 6f5a84f0d0b64958a31aeb68b9bd9d43
+#: ../../source/projects/doc-proj-categories.rst:32
+msgid "`nbconvert <http://nbconvert.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 87e7cf3391ae49e2b5719e4f2843a9bc
+#: ../../source/projects/doc-proj-categories.rst:33
+msgid "`nbformat <http://nbformat.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 1642454b670a4f23b884da1cf8b42095
+# 838d9a305b6d4cf29191f3b95bd29e52
+#: ../../source/projects/doc-proj-categories.rst:36
+#: ../../source/projects/subprojects.rst:39
+msgid "Kernels"
+msgstr ""
+
+# 12d4b4b3066048b68cc4ff247e2beb3c
+#: ../../source/projects/doc-proj-categories.rst:37
+msgid "`IPython <https://ipython.readthedocs.io/en/stable/>`_"
+msgstr ""
+
+# 0939ba530c894801ae11b4e65e2530f2
+#: ../../source/projects/doc-proj-categories.rst:38
+msgid "`IRkernel <https://irkernel.github.io/>`_"
+msgstr ""
+
+# 10e09d0397ef4458890c8ed800194814
+#: ../../source/projects/doc-proj-categories.rst:39
+msgid "`IJulia <https://github.com/JuliaLang/IJulia.jl>`_"
+msgstr ""
+
+# e7d05d24d92f4db3a46dd43f6b247ad6
+#: ../../source/projects/doc-proj-categories.rst:40
+msgid ""
+"`List of community maintained language kernels "
+"<https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-"
+"languages>`_"
+msgstr ""
+
+# 831ada76059b4ebea4e80a139b91ef06
+#: ../../source/projects/doc-proj-categories.rst:43
+msgid "IPython"
+msgstr ""
+
+# 38ae294a26394b5d97233f08b0fe9b0d
+#: ../../source/projects/doc-proj-categories.rst:44
+msgid "`IPython`_"
+msgstr ""
+
+# 8c06cd6a311e440a8b4b90313e599a5d
+#: ../../source/projects/doc-proj-categories.rst:45
+msgid "`ipykernel <https://ipython.readthedocs.io/en/stable/>`_"
+msgstr ""
+
+# b890abfa9d4c4040a128bf67fdaa6139
+#: ../../source/projects/doc-proj-categories.rst:46
+msgid "`ipyparallel <https://ipyparallel.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 1f0fbbbf059d4c7182c15c9c48dd5450
+# aafbcd62f5d4479f9501ef2df6a138f0
+#: ../../source/projects/doc-proj-categories.rst:49
+#: ../../source/projects/subprojects.rst:106
+msgid "Deployment"
+msgstr ""
+
+# 3e5210e31d784c19acf03439c303ab54
+#: ../../source/projects/doc-proj-categories.rst:50
+msgid "`docker-stacks <https://github.com/jupyter/docker-stacks>`_"
+msgstr ""
+
+# 4ee088e2656c4478ae6af2f710282744
+#: ../../source/projects/doc-proj-categories.rst:51
+msgid "`ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 6ce5c42884a14600bb1271b40d06d02b
+#: ../../source/projects/doc-proj-categories.rst:52
+msgid "`jupyter-drive <https://github.com/jupyter/jupyter-drive>`_"
+msgstr ""
+
+# 97e013d4dc7e44dc88d18c6151f7f7e7
+#: ../../source/projects/doc-proj-categories.rst:53
+msgid "`jupyter-sphinx-theme <https://github.com/jupyter/jupyter-sphinx-theme>`_"
+msgstr ""
+
+# 2844f35d88594b1cbcdd4fabba433e14
+#: ../../source/projects/doc-proj-categories.rst:54
+msgid ""
+"`kernel_gateway <http://jupyter-kernel-"
+"gateway.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# 6b76351692c6479493985193869e2a03
+#: ../../source/projects/doc-proj-categories.rst:55
+msgid "`nbviewer <https://github.com/jupyter/nbviewer>`_"
+msgstr ""
+
+# 66405b5e2ad54aa39e2dd7f77874a08c
+#: ../../source/projects/doc-proj-categories.rst:56
+msgid "`tmpnb <https://github.com/jupyter/tmpnb>`_"
+msgstr ""
+
+# 0a3317a3f98a4a428c7af8adb2d282be
+#: ../../source/projects/doc-proj-categories.rst:57
+msgid "`traitlets <http://traitlets.readthedocs.io/en/stable/>`_"
+msgstr ""
+
+# 469c33adacf44e77be8479c50a3afde7
+#: ../../source/projects/doc-proj-categories.rst:60
+msgid "JupyterLab"
+msgstr ""
+
+# e73d09d0ce1245c88186f99fb6d07143
+#: ../../source/projects/doc-proj-categories.rst:61
+msgid "`jupyter-js-notebook <https://github.com/jupyter/jupyter-js-notebook>`_"
+msgstr ""
+
+# 312f96ae98194c598857978bec70d4e1
+#: ../../source/projects/doc-proj-categories.rst:62
+msgid "`jupyter-js-phosphide <https://github.com/jupyter/jupyter-js-phosphide>`_"
+msgstr ""
+
+# 3f8abf0c8fa54d01ba938fe0cfa6ae3f
+#: ../../source/projects/doc-proj-categories.rst:63
+msgid "`jupyter-js-plugins <https://github.com/jupyter/jupyter-js-plugins>`_"
+msgstr ""
+
+# f563f0f8921b40c9a56aa72a62a7ae08
+#: ../../source/projects/doc-proj-categories.rst:64
+msgid "`jupyter-js-services <http://jupyter.org/jupyter-js-services/>`_"
+msgstr ""
+
+# 932e4e56da8149dc9b19c939d0ce6291
+#: ../../source/projects/doc-proj-categories.rst:65
+msgid "`jupyter-js-ui <http://jupyter.org/jupyter-js-ui/>`_"
+msgstr ""
+
+# 5d5e4940d3624873a4b2c39ce7d4ea00
+#: ../../source/projects/doc-proj-categories.rst:66
+msgid "`jupyter-js-utils <http://jupyter.org/jupyter-js-utils/>`_"
+msgstr ""
+
+# edd42737bc98463498d711d9d916c157
+# 73d33f0f3c864e74b012a215450194c5
+#: ../../source/projects/doc-proj-categories.rst:69
+#: ../../source/projects/subprojects.rst:151
+msgid "Architecture"
+msgstr ""
+
+# 94f4104fc2a346e9b752026e94ccb9b8
+#: ../../source/projects/doc-proj-categories.rst:70
+msgid "`jupyter_client <http://jupyter-client.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# a7c0c77907204a10aa56b382435e60e7
+#: ../../source/projects/doc-proj-categories.rst:71
+msgid "`jupyter_core <http://jupyter-core.readthedocs.io/en/latest/>`_"
+msgstr ""
+
+# cba6565dfef44292847ee4619fb67cdd
+#: ../../source/projects/incubator.rst:2
+msgid "Incubator Projects"
+msgstr ""
+
+# 28287c3575fc4697829583939cfd9ef0
+#: ../../source/projects/incubator.rst:7
+msgid ""
+"The `Jupyter incubator <https://github.com/jupyter-incubator>`_ gives "
+"emerging projects a place to evolve."
+msgstr ""
+
+# b6fadf1a90d64f40bc531afda9e7f181
+#: ../../source/projects/incubator.rst:11
+msgid "Descriptions"
+msgstr ""
+
+# 75694883742b41c7b1dbf76b66fab082
+#: ../../source/projects/incubator.rst:13
+msgid "Interesting projects include:"
+msgstr ""
+
+# edf5c1a57381452f81241ced74bfd684
+#: ../../source/projects/incubator.rst:15
+msgid ""
+"`content management extensions <https://github.com/jupyter-"
+"incubator/contentmanagement>`_ - Jupyter Content Management Extensions"
+msgstr ""
+
+# 60cda82020be42c08afd057695bea4a4
+#: ../../source/projects/incubator.rst:16
+msgid ""
+"`dashboards <https://github.com/jupyter-incubator/dashboards>`_ - Jupyter"
+" Dynamic Dashboards from Notebooks"
+msgstr ""
+
+# 254de647304647ab8073b020d1cc3b01
+#: ../../source/projects/incubator.rst:17
+msgid ""
+"`declarative widgets <https://github.com/jupyter-"
+"incubator/declarativewidgets>`_ - Jupyter Declarative Widgets Extension"
+msgstr ""
+
+# 43b5a7a788f74c0fa8d7532dcec2a001
+#: ../../source/projects/incubator.rst:18
+msgid ""
+"`kernel gateway bundlers <https://github.com/jupyter-"
+"incubator/kernel_gateway_bundlers>`_ - Converts a notebook to a kernel "
+"gateway microservice bundle for download"
+msgstr ""
+
+# a70e8c643c034c8f95ecc7d52c3b76eb
+#: ../../source/projects/incubator.rst:19
+msgid ""
+"`showcase`_ - A spot to try demos of one or more incubating Jupyter "
+"projects in `Binder <http://mybinder.org/>`_"
+msgstr ""
+
+# d70eebc552ab4bd197ee7bbd9def1a9b
+#: ../../source/projects/incubator.rst:20
+msgid ""
+"`sparkmagic <https://github.com/jupyter-incubator/sparkmagic>`_ - Jupyter"
+" magics and kernels for working with remote Spark clusters"
+msgstr ""
+
+# 99fd5864d2694a498188465e90d5e366
+#: ../../source/projects/incubator.rst:21
+msgid ""
+"`traittypes <https://github.com/jupyter-incubator/traittypes>`_ - "
+"Traitlets types for NumPy, SciPy and friends"
+msgstr ""
+
+# 39368898693b438885f9f91f59f62a9f
+#: ../../source/projects/incubator.rst:23
+msgid ""
+"There's also a `repository with proposals <https://github.com/jupyter-"
+"incubator/proposals>`_ of projects wishing to enter the incubator."
+msgstr ""
+
+# 71076519b1d94f87afd451f597df50a4
+#: ../../source/projects/incubator.rst:27
+msgid "Try the Incubator Projects"
+msgstr ""
+
+# a90ed853561445ad937d3baab7ed807a
+#: ../../source/projects/incubator.rst:29
+msgid ""
+"The `showcase`_ application allows you to try demos of one or more "
+"incubating Jupyter projects in `Binder <http://mybinder.org/>`_. Just "
+"head over to the `showcase`_ repo and press the :guilabel:`Launch Binder`"
+" button badge to launch the online trial. You should see an interactive "
+"notebook similar to this one:"
+msgstr ""
+
+# d70338c3f7bf458daf73b7925ba29e35
+#: ../../source/projects/ipython_projects.rst:2
+msgid "IPython Projects"
+msgstr ""
+
+# 7f631307348a402f9ab66eba132737cb
+# 40bf2641321f415f931e61d4e62e90cb
+#: ../../source/projects/ipython_projects.rst:8
+#: ../../source/projects/jupyter-command.rst:16
+msgid "Description"
+msgstr ""
+
+# 543da61e80f44ef1b1e3d57d909161c4
+#: ../../source/projects/ipython_projects.rst:10
+msgid ""
+"`IPython <https://ipython.org>`_ provides a rich architecture for "
+"interactive computing with:"
+msgstr ""
+
+# 8e4ff36b60e9432594471c8fee1d7163
+#: ../../source/projects/ipython_projects.rst:13
+msgid "A powerful interactive shell."
+msgstr ""
+
+# d432b9c2e4c64adfb2f6100665eb0f9c
+#: ../../source/projects/ipython_projects.rst:14
+msgid "A kernel for Jupyter."
+msgstr ""
+
+# b0e52b8513b0457eb61bda3e14f785ec
+#: ../../source/projects/ipython_projects.rst:15
+msgid "Support for interactive data visualization and use of GUI toolkits."
+msgstr ""
+
+# aaaead17f2ca44c896c99ed5e1192dee
+#: ../../source/projects/ipython_projects.rst:16
+msgid "Flexible, embeddable interpreters to load into your own projects."
+msgstr ""
+
+# ea29a6d9e0734512a00cfa5ad436bec1
+#: ../../source/projects/ipython_projects.rst:17
+msgid "Easy to use, high performance tools for parallel computing."
+msgstr ""
+
+# 2cc5f1f88b0c4d8cb1a1613e4282356c
+#: ../../source/projects/ipython_projects.rst:20
+msgid "Background"
+msgstr ""
+
+# 3fe872113f4c4e15b82282d04efface1
+#: ../../source/projects/ipython_projects.rst:22
+msgid ""
+"IPython is a growing project, with increasingly language-agnostic "
+"components. IPython 3.x was the last monolithic release of IPython, "
+"containing the notebook server, qtconsole, etc. As of IPython 4.0, the "
+"language-agnostic parts of the project: the notebook format, message "
+"protocol, qtconsole, notebook web application, etc. have moved to new "
+"projects under the name Jupyter. IPython itself is focused on interactive"
+" Python, part of which is providing a Python kernel for Jupyter."
+msgstr ""
+
+# b42a67733d444e32973954185f0f70cb
+#: ../../source/projects/ipython_projects.rst:31
+msgid "Resources"
+msgstr ""
+
+# 3e453e9551974bec9e26dd108e807789
+#: ../../source/projects/ipython_projects.rst:33
+msgid "The projects with repos in the IPython organization on GitHub include:"
+msgstr ""
+
+# 5031645557cd44ecb80e167383ac147f
+#: ../../source/projects/ipython_projects.rst:35
+msgid ""
+"IPython `ipykernel <https://ipython.readthedocs.io/en/stable/>`_ "
+"interactive computing in Python."
+msgstr ""
+
+# fcd79ae7b74b40ccbf3aaf50a7ace569
+#: ../../source/projects/ipython_projects.rst:37
+msgid ""
+"`ipyparallel <https://ipyparallel.readthedocs.io/en/latest/>`_ "
+"lightweight parallel computing in Python offering seamless notebook "
+"integration"
+msgstr ""
+
+# 69568ee92daf451489775caebb747947
+#: ../../source/projects/ipython_projects.rst:39
+msgid ""
+"`ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`_ interactive "
+"widgets for Python in the Jupyter Notebook"
+msgstr ""
+
+# 5873cdc3af584936a50d5b8af40991b8
+#: ../../source/projects/jupyter-command.rst:4
+msgid "The :command:`jupyter` Command"
+msgstr ""
+
+# dc3c602ec8854657a96f6c09c3dd9f45
+#: ../../source/projects/jupyter-command.rst:9
+msgid "Synopsis"
+msgstr ""
+
+# 5d111077ba074d05aa380c53ba1077ea
+#: ../../source/projects/jupyter-command.rst:18
+msgid ""
+"Commands like ``jupyter notebook`` start Jupyter applications. The "
+"``jupyter`` command is primarily a namespace for subcommands. A command "
+"like ``jupyter-foo`` found on your :envvar:`PATH` will be available as a "
+"subcommand ``jupyter foo``."
+msgstr ""
+
+# 0e8211d5b2854743b58424aefd143a97
+#: ../../source/projects/jupyter-command.rst:23
+msgid ""
+"The :command:`jupyter` command can also be used to do actions other than "
+"starting a Jupyter application."
+msgstr ""
+
+# a546e6c4a3b24260a822ed09c7693c0b
+#: ../../source/projects/jupyter-command.rst:27
+msgid "Command options"
+msgstr ""
+
+# d3d42ef830c540d385919f7ed738f6a4
+#: ../../source/projects/jupyter-command.rst:31
+msgid "Show help information, including available subcommands."
+msgstr ""
+
+# 2ee91915ba0a4908852438e641def692
+#: ../../source/projects/jupyter-command.rst:35
+msgid "Show the location of the config directory."
+msgstr ""
+
+# 997e64311bf24e22a8e4e0a0a9b89dbd
+# 22ee798fcab64510b6f0c41b0df73590
+#: ../../source/projects/jupyter-command.rst:39
+#: ../../source/projects/jupyter-command.rst:43
+msgid "Show the location of the data directory."
+msgstr ""
+
+# e5c4ae5c93e746cda9ba4d8983622523
+#: ../../source/projects/jupyter-command.rst:47
+msgid "Show all Jupyter directories and search paths."
+msgstr ""
+
+# 4d02755d025148c1a043839fec6f39ac
+#: ../../source/projects/jupyter-command.rst:51
+msgid "Print directories and search paths in machine-readable JSON format."
+msgstr ""
+
+# ccb6b7bfee9d4fad9e1e4da9ab283003
+#: ../../source/projects/jupyter-directories.rst:4
+msgid "Common Directories and File Locations"
+msgstr ""
+
+# 0b4e49809d05429a85146eae83d1b3a5
+#: ../../source/projects/jupyter-directories.rst:9
+msgid ""
+"Jupyter stores different files (i.e. configuration, data, runtime) in a "
+"number of different locations. Environment variables may be set to "
+"customize for the location of each file type."
+msgstr ""
+
+# bee4d55638044b5ca68875379f764a1c
+#: ../../source/projects/jupyter-directories.rst:16
+msgid "Configuration files"
+msgstr ""
+
+# a2bb292bb5b44bc6ac0a00926eb1a21c
+#: ../../source/projects/jupyter-directories.rst:18
+msgid "Config files are stored by default in the :file:`~/.jupyter` directory."
+msgstr ""
+
+# e41adbe74f6d474e9cc3eb26c516ce89
+#: ../../source/projects/jupyter-directories.rst:22
+msgid ""
+"Set this environment variable to use a particular directory, other than "
+"the default, for Jupyter config files."
+msgstr ""
+
+# e12398b48b1340d6bbaf749a104ae9e7
+#: ../../source/projects/jupyter-directories.rst:25
+msgid ""
+"Besides the user config directory mentioned above, Jupyter has a search "
+"path of additional locations from which a config file will be loaded. "
+"Here's a table of the locations to be searched, in order of preference:"
+msgstr ""
+
+# 279e6f91f5d44886a35a4c1357897789
+#: ../../source/projects/jupyter-directories.rst:30
+msgid "Unix"
+msgstr ""
+
+# 6fd5c493414044c59661c483a397b901
+# 7ac748a5da594a0e8795dc4d126d5ff6
+#: ../../source/projects/jupyter-directories.rst:30
+#: ../../source/projects/jupyter-directories.rst:67
+msgid "Windows"
+msgstr ""
+
+# 7d93e5f1b6964a0a8749d3f4589b2c66
+#: ../../source/projects/jupyter-directories.rst:32
+msgid ":envvar:`JUPYTER_CONFIG_DIR`"
+msgstr ""
+
+# 76ba7f9b667d4164a38b80798883a1b7
+#: ../../source/projects/jupyter-directories.rst:34
+msgid "``{sys.prefix}/etc/jupyter/``"
+msgstr ""
+
+# 91813f6c49834cf3af9f4a75bdd82a3f
+#: ../../source/projects/jupyter-directories.rst:36
+msgid "``/usr/local/etc/jupyter/`` ``/etc/jupyter/``"
+msgstr ""
+
+# e74637fd387f47ccb068dbc01bded802
+#: ../../source/projects/jupyter-directories.rst:36
+msgid "``%PROGRAMDATA%\\jupyter\\``"
+msgstr ""
+
+# 712a90ba320f4bda9acb4e6df9b85bc2
+#: ../../source/projects/jupyter-directories.rst:40
+msgid ""
+"To list the config directories currrently being used you can run the "
+"below command from the :term:`command line`::"
+msgstr ""
+
+# 64964fbe2be242c8bac8ee7af6ec573a
+#: ../../source/projects/jupyter-directories.rst:48
+msgid "Data files"
+msgstr ""
+
+# 11ceec0e782b4fc29d0268325a9e2a2c
+#: ../../source/projects/jupyter-directories.rst:50
+msgid ""
+"Jupyter uses a search path to find installable data files, such as "
+":ref:`kernelspecs <kernelspecs>` and notebook extensions. When searching "
+"for a resource, the code will search the search path starting at the "
+"first directory until it finds where the resource is contained."
+msgstr ""
+
+# c90c9a0db78f48a2a2d9c62ec1d46ab6
+#: ../../source/projects/jupyter-directories.rst:55
+msgid ""
+"Each category of file is in a subdirectory of each directory of the "
+"search path. For example, kernel specs are in ``kernels`` subdirectories."
+msgstr ""
+
+# ba1504c274984be89d08649e83e6a9a4
+#: ../../source/projects/jupyter-directories.rst:60
+msgid ""
+"Set this environment variable to provide extra directories for the data "
+"search path. :envvar:`JUPYTER_PATH` should contain a series of "
+"directories, separated by ``os.pathsep`` (``;`` on Windows, ``:`` on "
+"Unix). Directories given in :envvar:`JUPYTER_PATH` are searched before "
+"other locations."
+msgstr ""
+
+# f8a146011f294865a766b75fa7e17ca7
+#: ../../source/projects/jupyter-directories.rst:67
+msgid "Linux (& other free desktops)"
+msgstr ""
+
+# b050321d85634c2b8e2b2a6dcd904919
+#: ../../source/projects/jupyter-directories.rst:67
+msgid "Mac"
+msgstr ""
+
+# cd9e53136025484cacee2884c4b0d516
+#: ../../source/projects/jupyter-directories.rst:69
+msgid ":envvar:`JUPYTER_PATH`"
+msgstr ""
+
+# 391fe50861314e57a7daa84d3e5e2bab
+#: ../../source/projects/jupyter-directories.rst:71
+msgid "``~/.local/share/jupyter/`` (respects ``$XDG_DATA_HOME``)"
+msgstr ""
+
+# 06e83363053c4fbba0effd942e901744
+#: ../../source/projects/jupyter-directories.rst:71
+msgid "``~/Library/Jupyter``"
+msgstr ""
+
+# 6d67a10caff64039a15564a99c3006f9
+#: ../../source/projects/jupyter-directories.rst:71
+msgid "``%APPDATA%\\jupyter``"
+msgstr ""
+
+# deb75cfd63164420803927a5649e969a
+#: ../../source/projects/jupyter-directories.rst:74
+msgid "``{sys.prefix}/share/jupyter/``"
+msgstr ""
+
+# f0d3dcdaccca4791b9a44deae35c97e4
+#: ../../source/projects/jupyter-directories.rst:76
+msgid "``/usr/local/share/jupyter`` ``/usr/share/jupyter``"
+msgstr ""
+
+# b7b523630e9242a4a12dbf7542ad65dc
+#: ../../source/projects/jupyter-directories.rst:76
+msgid "``%PROGRAMDATA\\jupyter``"
+msgstr ""
+
+# b93aebf5941e4312998c3a4c9f1e295e
+#: ../../source/projects/jupyter-directories.rst:83
+msgid "Runtime files"
+msgstr ""
+
+# 9e1d0a2fed714ebdad259185c2c0ebbc
+#: ../../source/projects/jupyter-directories.rst:85
+msgid ""
+"Things like connection files, which are only useful for the lifetime of a"
+" particular process, have a runtime directory."
+msgstr ""
+
+# 6863708a008443d2b5c64ccc5536c1e0
+#: ../../source/projects/jupyter-directories.rst:88
+msgid ""
+"On Linux and other free desktop platforms, these runtime files are stored"
+" in ``$XDG_RUNTIME_DIR/jupyter`` by default. On other platforms, it's a "
+"``runtime/`` subdirectory of the user's data directory (second row of the"
+" table above)."
+msgstr ""
+
+# bd275402d825484bb6293ac54280c325
+#: ../../source/projects/jupyter-directories.rst:93
+msgid "An environment variable may also be used to set the runtime directory."
+msgstr ""
+
+# dffbcd47c8624f2b9add3a0577b40ea2
+#: ../../source/projects/jupyter-directories.rst:97
+msgid "Set this to override where Jupyter stores runtime files."
+msgstr ""
+
+# f79b9f3ae9f64f58abb71234571306d4
+#: ../../source/projects/jupyter-directories.rst:102
+msgid ":envvar:`JUPYTER_CONFIG_DIR` for config file location"
+msgstr ""
+
+# 337b31b2027e41ee99263264a0e43464
+#: ../../source/projects/jupyter-directories.rst:104
+msgid ":envvar:`JUPYTER_PATH` for datafile directory locations"
+msgstr ""
+
+# 5d107ae276ea4dc8bf1d85dbb80bc83d
+#: ../../source/projects/jupyter-directories.rst:106
+msgid ":envvar:`JUPYTER_RUNTIME_DIR` for runtime file location"
+msgstr ""
+
+# e23bc6d9b72d47548301020f53a1ed24
+#: ../../source/projects/jupyter-directories.rst:112
+msgid ":mod:`jupyter_core.paths`"
+msgstr ""
+
+# ca3b8f756259407baf25bf422b315237
+#: ../../source/projects/jupyter-directories.rst:112
+msgid "The Python API to locate these directories."
+msgstr ""
+
+# 5ce8e7c0d39740a1bfcbf01c68fd1eaf
+#: ../../source/projects/jupyter-directories.rst:114
+msgid ":ref:`jupyter_command`"
+msgstr ""
+
+# 77254e7e6f644d49a9475e8bd2e47d8a
+#: ../../source/projects/jupyter-directories.rst:115
+msgid "Locate these directories from the command line."
+msgstr ""
+
+# 8ccbc30eb55f436d8af25b13a9cd5ef7
+#: ../../source/projects/kernels.rst:4
+msgid "Kernels (Programming Languages)"
+msgstr ""
+
+# badc42c2b34c4d11ae7aa2b2767f3728
+#: ../../source/projects/kernels.rst:6
+msgid ""
+"The Jupyter team maintains the `IPython kernel "
+"<https://github.com/ipython/ipython>`_ since the Jupyter notebook server "
+"depends on the IPython :term:`kernel` functionality. Many other "
+"languages, in addition to Python, may be used in the notebook."
+msgstr ""
+
+# 028a578af22144598ff940f737764962
+#: ../../source/projects/kernels.rst:11
+msgid ""
+"The community maintains many other language kernels, and new kernels "
+"become available often. Please see the `list of available kernels`_ for "
+"additional languages and `kernel installation instructions`_ to begin "
+"using these language kernels."
+msgstr ""
+
+# 9910335ae4fe47adbef725bbdb9f7faa
+#: ../../source/projects/subprojects.rst:5
+msgid "Jupyter Projects"
+msgstr ""
+
+# b8c9bc5ad06b47d1bf4eb72a5bb7778a
+#: ../../source/projects/subprojects.rst:10
+msgid ""
+"Project Jupyter is developed as a set of subprojects. This section "
+"describes the subprojects with links to their documentation or GitHub "
+"repositories."
+msgstr ""
+
+# c84899e578ac4b95b3ddcb1e19ae40e4
+#: ../../source/projects/subprojects.rst:15
+msgid ""
+"The Jupyter user interfaces offer a foundation of interactive computing "
+"environments where scientific computing, data science, and analytics can "
+"be performed using a wide range of programming languages."
+msgstr ""
+
+# 3c3427b170f3480eacb5a12321c2763f
+#: ../../source/projects/subprojects.rst:20
+msgid "`Jupyter Notebook <https://jupyter-notebook.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 83a65fc880d64bcd9cbdc020b85c0c6c
+#: ../../source/projects/subprojects.rst:22
+msgid ""
+"Web-based application for authoring documents that combine live-code with"
+" narrative text, equations and visualizations. `Documentation <https"
+"://jupyter-notebook.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/notebook>`__"
+msgstr ""
+
+# aec9f2d0779b4c4c92d8cf427f0d8716
+#: ../../source/projects/subprojects.rst:26
+msgid "`Jupyter Console <https://jupyter-console.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 1849d5bef10540caba484b7e713d550c
+#: ../../source/projects/subprojects.rst:28
+msgid ""
+"Terminal based console for interactive computing. `Documentation <https"
+"://jupyter-console.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/jupyter_console>`__"
+msgstr ""
+
+# 6d562e69261247958e947bf1f99a1578
+#: ../../source/projects/subprojects.rst:31
+msgid "`Jupyter QtConsole <https://jupyter.org/qtconsole/stable/>`__"
+msgstr ""
+
+# d11809f22b934f51994dbdd75402efe0
+#: ../../source/projects/subprojects.rst:33
+msgid ""
+"Qt application for interactive computing with rich output. `Documentation"
+" <https://jupyter.org/qtconsole/stable/>`__ | `Repo "
+"<https://github.com/jupyter/qtconsole>`__"
+msgstr ""
+
+# c4527340da8c4cb89829a1a1b39ed1a5
+#: ../../source/projects/subprojects.rst:40
+msgid ""
+"Kernels are `programming language specific` processes that run "
+"independently and interact with the Jupyter Applications and their user "
+"interfaces. `IPython <https://ipython.org>`__ is the reference Jupyter "
+"kernel, providing a powerful environment for interactive computing in "
+"Python."
+msgstr ""
+
+# 6dd6dcd0bc1840da8916fc03f01788ef
+#: ../../source/projects/subprojects.rst:46
+msgid "`IPython <https://ipython.org>`__"
+msgstr ""
+
+# f2c9f65822ee444fbaa722750c715cce
+#: ../../source/projects/subprojects.rst:48
+msgid ""
+"interactive computing in Python. `Documentation "
+"<http://ipython.readthedocs.io/en/stable/>`__ | `Repo "
+"<https://github.com/ipython/ipython>`__"
+msgstr ""
+
+# bb0dcd6ea74f438e8a548661894d6f19
+#: ../../source/projects/subprojects.rst:51
+msgid "`ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# ca8e8d5e5b844a9ca0d94fbd32717a7a
+#: ../../source/projects/subprojects.rst:53
+msgid ""
+"interactive widgets for Python in the Jupyter Notebook. `Documentation "
+"<https://ipywidgets.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/ipython/ipywidgets>`__"
+msgstr ""
+
+# c377fd53c79042d6b56baae717d8c2a0
+#: ../../source/projects/subprojects.rst:56
+msgid "`ipyparallel <https://ipyparallel.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 6d54f08db9124d3ab5eb18ab39c88c6e
+#: ../../source/projects/subprojects.rst:58
+msgid ""
+"lightweight parallel computing in Python offering seamless notebook "
+"integration. `Documentation "
+"<https://ipyparallel.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/ipython/ipyparallel>`__"
+msgstr ""
+
+# 5d320a536a8b490fa66f06971b80fcbf
+#: ../../source/projects/subprojects.rst:64
+msgid ""
+"`Jupyter kernels <https://github.com/ipython/ipython/wiki/IPython-"
+"kernels-for-other-languages>`_"
+msgstr ""
+
+# 9474725a4e414c47a8a2c081deb7d361
+#: ../../source/projects/subprojects.rst:66
+msgid ""
+"A full list of kernels available for other languages. Many of these "
+"kernels are developed by third parties and may or may not be stable."
+msgstr ""
+
+# bada42846faa4c76bcb0870aa7b4ff67
+#: ../../source/projects/subprojects.rst:70
+msgid "Formatting and Conversion"
+msgstr ""
+
+# 8a0210fab25448ce9a8ce955a5e98b81
+#: ../../source/projects/subprojects.rst:71
+msgid ""
+"Notebooks are rich interactive documents that combine live code, "
+"narrative text (using markdown), visualizations, and other rich media. "
+"The following utility subprojects allow programmatic format conversion "
+"and manipulation of notebook documents."
+msgstr ""
+
+# 63aa809df72b43d187a73bb2e4e6a583
+#: ../../source/projects/subprojects.rst:77
+msgid "`nbconvert <https://nbconvert.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 4c57295fbf23443daf9fdd2905ef7fcf
+#: ../../source/projects/subprojects.rst:79
+msgid ""
+"Convert dynamic notebooks to static formats such as HTML, Markdown, "
+"LaTeX/PDF, and reStrucuredText. `Documentation "
+"<https://nbconvert.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/nbconvert>`__"
+msgstr ""
+
+# ce77e006f955438aa5a921968dc8b922
+#: ../../source/projects/subprojects.rst:83
+msgid "`nbformat <https://nbformat.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 6dff295e412a47da84bb23b4786708b9
+#: ../../source/projects/subprojects.rst:85
+msgid ""
+"Work with notebook documents programmatically. `Documentation "
+"<https://nbformat.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/nbformat>`__"
+msgstr ""
+
+# de4778c3365b43a3b2f0eaf1202f009e
+#: ../../source/projects/subprojects.rst:92
+msgid ""
+"Jupyter Notebooks offer exciting and creative possibilities in education."
+" The following subprojects are focused on supporting the use of Jupyter "
+"Notebook in a variety of educational settings."
+msgstr ""
+
+# 7c1bb06e24c34d31a3e5d647eb968ef4
+#: ../../source/projects/subprojects.rst:97
+msgid "`nbgrader <https://nbgrader.readthedocs.io/en/stable/>`__"
+msgstr ""
+
+# e871a361fed74d7984ccf6be1d16ae4f
+#: ../../source/projects/subprojects.rst:99
+msgid ""
+"tools for managing, grading, and reporting of notebook based assignments."
+" `Documentation <https://nbgrader.readthedocs.io/en/stable/>`__ | `Repo "
+"<https://github.com/jupyter/nbgrader>`__"
+msgstr ""
+
+# 9bddab1e2cba4c829b435171cbe67474
+#: ../../source/projects/subprojects.rst:107
+msgid ""
+"To serve a variety of users and use cases, these subprojects are being "
+"developed to support notebook deployment in various contexts, including "
+"multiuser capabilities and secure, scalable cloud deployments."
+msgstr ""
+
+# eefb0ea614334021a3d54a1978ace7c4
+#: ../../source/projects/subprojects.rst:112
+msgid "`jupyterhub <https://github.com/jupyterhub/jupyterhub>`__"
+msgstr ""
+
+# 17d831ed81344a498d1e6449876780e6
+#: ../../source/projects/subprojects.rst:114
+msgid ""
+"Multi-user notebook for organizations with pluggable authentication and "
+"scalability. `Documentation "
+"<https://jupyterhub.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyterhub/jupyterhub>`__"
+msgstr ""
+
+# bf80256b0a2d49beb74926620c0e63d0
+#: ../../source/projects/subprojects.rst:118
+msgid "`jupyter-drive <https://github.com/jupyter/jupyter-drive>`__"
+msgstr ""
+
+# d6e3c6aaebe44f4cb095e4097d8ffbfe
+#: ../../source/projects/subprojects.rst:120
+msgid ""
+"Store notebooks on Google Drive. `Documentation "
+"<https://github.com/jupyter/jupyter-drive>`__ | `Repo "
+"<https://github.com/jupyter/jupyter-drive>`__"
+msgstr ""
+
+# 7abe71ed8d0c4b78abda9410c630fce5
+#: ../../source/projects/subprojects.rst:123
+msgid "`nbviewer <https://nbviewer.jupyter.org/>`__"
+msgstr ""
+
+# 9f9dbdacd8284a36a9e4fabb09e6f75b
+#: ../../source/projects/subprojects.rst:125
+msgid ""
+"Share notebooks as static HTML on the web. `Documentation "
+"<https://github.com/jupyter/nbviewer>`__ | `Repo "
+"<https://github.com/jupyter/nbviewer>`__"
+msgstr ""
+
+# 21c5717ce0bb494abeb4f7efe21689cf
+#: ../../source/projects/subprojects.rst:128
+msgid "`tmpnb <https://github.com/jupyter/tmpnb>`__"
+msgstr ""
+
+# b33b868fce914e299fd08a5835536be1
+#: ../../source/projects/subprojects.rst:130
+msgid ""
+"Create temporary, transient notebooks in the cloud. `Documentation "
+"<https://github.com/jupyter/tmpnb>`__ | `Repo "
+"<https://github.com/jupyter/tmpnb>`__"
+msgstr ""
+
+# 21a190811e944b0da16ade016dc3b614
+#: ../../source/projects/subprojects.rst:133
+msgid "`tmpnb-deploy <https://github.com/jupyter/tmpnb-deploy>`__"
+msgstr ""
+
+# 5daf6e80c11b44c595c655040dc09d64
+#: ../../source/projects/subprojects.rst:135
+msgid ""
+"Deployment tools for tmpnb. `Documentation <https://github.com/jupyter"
+"/tmpnb-deploy>`__ | `Repo <https://github.com/jupyter/tmpnb-deploy>`__"
+msgstr ""
+
+# 1f8ac9a7b4db4bb3b330567ac288e212
+#: ../../source/projects/subprojects.rst:138
+msgid "`dockerspawner <https://github.com/jupyterhub/dockerspawner>`__"
+msgstr ""
+
+# 2b17819baf714cbea333e87b1007f41a
+#: ../../source/projects/subprojects.rst:140
+msgid ""
+"Deploy notebooks for 'jupyterhub' inside Docker containers. "
+"`Documentation <https://github.com/jupyterhub/dockerspawner>`__ | `Repo "
+"<https://github.com/jupyterhub/dockerspawner>`__"
+msgstr ""
+
+# 8ef739ace1cf4cc8bad61fb84a2d4c6d
+#: ../../source/projects/subprojects.rst:143
+msgid "`docker-stacks <https://github.com/jupyter/docker-stacks>`__"
+msgstr ""
+
+# d77ec1880fb64bef854fafe43b182310
+#: ../../source/projects/subprojects.rst:145
+msgid ""
+"Stacks of Jupyter applications and kernels as Docker containers. "
+"`Documentation <https://github.com/jupyter/docker-stacks>`__ | `Repo "
+"<https://github.com/jupyter/docker-stacks>`__"
+msgstr ""
+
+# 2c6f57f2e66247acbba9d318b5c2ce75
+#: ../../source/projects/subprojects.rst:152
+msgid ""
+"The Jupyter architecture relies on these projects' specifications and "
+"implementation."
+msgstr ""
+
+# 682935d71e0f4ab7be95b5b3aea567d5
+#: ../../source/projects/subprojects.rst:156
+msgid "`jupyter_client <https://jupyter-client.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# 0e90e5cc30614edab2b9cb1f02d94a33
+#: ../../source/projects/subprojects.rst:158
+msgid ""
+"The specification of the Jupyter message protocol and a client library in"
+" Python. `Documentation <https://jupyter-"
+"client.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/jupyter_client>`__"
+msgstr ""
+
+# ed800037c68c47df8948d52e1b135a2b
+#: ../../source/projects/subprojects.rst:162
+msgid "`jupyter_core <https://jupyter-core.readthedocs.io/en/latest/>`__"
+msgstr ""
+
+# d925cc4bc47747ea85133aad35a742dc
+#: ../../source/projects/subprojects.rst:164
+msgid ""
+"Core functionality and miscellaneous utilities. `Documentation <https"
+"://jupyter-core.readthedocs.io/en/latest/>`__ | `Repo "
+"<https://github.com/jupyter/jupyter_core>`__"
+msgstr ""
+
+# 42f7355e70a2465091323cab4580f41c
+#: ../../source/projects/upgrade-notebook.rst:2
+msgid "Upgrading Jupyter Notebook"
+msgstr ""
+
+# 440ad06fd1184be59ef54118786fb0e4
+#: ../../source/projects/upgrade-notebook.rst:8
+msgid "Upgrading Jupyter Notebook using Anaconda"
+msgstr ""
+
+# 18dbe73b2ce04c938891ba31dea7fe2c
+# dd8463cadc3a4083a009cd56974e52d5
+#: ../../source/projects/upgrade-notebook.rst:9
+#: ../../source/projects/upgrade-notebook.rst:28
+msgid "If using **Anaconda**, update Jupyter using ``conda``:"
+msgstr ""
+
+# a9da6695326c43b2a352e704d29b2dca
+# 6fab146490114576a0eb827544c97bda
+#: ../../source/projects/upgrade-notebook.rst:15
+#: ../../source/projects/upgrade-notebook.rst:42
+msgid "See :ref:`Run the Notebook <running>` for running the Jupyter Notebook."
+msgstr ""
+
+# f8b0d1051b0744969dc1f9f522461d3e
+#: ../../source/projects/upgrade-notebook.rst:21
+msgid "Upgrading IPython Notebook to Jupyter Notebook"
+msgstr ""
+
+# 1a22753f51114de08d7186b0712d06b8
+#: ../../source/projects/upgrade-notebook.rst:23
+msgid ""
+"The Jupyter Notebook used to be called the IPython Notebook. If you are "
+"running an older version of the IPython Notebook (version 3 or earlier) "
+"you can use the following to upgrade to the latest version of the Jupyter"
+" Notebook."
+msgstr ""
+
+# d88146b35caa48739050570489690ea2
+#: ../../source/projects/upgrade-notebook.rst:34
+msgid "*or*"
+msgstr ""
+
+# e5a0f0b2480d4d288496520262d1b1f5
+#: ../../source/projects/upgrade-notebook.rst:36
+msgid "If using :term:`pip`:"
+msgstr ""
+
+# f3af7fac60674d649aee3681c819a3f8
+#: ../../source/projects/upgrade-notebook.rst:46
+msgid ""
+"The :ref:`migrating <migrating>` document has additional information "
+"about migrating from IPython 3 to Jupyter."
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/reference.po
+++ b/docs/source/locale/es/LC_MESSAGES/reference.po
@@ -1,0 +1,79 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 4186a713d84a4c2b806a912fb2becfc9
+#: ../../source/reference/content-reference.rst:2
+msgid "Reference"
+msgstr ""
+
+# 47d932f599ef4dc1a3fce9d83d3e7bc4
+#: ../../source/reference/content-reference.rst:12
+msgid "Resources"
+msgstr ""
+
+# 23b33a4ebf624f9f8ac3989d8fb30bd8
+#: ../../source/reference/content-reference.rst:14
+msgid ":ref:`genindex`"
+msgstr ""
+
+# fdf2e34429ec43cfa4182e18d95e3546
+#: ../../source/reference/content-reference.rst:15
+msgid ":ref:`search`"
+msgstr ""
+
+# 1af8e86e71ef4cdfa9a78a51877391cc
+#: ../../source/reference/mimetype.md:1
+msgid "Custom mimetypes (MIME types)"
+msgstr ""
+
+# 42772fdb996b48deb68314fc87c61069
+#: ../../source/reference/mimetype.md:4
+msgid "What's a mimetype?"
+msgstr ""
+
+# b4587f2848af4bb6bedc27fc5478e0e1
+#: ../../source/reference/mimetype.md:6
+msgid ""
+"When an internet request and response occurs, a Content-Type header is "
+"passed. A mimetype, also referred to as MIME type, identifies how the "
+"content that is being returned should be handled or used, based on type, "
+"by the application and browser. A MIME type is made up of a MIME group "
+"(i.e. application, image, audio, etc.) and a MIME subtype. For example, a"
+" MIME type is image/png where MIME group is image and subtype is png."
+msgstr ""
+
+# 45992d4e958c48eeade184b7bf32f2a1
+#: ../../source/reference/mimetype.md:13
+msgid ""
+"As types may contain vendor specific items, a custom vendor specific MIME"
+" type, vnd, can be used. A vendor specific MIME type will contain vnd "
+"such as application/vnd.jupyter.cells."
+msgstr ""
+
+# 197f07f4e1a64a4abeaae091b0bc2bcd
+#: ../../source/reference/mimetype.md:19
+msgid "Custom mimetypes used in Jupyter and IPython projects"
+msgstr ""
+
+# e9b912b57b8149408f2ac38653e37ccf
+#: ../../source/reference/mimetype.md:29
+msgid "Listing of custom mimetypes used for display"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/releases.po
+++ b/docs/source/locale/es/LC_MESSAGES/releases.po
@@ -1,0 +1,44 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 999687e2672c4830be8be849ba17fdd8
+#: ../../source/releases/content-releases.rst:2
+msgid "Release Notes"
+msgstr ""
+
+# f2e5171237034eeeafdd4917d74a1fdb
+#: ../../source/releases/content-releases.rst:4
+msgid ""
+"Each project's documentation and GitHub repository has information about "
+"releases and changes from the prior release."
+msgstr ""
+
+# b6a439cd2ee94119bbd0f928c111ccda
+#: ../../source/releases/content-releases.rst:7
+msgid "Coming Soon"
+msgstr ""
+
+# eb314f1a6b1c47b8b4aaf0281c3f1c94
+#: ../../source/releases/content-releases.rst:9
+msgid ""
+"We're actively working on a graphic that displays each project, their "
+"current release, and a link to the changelog. Thanks for your patience."
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/running.po
+++ b/docs/source/locale/es/LC_MESSAGES/running.po
@@ -1,0 +1,153 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 034fbf47daca43d69d2f69db956f0925
+#: ../../source/running.rst:5
+msgid "Running the Notebook"
+msgstr ""
+
+# 0f84d33b57f44a6c866def4270ab75d4
+#: ../../source/running.rst:9
+msgid "Contents"
+msgstr ""
+
+# de423761fe414a8bb5c042ffafd69e67
+#: ../../source/running.rst:12
+msgid "Basic Steps"
+msgstr ""
+
+# 772caec806c34073bc157412767069c3
+#: ../../source/running.rst:14
+msgid "Start the notebook server from the :term:`command line`::"
+msgstr ""
+
+# 381fc8c07c8d4b12907dece1a9391603
+#: ../../source/running.rst:18
+msgid "You should see the notebook open in your browser."
+msgstr ""
+
+# 5b2da16c94e74d859ce8055fdce8aeb6
+#: ../../source/running.rst:21
+msgid "Starting the Notebook Server"
+msgstr ""
+
+# 81d1855aa3064e38a5145051195be5ce
+#: ../../source/running.rst:23
+msgid ""
+"After you have installed the Jupyter Notebook on your computer, you are "
+"ready to run the notebook server. You can start the notebook server from "
+"the :term:`command line` (using :term:`Terminal` on Mac/Linux, "
+":term:`Command Prompt` on Windows) by running::"
+msgstr ""
+
+# 178e1601d2154fc198cd68d6167cb4ee
+#: ../../source/running.rst:30
+msgid ""
+"This will print some information about the notebook server in your "
+"terminal, including the URL of the web application (by default, "
+"``http://localhost:8888``):"
+msgstr ""
+
+# 2499df7720c9421eaf3671e9c9a7e4b7
+#: ../../source/running.rst:42
+msgid "It will then open your default web browser to this URL."
+msgstr ""
+
+# f9ca618037bf469490a7fc5a2e793ebf
+#: ../../source/running.rst:44
+msgid ""
+"When the notebook opens in your browser, you will see the :term:`Notebook"
+" Dashboard`, which will show a list of the notebooks, files, and "
+"subdirectories in the directory where the notebook server was started. "
+"Most of the time, you will wish to start a notebook server in the highest"
+" level directory containing notebooks. Often this will be your home "
+"directory."
+msgstr ""
+
+# dc50f37acb364b30924ee135608f01e4
+#: ../../source/running.rst:50
+msgid "**Notebook Dashboard**"
+msgstr ""
+
+# 1cd18ab0da2945bbaefbe684313b04a0
+#: ../../source/running.rst:55
+msgid "Introducing the Notebook Server's Command Line Options"
+msgstr ""
+
+# 6e674cad5104461aa03097ede9bb7b7f
+#: ../../source/running.rst:58
+msgid "How do I open a specific Notebook?"
+msgstr ""
+
+# dfbad8a998c7422ca95f3c2a41fb3964
+#: ../../source/running.rst:60
+msgid ""
+"The following code should open the given notebook in the currently "
+"running notebook server, starting one if necessary."
+msgstr ""
+
+# 57ba78a74c634ad5a2709e1cc3bbe370
+#: ../../source/running.rst:67
+msgid "How do I start the Notebook using a custom IP or port?"
+msgstr ""
+
+# 425d27eeb2084312960454783a563cdd
+#: ../../source/running.rst:69
+msgid ""
+"By default, the notebook server starts on port 8888. If port 8888 is "
+"unavailable or in use, the notebook server searches the next available "
+"port. You may also specify a port manually. In this example, we set the "
+"server's port to 9999:"
+msgstr ""
+
+# e4bf6e61b19a4c33b6aff46cf9e29eaf
+#: ../../source/running.rst:79
+msgid "How do I start the Notebook server without opening a browser?"
+msgstr ""
+
+# 56643f36db0446c38012f871fbabf0d7
+#: ../../source/running.rst:81
+msgid "Start notebook server without opening a web browser:"
+msgstr ""
+
+# 265b6dcd97d4439eaa5fb4436fcf1189
+#: ../../source/running.rst:88
+msgid "How do I get help about Notebook server options?"
+msgstr ""
+
+# ec00daf0abd7419d8fae626b3ea49805
+#: ../../source/running.rst:90
+msgid ""
+"The notebook server provides help messages for other command line "
+"arguments using the ``--help`` flag:"
+msgstr ""
+
+# b21136ba910742b9b9ecaccaa257051b
+#: ../../source/running.rst:99
+msgid ":ref:`Jupyter Installation, Configuration, and Usage <content-projects>`"
+msgstr ""
+
+# aece793a237545f9817252206a46e633
+#: ../../source/running.rst:100
+msgid ""
+"Detailed information about command line arguments, configuration, and "
+"usage."
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/sphinx.po
+++ b/docs/source/locale/es/LC_MESSAGES/sphinx.po
@@ -1,0 +1,283 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 20:11-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# 7c11dbc4811f481794057766800832ee
+#: ../../source/_templates/index.html:2
+msgid "Overview"
+msgstr ""
+
+# 87674d21ac2842d9b2ca32525a06983c
+#: ../../source/_templates/index.html:4
+msgid "Welcome"
+msgstr ""
+
+# fbe326ee1913477fbbef9e36280cb3d5
+#: ../../source/_templates/index.html:7
+msgid "Start Here"
+msgstr ""
+
+# dd871a3570ef4360993c9f5f9a6e9a6f
+#: ../../source/_templates/index.html:13
+msgid "Jupyter Notebook Quickstart"
+msgstr ""
+
+# 5b38b22813c440bda17aa0cb1015468a
+#: ../../source/_templates/index.html:14
+msgid "Try the notebook"
+msgstr ""
+
+# e24d669c50e84c10a9b7d2db8e2a206b
+#: ../../source/_templates/index.html:15
+msgid "Architecture"
+msgstr ""
+
+# 666d449fc8564f81951df06fb28f857b
+#: ../../source/_templates/index.html:16
+msgid "What is Jupyter?"
+msgstr ""
+
+# b73a8286763d448c8e471e7c19863f07
+#: ../../source/_templates/index.html:17
+msgid "Narratives and Use Cases"
+msgstr ""
+
+# 27c32a3a5ae34fba8a569bee972dc21a
+#: ../../source/_templates/index.html:18
+msgid "Narratives of common deployment scenarios"
+msgstr ""
+
+# 073c45ea86594cad8be3d011b9b3b5ed
+# 209be84e7b1c48b59ed8ad4f4ba9bd9e
+# e68ee3bc1d344ea892e96b9a0c557ec4
+#: ../../source/_templates/index.html:19 ../../source/_templates/index.html:61
+#: ../../source/_templates/index.html:67
+msgid "IPython"
+msgstr ""
+
+# fa896a9ecf334ec59243584de08ebc4c
+#: ../../source/_templates/index.html:20
+msgid "An interactive Python kernel and REPL"
+msgstr ""
+
+# d8bfcdc723ba4ff9be620bc7a48c9bbb
+#: ../../source/_templates/index.html:21
+msgid "Installation, Configuration, and Usage"
+msgstr ""
+
+# b85884536fe94bbbb0bc361199515e97
+#: ../../source/_templates/index.html:22
+msgid "Documentation for users"
+msgstr ""
+
+# 187c62af4f4946368cc1912dc4ed72bd
+#: ../../source/_templates/index.html:25
+msgid "Community"
+msgstr ""
+
+# 01be44444a6944f8b66f5d33ecada473
+#: ../../source/_templates/index.html:26
+msgid "Sustainability and growth"
+msgstr ""
+
+# 1c7430b771f34dea888a279f5159cfd1
+#: ../../source/_templates/index.html:27
+msgid "Contributor Guides"
+msgstr ""
+
+# 060fa8d986484cc5920822becdc72633
+#: ../../source/_templates/index.html:28
+msgid "How to contribute to the projects"
+msgstr ""
+
+# 4a62e635396944ce8ac3b0a846bee09c
+#: ../../source/_templates/index.html:29
+msgid "Release Notes"
+msgstr ""
+
+# e008293ddb6c4b84ba2ae3c01af0ddd8
+#: ../../source/_templates/index.html:30
+msgid "New features, upgrades, deprecation notes, and bug fixes"
+msgstr ""
+
+# 632f425094284248a3904601833d3282
+#: ../../source/_templates/index.html:31
+msgid "Reference"
+msgstr ""
+
+# 60a7fa2b852447948397bee452574352
+#: ../../source/_templates/index.html:32
+msgid "APIs"
+msgstr ""
+
+# 078a4e5b447d464f980c754d79bd0d8f
+#: ../../source/_templates/index.html:33
+msgid "Contents"
+msgstr ""
+
+# fe624220d72f4eb68b635b704ce7857d
+#: ../../source/_templates/index.html:34
+msgid "Full table of contents"
+msgstr ""
+
+# fd469284c910443c9a94f1e5c2890809
+#: ../../source/_templates/index.html:40
+msgid "Project Documentation"
+msgstr ""
+
+# 82990c9abe5a481b8e029e99d56eda97
+#: ../../source/_templates/index.html:45
+msgid "Jupyter Notebook"
+msgstr ""
+
+# 0fa103f6933a4fae8e861337f0dc4dfe
+#: ../../source/_templates/index.html:46
+msgid "Jupyter console"
+msgstr ""
+
+# aeecc22f41504fa78c3e6bc2a5918062
+#: ../../source/_templates/index.html:47
+msgid "Qt console"
+msgstr ""
+
+# e58d1a93d24a4dffb852da36feb32d2d
+#: ../../source/_templates/index.html:49
+msgid "JupyterHub"
+msgstr ""
+
+# b8c2f78b5e064757a6f7fd58b7a47d83
+#: ../../source/_templates/index.html:50
+msgid "configurable HTTP proxy"
+msgstr ""
+
+# 4b0500d653a140c6ae920817c825165f
+#: ../../source/_templates/index.html:51
+msgid "dockerspawner"
+msgstr ""
+
+# d6bed661873740d9b060211a971ab15e
+#: ../../source/_templates/index.html:52
+msgid "ldapauthenticator"
+msgstr ""
+
+# b00d98858cd348dc9c8aa5777c19b125
+#: ../../source/_templates/index.html:53
+msgid "oauthenticator"
+msgstr ""
+
+# a7ee2953ae3149bdbb7c6dedd24d39b4
+#: ../../source/_templates/index.html:54
+msgid "sudospawner"
+msgstr ""
+
+# 75f1af39b9134416a9c076a314298dbe
+#: ../../source/_templates/index.html:56
+msgid "nbgrader"
+msgstr ""
+
+# fc5ad0b0e7ed441ca42f9046d3d418bf
+#: ../../source/_templates/index.html:58
+msgid "nbconvert"
+msgstr ""
+
+# d2e632b13f7a4336814338eed74f44fb
+#: ../../source/_templates/index.html:59
+msgid "nbformat"
+msgstr ""
+
+# 5e25a71dee6f4ba6a9798efa502a8636
+#: ../../source/_templates/index.html:62
+msgid "IRkernel"
+msgstr ""
+
+# 9cf27e2f496f472d8b31c31a8d50f93f
+#: ../../source/_templates/index.html:63
+msgid "IJulia"
+msgstr ""
+
+# a4408d07c95b4196ad698778f8f67033
+#: ../../source/_templates/index.html:64
+msgid "Community maintained kernels"
+msgstr ""
+
+# 2904cce51a98448491bb284edb4307fa
+#: ../../source/_templates/index.html:68
+msgid "ipykernel"
+msgstr ""
+
+# 6568de0311404a3a8e217053421abd97
+#: ../../source/_templates/index.html:69
+msgid "ipyparallel"
+msgstr ""
+
+# 41e36095f7f742798a17eb53fbd9e115
+#: ../../source/_templates/index.html:71
+msgid "jupyter_client"
+msgstr ""
+
+# 0829b56cf4c64e43ad26445146b01b00
+#: ../../source/_templates/index.html:72
+msgid "jupyter_core"
+msgstr ""
+
+# 443f2d6d97e94855a386370356e7d859
+#: ../../source/_templates/index.html:74
+msgid "docker-stacks"
+msgstr ""
+
+# 1ce3fe422ec24231abd162189e6a1b84
+#: ../../source/_templates/index.html:75
+msgid "ipywidgets"
+msgstr ""
+
+# 6523ea7d2bfd43b99a6f08b105fb0e50
+#: ../../source/_templates/index.html:76
+msgid "jupyter-drive"
+msgstr ""
+
+# f01bf4a28b1c4ac8bdf4d8a13cfdae5e
+#: ../../source/_templates/index.html:77
+msgid "jupyter-sphinx-theme"
+msgstr ""
+
+# 744f8e6f66474cf4bee3f3bed2f28750
+#: ../../source/_templates/index.html:78
+msgid "kernel_gateway"
+msgstr ""
+
+# e74b30a13ebd473c89b8678769cc6e14
+#: ../../source/_templates/index.html:79
+msgid "nbviewer"
+msgstr ""
+
+# 3465cff3b57a4f3d87d71548f0b523b8
+#: ../../source/_templates/index.html:80
+msgid "tmpnb"
+msgstr ""
+
+# a89a262455e04f8881482759567c34f5
+#: ../../source/_templates/index.html:81
+msgid "traitlets"
+msgstr ""
+
+# c319a5d418a24253ba83ff826d666716
+#: ../../source/_templates/index.html:83
+msgid "jupyter-js-services"
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/tryjupyter.po
+++ b/docs/source/locale/es/LC_MESSAGES/tryjupyter.po
@@ -1,0 +1,62 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# aac44b6e1fec4f468a8d726af2e658a1
+#: ../../source/tryjupyter.rst:5
+msgid "Try Jupyter"
+msgstr ""
+
+# 3a668d6e2d0c48e1a9edb05dccda1893
+#: ../../source/tryjupyter.rst:8
+msgid "Contents"
+msgstr ""
+
+# 69cbf5beb07e43cbb0ca9eb9fa01a78e
+#: ../../source/tryjupyter.rst:11
+msgid "Try in Your Browser. No Installation Needed."
+msgstr ""
+
+# 4a876c620c274d63abade59bdfd082a3
+#: ../../source/tryjupyter.rst:13
+msgid "Go to https://try.jupyter.org. No installation is needed."
+msgstr ""
+
+# 3dfbe1fd06a44fc8be1b057fa7a62b43
+#: ../../source/tryjupyter.rst:15
+msgid "**Notebook Dashboard**"
+msgstr ""
+
+# 6b4e878bb42947ef8919b89bc6217086
+#: ../../source/tryjupyter.rst:19
+msgid "**Notebook Editor**"
+msgstr ""
+
+# 8c70aa16e8b54e769815667cf4b4b4da
+#: ../../source/tryjupyter.rst:25
+msgid "Are You Ready to Install Jupyter?"
+msgstr ""
+
+# 11a41db69b334abfb7687cfe4721da14
+#: ../../source/tryjupyter.rst:27
+msgid ""
+"If you have tried Jupyter and like it, please use our detailed "
+":ref:`Installation Guide <install>` to install Jupyter on your computer."
+msgstr ""
+

--- a/docs/source/locale/es/LC_MESSAGES/use-cases.po
+++ b/docs/source/locale/es/LC_MESSAGES/use-cases.po
@@ -1,0 +1,373 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2015, Jupyter Team, https://jupyter.org
+# This file is distributed under the same license as the Jupyter
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Jupyter Documentation 4.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-07-04 19:51-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+# c7a3e6ef18974fdf9970ec0c8cf6b1a4
+#: ../../source/use-cases/content-user.rst:2
+msgid "Narratives and Use Cases"
+msgstr ""
+
+# 74a57ce9257b4dcf8cd496659310f050
+#: ../../source/use-cases/content-user.rst:5
+msgid "What are Narratives?"
+msgstr ""
+
+# 4d5ab784c1c0495a953ec916572ab868
+#: ../../source/use-cases/content-user.rst:6
+msgid ""
+"Narratives are *collaborative*, *shareable*, *publishable*, and "
+"*reproducible*. We believe that Narratives help both yourself and other "
+"researchers by sharing your use of Jupyter projects, technical specifics "
+"of your deployment, and installation and configuration tips so that "
+"others can learn from your experiences."
+msgstr ""
+
+# 38991fbc6546442fac82338471a16196
+#: ../../source/use-cases/data_science.rst:5
+msgid "Jupyter for Data Science"
+msgstr ""
+
+# 9b4934127359431a8eae07c4e6d35177
+#: ../../source/use-cases/data_science.rst:7
+msgid ""
+"The purpose of this page is to highlight kernels and other projects that "
+"are central to the usage of Jupyter in data science. This page is not "
+"meant to be comprehensive or unbiased, but rather to provide an "
+"opinionated view of the usage of Jupyter in data science based on our "
+"interactions with users."
+msgstr ""
+
+# 79646aee3a3a4e799435131c32b9fa38
+#: ../../source/use-cases/data_science.rst:12
+msgid "The following Jupyter kernels are widely used in data science:"
+msgstr ""
+
+# 61a8d058c87947fcb61ad48ca8b85c1c
+#: ../../source/use-cases/data_science.rst:14
+msgid "python"
+msgstr ""
+
+# e1ab9a92301d44bbb0e3792b6ed0490d
+#: ../../source/use-cases/data_science.rst:15
+msgid "IPython (`GitHub Repo <https://github.com/ipython/ipykernel>`__)"
+msgstr ""
+
+# 0d1a6ecffddc475596df6bc7d7ab6ac9
+#: ../../source/use-cases/data_science.rst:18
+msgid "R"
+msgstr ""
+
+# b617b75cdf6b4f09bd81a46e54f67b4c
+#: ../../source/use-cases/data_science.rst:17
+msgid ""
+"IRkernel (`Documentation <https://irkernel.github.io/>`__, `GitHub Repo "
+"<https://github.com/IRkernel/IRkernel>`__)"
+msgstr ""
+
+# 6c033e0b10c943c7b1d015a324bd5043
+#: ../../source/use-cases/data_science.rst:18
+msgid "IRdisplay (`GitHub Repo <https://github.com/IRkernel/IRdisplay>`__)"
+msgstr ""
+
+# b5577205b7ea4a5e863601eedc8826fc
+#: ../../source/use-cases/data_science.rst:19
+msgid "repr (`GitHub Repo <https://github.com/IRkernel/repr>`__)"
+msgstr ""
+
+# e204fea1f5694325a9ebb16297f8efff
+#: ../../source/use-cases/data_science.rst:21
+msgid "Julia"
+msgstr ""
+
+# aee5a4b089b04f0080ad7ba2a1f5031f
+#: ../../source/use-cases/data_science.rst:21
+msgid "IJulia Kernel (`GitHub Repo <https://github.com/JuliaLang/IJulia.jl>`__)"
+msgstr ""
+
+# 7bbb9b36f2f84459aef3fb97869ce6b9
+#: ../../source/use-cases/data_science.rst:22
+msgid ""
+"Interactive Widgets (`GitHub Repo "
+"<https://github.com/JuliaLang/Interact.jl>`__)"
+msgstr ""
+
+# 1b6b2ad9e6f3428dbf5172927a9169a9
+#: ../../source/use-cases/data_science.rst:23
+msgid "Bash (`GitHub Repo <https://github.com/takluyver/bash_kernel>`__)"
+msgstr ""
+
+# 37b3885a41144745a83ca6b4cd08778e
+#: ../../source/use-cases/education.rst:2
+msgid "Jupyter in Education"
+msgstr ""
+
+# 537dc039d5b140bdaf1f53e9a7e508ab
+# d387c0b434c84dd2842f3f53e48eaca9
+# 51f6e28c5aae4489afff3acfd1033f00
+# 5824e4f59f5a48a5a8441ea228e71850
+# ad1ed25e378745da95f1815cc1a9c5ca
+#: ../../source/use-cases/education.rst:5
+#: ../../source/use-cases/narrative-hub.rst:29
+#: ../../source/use-cases/narrative-notebook.rst:24
+#: ../../source/use-cases/narrative-other.rst:23
+#: ../../source/use-cases/science.rst:5
+msgid ""
+"We're actively working on this section of the documentation to improve it"
+" for you. Thanks for your patience."
+msgstr ""
+
+# e5ea9daf28014d91919d78648a1a3c6c
+#: ../../source/use-cases/enterprise.rst:5
+msgid "Jupyter in the Enterprise"
+msgstr ""
+
+# e6075014f1a94cb08daccbf89fa4bf7e
+# 0d285e91e9e34a579165b524a3bc024e
+# 04b5bb4dfe2d49c7bcbeb444bd97a735
+# 45567a5466db4b78905ff14d59ede989
+#: ../../source/use-cases/enterprise.rst:8
+#: ../../source/use-cases/narrative-hub.rst:5
+#: ../../source/use-cases/narrative-notebook.rst:5
+#: ../../source/use-cases/narrative-other.rst:5
+msgid "Contents"
+msgstr ""
+
+# 0192beb23b4842a0a1e6cb765973592b
+# aca370754a0b41dbaba092dd77a3f385
+# 9d431db72aa14375914f90b6b7e2d86f
+# 0e0b9dc725fc4c6da2f26d04f88f70a6
+#: ../../source/use-cases/enterprise.rst:11
+#: ../../source/use-cases/narrative-hub.rst:8
+#: ../../source/use-cases/narrative-notebook.rst:8
+#: ../../source/use-cases/narrative-other.rst:8
+msgid "Description"
+msgstr ""
+
+# 4d5b3832ecb24a678ed06238e69a35b8
+#: ../../source/use-cases/enterprise.rst:13
+msgid ""
+"Businesses, especially those that started their ‘digital transformation’ "
+"journey, are producing ever-increasing volumes of data. Enterprise data "
+"science aims to unearth the hidden value of those digital assets, which "
+"are typically siloed, uncategorized, and inaccessible to humans."
+msgstr ""
+
+# e9407a7e2195481583ac70537e535b51
+#: ../../source/use-cases/enterprise.rst:17
+msgid ""
+"Jupyter and JupyterHub can play a major role in related initiatives, "
+"especially in companies with an established open-source culture. The "
+"intent of this page is to provide you with ideas how Jupyter technology "
+"can fit into *your* organization's processes and system landscapes, by "
+"providing real-world examples and showcases."
+msgstr ""
+
+# 92f850f3933a4c82972254363d00920d
+#: ../../source/use-cases/enterprise.rst:24
+msgid "Example Use-Cases"
+msgstr ""
+
+# 1124b2efb8e5441a9bae96db904a4d13
+#: ../../source/use-cases/enterprise.rst:26
+msgid ""
+"`Beyond Interactive: Notebook Innovation at Netflix <https://medium.com"
+"/netflix-techblog/notebook-innovation-591ee3221233>`_"
+msgstr ""
+
+# a032d148013249c19a4b7997d144d6e5
+#: ../../source/use-cases/enterprise.rst:28
+msgid ""
+"`Part 2: Scheduling Notebooks at Netflix <https://medium.com/netflix-"
+"techblog/scheduling-notebooks-348e6c14cfd6>`_"
+msgstr ""
+
+# 3ea08bce807d455c97b4e99507bf7bc1
+#: ../../source/use-cases/enterprise.rst:30
+msgid ""
+"`PayPal Notebooks: Data science and machine learning at scale, powered by"
+" Jupyter <https://conferences.oreilly.com/jupyter/jup-"
+"ny/public/schedule/detail/68405>`_ (JupyterCon 2018 · `video "
+"<https://youtu.be/KVGrACWVUgE>`_)"
+msgstr ""
+
+# 12d4de71971e4485aa5f391ea154dd5f
+#: ../../source/use-cases/enterprise.rst:32
+msgid "Bloomberg BQuant platform:"
+msgstr ""
+
+# b8efa7cb7d964b33a93f5f889328f5e9
+#: ../../source/use-cases/enterprise.rst:34
+msgid "`Part 1: Overview <https://adrian-gao.com/2018/02/bloomberg-bqnt-1/>`_"
+msgstr ""
+
+# ec673432d6994bbca5bcd2e8703688d3
+#: ../../source/use-cases/enterprise.rst:35
+msgid "`Part 2: The BQNT App <https://adrian-gao.com/2018/04/bloomberg-bqnt-2/>`_"
+msgstr ""
+
+# a5be50b562b649af8ab4406992e4e1cb
+#: ../../source/use-cases/enterprise.rst:37
+msgid ""
+"`Jupyter & Python in the corporate LAN "
+"<https://medium.com/@olivier.borderies/jupyter-python-in-the-corporate-"
+"lan-109e2ffde897>`_"
+msgstr ""
+
+# 6319bc990dcd4dca8a8d84f86ed2742e
+#: ../../source/use-cases/enterprise.rst:39
+msgid ""
+"`DevOps Intelligence with JupyterHub "
+"<https://nbviewer.jupyter.org/github/jhermann/jupyter-by-"
+"example/blob/master/complete-scenarios/devops-intelligence.ipynb>`_"
+msgstr ""
+
+# 9684506604dc48f8bf0349b784ab1317
+#: ../../source/use-cases/enterprise.rst:43
+msgid ""
+"We're actively working on this section of the documentation to improve it"
+" for you. If you've got a suggestion for a resource that would be "
+"helpful, please create an issue or a pull request!"
+msgstr ""
+
+# a2f2ed36e51e49eb8e0dafad92b083dd
+#: ../../source/use-cases/narrative-hub.rst:2
+msgid "JupyterHub Narratives"
+msgstr ""
+
+# 5fd29ccb39f546d3b5c56980d35d5443
+#: ../../source/use-cases/narrative-hub.rst:10
+msgid ""
+"JupyterHub Narratives explore deployment and scaling of the Jupyter "
+"Notebook for a group of users. JupyterHub allows flexibility in "
+"configuration and deployment which makes JupyterHub valuable to "
+"education, industry research teams, and service providers. In these "
+"Narratives, we will look at differences in deployment, deployment "
+"advantages, and best practices."
+msgstr ""
+
+# 6a00f5a8c10b4becba9ae2de4e09920d
+# d11d3f4bb4654347884f0e30aeff7efc
+# 93f4d0e4bb044d388ee7e9568d0351c6
+#: ../../source/use-cases/narrative-hub.rst:17
+#: ../../source/use-cases/narrative-notebook.rst:14
+#: ../../source/use-cases/narrative-other.rst:15
+msgid "Narrative examples"
+msgstr ""
+
+# 37667e2cc4db44b7840b61219286817c
+#: ../../source/use-cases/narrative-hub.rst:19
+msgid "A basic JupyterHub deployment"
+msgstr ""
+
+# 9efafc8059f74b20a96a0f2cf057b7ba
+#: ../../source/use-cases/narrative-hub.rst:20
+msgid ""
+"A `reference deployment of JupyterHub using Docker "
+"<https://github.com/jupyterhub/jupyterhub-deploy-docker>`_"
+msgstr ""
+
+# 83e972a4838b45b985c3795f51d91325
+#: ../../source/use-cases/narrative-hub.rst:21
+msgid ""
+"Teaching a Course with JupyterHub and nbgrader using a `reference "
+"deployment on a single server and Ansible scripts "
+"<https://github.com/jupyterhub/jupyterhub-deploy-teaching>`_ to automate "
+"set up"
+msgstr ""
+
+# bc90954a01844a18aabe588e48560982
+#: ../../source/use-cases/narrative-hub.rst:24
+msgid "Teaching a Course with JupyterHub, nbgrader, and containers"
+msgstr ""
+
+# a63a5a9c78b541d39c2ca4a324bfa928
+#: ../../source/use-cases/narrative-hub.rst:25
+msgid "JupyterHub deployments using Containers including Docker"
+msgstr ""
+
+# 1eaed5aeb1c44f48907382a9aa29974f
+#: ../../source/use-cases/narrative-notebook.rst:2
+msgid "Notebook Narratives"
+msgstr ""
+
+# 97653c247b5542f3a630af8650f8bc2a
+#: ../../source/use-cases/narrative-notebook.rst:10
+msgid ""
+"The Notebook Narratives explore uses of the Jupyter Notebook in a variety"
+" of applications."
+msgstr ""
+
+# 5f19fbc7dd8449e4aa030e5c901b4333
+#: ../../source/use-cases/narrative-notebook.rst:16
+msgid "Using the Notebook for data exploration"
+msgstr ""
+
+# 83ddeff477bb456599fe4d3361ef91f2
+#: ../../source/use-cases/narrative-notebook.rst:17
+msgid "Using extensions and widgets"
+msgstr ""
+
+# aa06224177374fe7ab21442a4e3f0e72
+#: ../../source/use-cases/narrative-notebook.rst:18
+msgid "Using nbconvert for code execution and workflow simplification"
+msgstr ""
+
+# 53697b1c3430469484f08a5b162b5f5e
+#: ../../source/use-cases/narrative-notebook.rst:19
+msgid "Using nbconvert for publishing"
+msgstr ""
+
+# 9a1429ea23d141af91a1c12036e2d00e
+#: ../../source/use-cases/narrative-notebook.rst:20
+msgid "Using multiple language kernels"
+msgstr ""
+
+# 8ccaa5dcc48c4ce1af5b541d84bc5402
+#: ../../source/use-cases/narrative-other.rst:2
+msgid "Narratives - Building blocks"
+msgstr ""
+
+# fd119e2d9ecb43c4814df9aa194455f7
+#: ../../source/use-cases/narrative-other.rst:10
+msgid ""
+"This section presents some examples of integrating different projects "
+"together. These projects form the foundation of innovative services and "
+"provide building blocks for future applications."
+msgstr ""
+
+# f9eee5e4fc7445408ff13eaa508df0cf
+#: ../../source/use-cases/narrative-other.rst:17
+msgid "A Narrative about Creating Dashboards"
+msgstr ""
+
+# f4349de4a38643859d8c319858ea9a86
+#: ../../source/use-cases/narrative-other.rst:18
+msgid "A Narrative about Thebe"
+msgstr ""
+
+# 7f4210300d32495db6891fdfb61bce00
+#: ../../source/use-cases/narrative-other.rst:19
+msgid "A Narrative about Hydrogen"
+msgstr ""
+
+# fe891df6078e4c7995cb79e020549cda
+#: ../../source/use-cases/science.rst:2
+msgid "Jupyter and Scientific Computing"
+msgstr ""
+


### PR DESCRIPTION
For #430

Configuration run at the command line to setup the `docs/.tx/config` file mapping source English `.po` files to `<lang>` translations.

```
pip install sphinx-intl transifex-client

sphinx-intl create-txconfig
sphinx-intl update -p build/locale -l en -l es
tx config mapping-bulk --project jupyter-meta-documentation --file-extension '.po' --source-file-dir source/locale/en/LC_MESSAGES --source-lang en --type PO --expression 'source/locale/<lang>/LC_MESSAGES/{filepath}/{filename}.po' --execute
```

Configuration for the GitHub - Transifex integration done in the Transifex web app:

```
filters:
  - filter_type: dir
    file_format: PO
    source_file_extension: po
    source_language: en
    source_file_dir: 'docs/source/locale/en/LC_MESSAGES'
    translation_files_expression: 'docs/source/locale/<lang>/LC_MESSAGES'
```