### PR TITLE
Fix typo and formatting in jupyter-directories.rst

### DIFF
--- a/docs/source/use/jupyter-directories.rst
+++ b/docs/source/use/jupyter-directories.rst
@@ -30,6 +30,7 @@ Besides the :envvar:`JUPYTER_CONFIG_DIR`, additional directories to search can b
 specified through :envvar:`JUPYTER_CONFIG_PATH`.
 
 .. envvar:: JUPYTER_CONFIG_PATH
+
    Set this environment variable to provide extra directories for the config search path.
    :envvar:`JUPYTER_CONFIG_PATH` should contain a series of directories, seperated by
    `` os.pathsep`` (``;`` on Windows, ``:`` on Unix).
@@ -59,7 +60,7 @@ To list the config directories currrently being used you can run the below comma
 
     jupyter --paths
 
-The following command shows the config directory specifically:::
+The following command shows the config directory specifically::
 
     jupyter --config-dir
 
@@ -114,7 +115,7 @@ As mentioned above, to list the config directories currently being used you can 
 
    jupyter --paths
 
-The following command shows the data directory specificially:::
+The following command shows the data directory specifically::
 
    jupyter --data-dir
 
@@ -141,7 +142,7 @@ As mentioned above, to list the config directories currently being used you can 
 
    jupyter --paths
 
-The following command shows the runtime directory specifically:::
+The following command shows the runtime directory specifically::
 
    jupyter --runtime-dir
 


### PR DESCRIPTION
Fix three little things

- specificially -> specifically
- triple-colon -> double-colon
- add  missing blank line

to improve the look of this page:

- https://jupyter.readthedocs.io/en/latest/use/jupyter-directories.html