### PR TITLE
Attempt to provide documentation for JUPYTER_DATA_DIR

### DIFF
--- a/docs/source/projects/jupyter-directories.rst
+++ b/docs/source/projects/jupyter-directories.rst
@@ -10,7 +10,9 @@ Jupyter stores different files (i.e. configuration, data, runtime) in a
 number of different locations. Environment variables may be set to
 customize for the location of each file type.
 
-Jupyter separates data files (nbextensions, kernelspecs) from runtime files (logs, pid files, connection files) from configuration (config files, custom.js).
+Jupyter separates **data files** (nbextensions, kernelspecs)
+from **runtime files** (logs, pid files, connection files)
+from **configuration** (config files, custom.js).
 
 .. _config_dir:
 
@@ -85,7 +87,8 @@ search path. For example, kernel specs are in ``kernels`` subdirectories.
 
 .. _jupyter_data_dir:
 
-The config directory for Jupyter data files, which non-transient, non-configuration files. Examples include kernelspecs or nbextensions.
+The config directory for Jupyter data files, which contain non-transient, non-configuration files.
+Examples include kernelspecs, nbextensions, or voila templates.
 
 .. envvar:: JUPYTER_DATA_DIR
 

--- a/docs/source/projects/jupyter-directories.rst
+++ b/docs/source/projects/jupyter-directories.rst
@@ -10,6 +10,8 @@ Jupyter stores different files (i.e. configuration, data, runtime) in a
 number of different locations. Environment variables may be set to
 customize for the location of each file type.
 
+Jupyter separates data files (nbextensions, kernelspecs) from runtime files (logs, pid files, connection files) from configuration (config files, custom.js).
+
 .. _config_dir:
 
 Configuration files
@@ -41,11 +43,15 @@ To list the config directories currrently being used you can run the below comma
 
     jupyter --paths
 
+The following command shows the config directory specifically:::
 
-.. _jupyter_path:
+    jupyter --config-dir
 
 Data files
 ----------
+
+.. _jupyter_path:
+
 
 Jupyter uses a search path to find installable data files, such as
 :ref:`kernelspecs <kernelspecs>` and notebook extensions. When searching for
@@ -61,7 +67,7 @@ search path. For example, kernel specs are in ``kernels`` subdirectories.
    search path. :envvar:`JUPYTER_PATH` should contain a series of directories,
    separated by ``os.pathsep`` (``;`` on Windows, ``:`` on Unix).
    Directories given in :envvar:`JUPYTER_PATH` are searched before other
-   locations.
+   locations. This is used in addition to other entries, rather than replacing any.
 
 +-------------------------------+----------------------------+----------------------------+
 | Linux (& other free desktops) | Mac                        | Windows                    |
@@ -76,6 +82,22 @@ search path. For example, kernel specs are in ``kernels`` subdirectories.
 | ``/usr/local/share/jupyter``                               | ``%PROGRAMDATA\jupyter``   |
 | ``/usr/share/jupyter``                                     |                            |
 +-------------------------------+----------------------------+----------------------------+
+
+.. _jupyter_data_dir:
+
+The config directory for Jupyter data files, which non-transient, non-configuration files. Examples include kernelspecs or nbextensions.
+
+.. envvar:: JUPYTER_DATA_DIR
+
+   Set this environment variable to use a particular directory, other than the default, as the user data directory. 
+
+As mentioned above, to list the config directories currently being used you can run the below command from the :term:`command line`::
+
+   jupyter --paths
+
+The following command shows the data directory specificially:::
+
+   jupyter --data-dir
 
 .. _jupyter_runtime_dir:
 
@@ -96,12 +118,22 @@ An environment variable may also be used to set the runtime directory.
 
    Set this to override where Jupyter stores runtime files.
 
+As mentioned above, to list the config directories currently being used you can run the below command from the :term:`command line`::
+
+   jupyter --paths
+
+The following command shows the runtime directory specifically:::
+
+   jupyter --runtime-dir
+
 Summary
 -------
 
 :envvar:`JUPYTER_CONFIG_DIR` for config file location
 
 :envvar:`JUPYTER_PATH` for datafile directory locations
+
+:envvar:`JUPYTER_DATA_DIR` for data file location
 
 :envvar:`JUPYTER_RUNTIME_DIR` for runtime file location
 


### PR DESCRIPTION
See: https://github.com/jupyter/jupyter/issues/449

I tried to copy what was said here by Min: https://github.com/jupyter/jupyter_core/issues/46#issuecomment-131945136

and here:
https://jupyter.readthedocs.io/en/latest/projects/jupyter-command.html#jupyter-command

and here:
https://stackoverflow.com/questions/47660483/jupyter-path-in-environment-variables-not-working

That being said I don't actually understand the difference between `JUPYTER_DATA_DIR` and `JUPYTER_PATH`, so I wasn't able to explain the difference.

That's actually how I wound up here -- I was googling for a clear explanation of what `JUPYTER_DATA_DIR` did and couldn't find it. 