### PR TITLE
Added programming language classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,11 @@ setup_args = dict(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
     ],
 )
 


### PR DESCRIPTION
Added programming language classifiers to specify Python minor release compatibility for versions 3.6, 3.7, 3.8, and 3.9.