### PR TITLE
ENH: Trim nav labels

### DIFF
--- a/docs/source/projects/content-projects.rst
+++ b/docs/source/projects/content-projects.rst
@@ -1,8 +1,8 @@
 .. _content-projects:
 
-================
-Jupyter Projects
-================
+========
+Projects
+========
 
 The Jupyter community is composed of several sub-communities and projects. These
 are organized around particular use-cases, users, or other aspects of the Jupyter

--- a/docs/source/use/using.rst
+++ b/docs/source/use/using.rst
@@ -1,6 +1,6 @@
-===================
-Using Jupyter Tools
-===================
+=====
+Usage
+=====
 
 Information relevant to using the various tools in the Jupyter
 ecosystem.


### PR DESCRIPTION
The usage and projects labels are, in my opinion, too long to appear in a tight nav. They also repeat the word "Jupyter," which isn't necessary in that context due to the masthead logo just a few pixels to the left.