### PR TITLE
Included description of the JUPYTER_CONFIG_PATH

### DIFF
--- a/docs/source/use/jupyter-directories.rst
+++ b/docs/source/use/jupyter-directories.rst
@@ -26,6 +26,18 @@ Config files are stored by default in the :file:`~/.jupyter` directory.
    Set this environment variable to use a particular directory, other than the
    default, for Jupyter config files.
 
+Besides the :envvar:`JUPYTER_CONFIG_DIR`, additional directories to search can be 
+specified through :envvar:`JUPYTER_CONFIG_PATH`.
+
+.. envvar:: JUPYTER_CONFIG_PATH
+   Set this environment variable to provide extra directories for the config search path.
+   :envvar:`JUPYTER_CONFIG_PATH` should contain a series of directories, seperated by
+   `` os.pathsep`` (``;`` on Windows, ``:`` on Unix).
+
+An example of where the :envvar:`JUPYTER_CONFIG_PATH` can be set is if notebook or server extensions are 
+installed in a custom prefix. Since notebook and server extensions are automatically enabled through configuration files, 
+automatic enabling will only work if the custom prefix's ``etc/jupyter`` directory is added to the Jupyter config search path.
+
 Besides the user config directory mentioned above, Jupyter has a search
 path of additional locations from which a config file will be loaded. Here's a
 table of the locations to be searched, in order of preference:
@@ -35,6 +47,8 @@ table of the locations to be searched, in order of preference:
 +==============================+============================+
 |                 :envvar:`JUPYTER_CONFIG_DIR`              |
 +------------------------------+----------------------------+
+|                 :envvar:`JUPYTER_CONFIG_PATH`             |
++-----------------------------------------------------------+
 |                ``{sys.prefix}/etc/jupyter/``              |
 +------------------------------+----------------------------+
 | ``/usr/local/etc/jupyter/``  | ``%PROGRAMDATA%\jupyter\`` |
@@ -76,6 +90,8 @@ search path. For example, kernel specs are in ``kernels`` subdirectories.
 +===============================+============================+============================+
 | :envvar:`JUPYTER_PATH`                                                                  |
 +-------------------------------+----------------------------+----------------------------+
+| :envvar:`JUPYTER_DATA_DIR`    | :envvar:`JUPYTER_DATA_DIR` | :envvar:`JUPYTER_DATA_DIR` |
+| or (if not set)               | or (if not set)            | or (if not set)            |
 | ``~/.local/share/jupyter/``   | ``~/Library/Jupyter``      | ``%APPDATA%\jupyter``      |
 | (respects ``$XDG_DATA_HOME``) |                            |                            |
 +-------------------------------+----------------------------+----------------------------+
@@ -133,6 +149,8 @@ Summary
 -------
 
 :envvar:`JUPYTER_CONFIG_DIR` for config file location
+
+:envvar:`JUPYTER_CONFIG_PATH` for config file locations
 
 :envvar:`JUPYTER_PATH` for datafile directory locations
 


### PR DESCRIPTION
Automatic enabling of notebook and server extensions is done through configuration files that are created when installing packages (see https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html#Automatically-enabling-a-server-extension-and-nbextension). When installing packages in non-default locations, automatic enabling does not work unless these non-default locations are added to Jupyter's config search path.

Fortunately, the `JUPYTER_CONFIG_PATH` environment variable allows us to do so, but it was undocumented so far. Here, I document it, as well as its possible use. 

I've also included a small correction to the table for the datafiles. The table shows for linux that e.g. the `~/.local/share/jupyter/` is one of the search paths, however, that is only the default if JUPYTER_DATA_DIR is _not_ set.