### PR TITLE
Centralized calendar for Project Jupyter

### DIFF
--- a/docs/source/community/community-call-notes/2019-september.md
+++ b/docs/source/community/community-call-notes/2019-september.md
@@ -1,0 +1,54 @@
+# Jupyter Community Call
+
+## September 24th, 2029
+
+**Date:** September 24, 2019, at 9am Pacific (your [timezone](https://arewemeetingyet.com/Los%20Angeles/2019-09-24/09:00/Jupyter%20Community%20Call))
+
+**Link:** [Youtube Video](https://youtu.be/so9F-Ha4q4U)
+
+## Purpose
+
+Think of it as a monthly, virtual JupyterCon. It’s a place to announce and share fun things happening in the Jupyter community.
+
+For more discussion on the format of these calls, see the thread [here](https://discourse.jupyter.org/t/reviving-the-all-jupyter-team-meetings/423).
+
+## Short reports, celebrations, shout-outs
+
+This is a place to make *short* announcements (without a need for discussion). 
+
+* [Co-locating a Jupyter Server and Dask Scheduler _By Matthew Rocklin](https://blog.dask.org/2019/09/13/jupyter-on-dask) [name=tonyfast]
+
+* [Language server protocol](https://github.com/jupyterlab/jupyterlab/issues/2163)
+  * [current work on jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp) [name=krassowski]
+  * [wip binder](https://mybinder.org/v2/gh/bollwyvl/jupyterlab-lsp/add-traitlets-proxy?urlpath=lab%2Ftree%2Fexamples%2FPython.ipynb) [name=bollwyvl]
+
+## Agenda Items
+
+Add agenda items here **before** the meeting. We will reorganize the agenda so that it fits in the 60m meeting slot.
+
+* **[importing notebooks with `importnb`](https://gist.github.com/tonyfast/15c6ac8f005a5522291f08d95619e085)** [name=tonyfast]
+
+  > _[`importnb`](https://github.com/deathbeds/importnb) provides easy, flexible reuse of IPython notebooks from other notebooks, `.py` scripts and libraries, and even the command line._
+
+* **[🤖 RobotLab: a one-click Jupyter and Robot Framework environment](https://github.com/robots-from-jupyter/robotlab)** [name=bollwyvl]
+
+  > _`RobotLab` was built to support a workshop introducing [acceptance-test-driven](https://en.wikipedia.org/wiki/Acceptance_testing) development and robot process automation with [robotkernel](https://github.com/robots-from-jupyter/robotkernel), a [Robot Framework](https://robotframework.org/) kernel, in JupyterLab. It is built with [conda](https://github.com/conda/conda), [constructor](https://github.com/conda/constructor) and [azure pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines). You can use the [installers](https://github.com/robots-from-jupyter/robotlab/releases/tag/v2019.9.0) to learn how you can use Robot Framework and Jupyter, or adapt its pipeline to produce your own, cross-platform installers_
+  > 
+
+* **Project Drawdown** [name=dgentry]
+  > _Project Drawdown is a global research organization that identifies, reviews, and analyzes the most viable solutions to climate change, and shares these findings with the world._
+  > _We'll show current state of climate solution models using Voila and JupyterHub, and ask for suggestions about git operation driven from the Notebook._
+
+
+
+## Attendees
+
+
+- Zach     | Jupyter Cal Poly          | @Zsailer        |
+- Denton   | Project Drawdown          | @DentonGentry   |
+- Nick     | GTRI                      | @nrbgt          |
+- Chico Venancio | BMC Group K. K.     | @chicocvenancio |
+- Tony Fast | Quansight | @tonyfast |
+- Wayne Decatur | Upstate Medical | @fomightez |
+- Kevin Bates | IBM | @kevin-bates |
+- Carol | Jupyter | @willingc |

--- a/docs/source/community/community-call-notes/2019-september.md
+++ b/docs/source/community/community-call-notes/2019-september.md
@@ -1,6 +1,6 @@
 # Jupyter Community Call
 
-## September 24th, 2029
+## September 24th, 2019
 
 **Date:** September 24, 2019, at 9am Pacific (your [timezone](https://arewemeetingyet.com/Los%20Angeles/2019-09-24/09:00/Jupyter%20Community%20Call))
 

--- a/docs/source/community/community-call-notes/index.rst
+++ b/docs/source/community/community-call-notes/index.rst
@@ -11,6 +11,7 @@ The Jupyter Community Call is an open video call. Think of this as a "monthly, v
 .. toctree::
    :maxdepth: 1
 
+   September 2019 <2019-september.md>
    August 2019 <2019-august.md>
    June 2019 <2019-june.md>   
    May 2019 <2019-may.md>

--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -14,12 +14,20 @@ may change, and we will do our best to keep it up to date.
 Monthly Meetings
 ----------------
 
+This following calendar shows the various meetings and events from Jupyter sub-projects:
+
+.. raw:: html
+
+    <iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=ZGdwZDM2ZjQzZXQ5Z3JhYm42dGRpbjZwbWNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=bTNoZWs2OWRhZzczODF1bXQ4a2NqZDc1dTRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=YXFwa3VpNXE3b2kzMnBrOXRjcDUzaG5zc2NAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=cGlhaGluZWpqcjZzc3ZpOGlrbWpqb3A2cm9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23AD1457&amp;color=%23F6BF26&amp;color=%23616161&amp;color=%239E69AF&amp;showTabs=1&amp;showCalendars=1&amp;showDate=1&amp;showNav=1&amp;showTitle=0" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+
 The core developers of various Jupyter sub-projects have regular meetings to
 discuss and demo what they have been working on, discuss future plans,
 and bootstrap conversation. These meetings are public and you are welcome to join remotely.
 
 Each team has their own processes around logistics and planning for the team meetings. The
 following pages should help you find the information for each.
+
 
 **All-Jupyter Community Calls** happen on the last Tuesday of every month, and are focused around demonstrations
 and sharing information across all of the Jupyter projects. 


### PR DESCRIPTION
This PR adds a single google calendar view for Jupyter-related meetings and events to the "Community" page. It sources those events from each Jupyter subproject's calendar.

To be transparent, I had to create two separate new calendars: "JupyterLab" and "Project Jupyter" (for governance, community calls, and jupyter server meetings). I'll move ownership of those calendars to members of those subprojects.   

Here's a preview of the full calendar:


<img width="813" alt="Screen Shot 2019-10-22 at 10 43 13 AM" src="https://user-images.githubusercontent.com/2791223/67314187-1f229d00-f4b9-11e9-8aac-a1186c3654cb.png">

As those calendars change, this view will source that infor and update :tada:


This also adds the meeting minutes from last month's community call.


Ping @willingc @choldgraf @fperez @ellisonbg @jasongrout @mpacer @rgbkrk @blink1073 @SylvainCorlay @damianavila @minrk @betatim.

Spread the word!