### PR TITLE
Remove redundant install section from usage page

### DIFF
--- a/docs/source/use/using.rst
+++ b/docs/source/use/using.rst
@@ -18,15 +18,6 @@ ecosystem.
    advanced/content-advanced
 
 
-Installation
-============
-
-.. toctree::
-   :maxdepth: 2
-
-   /install
-
-
 Use and Configure
 =================
 


### PR DESCRIPTION
This information is already available in the "Get Started" section. It should live in one and only one place. 