### PR TITLE
adding circleci docs preview to builds

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+0/html/index.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2
+jobs:
+  docs:
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      - checkout
+
+      # Restore cached files to speed things up
+      - restore_cache:
+          keys:
+            - cache-pip
+      - run: pip install --user -e .
+      - run: pip install --user -r docs/doc-requirements.txt
+      - run: pip install --user sphinx_rtd_theme
+      
+      # Cache some files for a speedup in subsequent builds
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+      # Build the docs
+      - run:
+          name: Build docs to store
+          command: |
+            cd docs
+            make html
+      
+      # Tell Circle to store the documentation output in a folder that we can access later
+      - store_artifacts:
+          path: docs/build/html/
+          destination: html
+
+# Tell CircleCI to use this workflow when it builds the site
+workflows:
+  version: 2
+  default:
+    jobs:
+      - docs

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,0 +1,5 @@
+sphinx>=1.6
+sphinx-intl
+recommonmark==0.4.0
+nbsphinx
+jupyter_sphinx_theme==0.0.6

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,8 +3,4 @@ dependencies:
   - python=3.7
   - sphinx_rtd_theme
   - pip:
-      - sphinx>=1.6
-      - sphinx-intl
-      - recommonmark==0.5.0
-      - nbsphinx
-      - jupyter_sphinx_theme==0.0.6
+      - -r doc-requirements.txt


### PR DESCRIPTION
This does a few minor docs updates:

* Pins recommonmark to 0.4 because pip installs were erroring with a version conflict
* Factors out the pip requirements into their own `doc-requirements.txt` file so that we can re-use them in integration
* Adds circleci doc previews w/ artifacts
* Adds a file that *should* work with a bot to automatically print doc preview links using [this useful bot](https://github.com/larsoner/circleci-artifacts-redirector)