### PR TITLE
Simplify TOC that doesn't need to be so deep

### DIFF
--- a/docs/source/projects/content-projects.rst
+++ b/docs/source/projects/content-projects.rst
@@ -36,7 +36,7 @@ including their technical components and how they work and relate to one another
 
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    user-interfaces
    kernels


### PR DESCRIPTION
The TOC here doesn't need that second level, and I think it distracts. This trim will give the page a little more economy.
![Screenshot from 2021-11-09 05-20-02](https://user-images.githubusercontent.com/9993/140931387-1de806d3-288b-4a6c-9457-1f3911411b91.png)
