### PR TITLE
Fix broken links and warnings

### DIFF
--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -78,4 +78,4 @@ Indices and tables
    `Jupyter mailing list <https://groups.google.com/forum/#!forum/jupyter>`_, General discussion of Jupyter's use
    `Jupyter in Education group <https://groups.google.com/forum/#!forum/jupyter-education>`_, Discussion of Jupyter's use in education
    `NumFocus <http://www.numfocus.org>`_, "Promotes world-class, innovative, open source scientific software"
-   `Donate to Project Jupyter <https://jupyter.org/donate.html>`_, Please contribute to open science collaboration and sustainability
+   `Donate to Project Jupyter <https://numfocus.salsalabs.org/donate-to-jupyter/index.html>`_, Please contribute to open science collaboration and sustainability

--- a/docs/source/contrib_docs/doc-tools.rst
+++ b/docs/source/contrib_docs/doc-tools.rst
@@ -9,7 +9,7 @@ Packages
 For user documentation, contributor guides, and communications content, we
 use:
 
-- `Sphinx <http://www.sphinx-doc.org/en/stable>`_
+- `Sphinx <https://www.sphinx-doc.org/en/master/contents.html>`_
 
 For developer API documentation (especially for JupyterLab js repos), we use:
 

--- a/docs/source/developer-docs/contrib_guide_vuln.rst
+++ b/docs/source/developer-docs/contrib_guide_vuln.rst
@@ -3,6 +3,6 @@ Reporting a Vulnerability
 =========================
 
 If you believe you've found a security vulnerability in a Jupyter project,
-please report it to [security@ipython.org](mailto:security@ipython.org). If you
-prefer to encrypt your security reports, you can use [this PGP public
-key](https://jupyter-notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc).
+please report it to `security@ipython.org <mailto:security@ipython.org>`_. If you
+prefer to encrypt your security reports, you can use `this PGP public
+key <https://jupyter-notebook.readthedocs.io/en/stable/_downloads/1d303a645f2505a8fd283826fafc9908/ipython_security.asc>`_.

--- a/docs/source/developer-docs/releasing.rst
+++ b/docs/source/developer-docs/releasing.rst
@@ -1,4 +1,4 @@
-.. _releasing:
+.. _releasing-Jupyter-Project:
 
 ==============================================
 Basic template for releasing a Jupyter project

--- a/docs/source/development_guide/releasing.rst
+++ b/docs/source/development_guide/releasing.rst
@@ -1,4 +1,4 @@
-.. _releasing:
+.. _releasing-IPython:
 
 Steps for Releasing IPython
 ===========================

--- a/docs/source/development_guide/sphinx_directive.rst
+++ b/docs/source/development_guide/sphinx_directive.rst
@@ -177,7 +177,7 @@ the inputs::
 Likewise, you can set ``:doctest:`` or ``:verbatim:`` to apply these
 settings to the entire block.  For example,
 
-.. code:: python3
+.. code:: bash
 
    In [9]: cd mpl/examples/
    /home/jdhunter/mpl/examples

--- a/docs/source/use-cases/enterprise.rst
+++ b/docs/source/use-cases/enterprise.rst
@@ -29,10 +29,7 @@ Example Use-Cases
 
 - `PayPal Notebooks: Data science and machine learning at scale, powered by Jupyter <https://conferences.oreilly.com/jupyter/jup-ny/public/schedule/detail/68405>`_ (JupyterCon 2018 · `video <https://youtu.be/KVGrACWVUgE>`_)
 
-- Bloomberg BQuant platform:
-
-  - `Part 1: Overview <https://adrian-gao.com/2018/02/bloomberg-bqnt-1/>`_
-  - `Part 2: The BQNT App <https://adrian-gao.com/2018/04/bloomberg-bqnt-2/>`_
+- `Bloomberg BQuant platform <https://mingze-gao.com/posts/bloomberg-bquant/>`_
 
 - `Jupyter & Python in the corporate LAN <https://medium.com/@olivier.borderies/jupyter-python-in-the-corporate-lan-109e2ffde897>`_
 


### PR DESCRIPTION
This fixes some of the broken links (found with `make linkcheck`) and two warnings from `make html`:
* `WARNING: duplicate label releasing`
* `WARNING: Could not lex literal_block as "python3". Highlighting skipped.`