### PR TITLE
Add nbclient to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup_args = dict(
         'notebook',
         'qtconsole',
         'jupyter-console',
+        'nbclient',
         'nbconvert',
         'ipykernel',
         'ipywidgets',


### PR DESCRIPTION
The latest version of nbclient, released this morning, includes a [simple command-line interface](https://nbclient.readthedocs.io/en/latest/client.html#using-a-command-line-interface) for running notebooks. It makes the most basic use case as simple as:

```sh
jupyter execute notebook.ipynb
```

My view is that such a tool should be available to beginners. A single, initial install should allow users to run notebooks from the shell, without having to learn the complexities of nbconvert or having to discover and install papermill.

For that reason, I'm proposing you add nbclient to the dependencies of this package.
