### PR TITLE
Specify required recommonmark version

### DIFF
--- a/docs/source/contrib_docs/getting-started.rst
+++ b/docs/source/contrib_docs/getting-started.rst
@@ -43,7 +43,7 @@ we recommend that you install the stable development version Sphinx
 (``pip install git+https://github.com/sphinx-doc/sphinx@stable``) or the
 current released version of Sphinx (``pip install sphinx``).
 
-In addition, you may need the following packages: sphinxcontrib-spelling, sphinx_rtd_theme, nbsphinx, pyenchant, recommonmark and jupyter_sphinx_theme, which can be installed via ``pip install sphinxcontrib-spelling sphinx_rtd_theme nbsphinx pyenchant recommonmark jupyter_sphinx_theme``.
+In addition, you may need the following packages: sphinxcontrib-spelling, sphinx_rtd_theme, nbsphinx, pyenchant, recommonmark 0.4.0 and jupyter_sphinx_theme, which can be installed via ``pip install sphinxcontrib-spelling sphinx_rtd_theme nbsphinx pyenchant recommonmark==0.4.0 jupyter_sphinx_theme``.
 
 If you are on Linux, you may also need to install the Enchant C library by running ``sudo apt-get install enchant``.
 


### PR DESCRIPTION
Following the installation instructions in [Testing Changes](https://jupyter.readthedocs.io/en/latest/contrib_docs/getting-started.html#testing-changes) results in the following conflict:

`ERROR: jupyter-sphinx-theme 0.0.6 has requirement recommonmark==0.4.0, but you'll have recommonmark 0.6.0 which is incompatible.`

Jupyter Sphinx Theme requires [recommonmark 0.4.0](https://github.com/jupyter/jupyter-sphinx-theme/blob/master/requirements.txt). This adds that dependency to the installation instructions.