### PR TITLE
DOCS: Add nox to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,65 @@
 
 Jupyter metapackage for installation and docs.
 
-## Running the docs locally
-First navigate to the `/docs` directory and create a `conda` environment:
+## Documentation setup
+
+This documentation uses the [Sphinx](https://sphinx-doc.org) documentation engine.
+
+The documentation is located in the `docs/source` folder. When you build the documentation, it will be placed in the `docs/build` folder.
+It is written in a combination of [reStructuredText](https://docutils.sourceforge.io/rst.html) and [MyST Markdown](https://myst-parser.readthedocs.io/).
+
+## Build the documentation locally
+
+There are a few ways to build the documentation, see below for instructions:
+
+### Build the documentation automaticlaly with `nox`
+
+The easiest way to build the documentation locally is by using the [`nox` command line tool](https://nox.thea.codes/). This tool makes it easy to automate commands in a repository, and we have included a `docs` command to quickly install the dependencies and build the the documentation.
+
+To build and preview the site locally, follow these steps:
+
+1. **Clone this repository**.
+   
+   ```console
+   $ git clone https://github.com/jupyter/jupyter
+   $ cd jupyter
+   ```
+2. **Install `nox`**
+
+   ```console
+   $ pip install nox
+   ```
+3. **Run the `docs` command**
+   
+   ```console
+   $ nox -s docs
+   ```
+
+This will install the needed dependencies in a virtual environment using `pip`.
+It will then place the documentation in the `docs/build/html` folder.
+You may explore these HTML files in order to preview the site.
+
+#### Create a live server to automatically preview changes
+
+There is another `nox` command that will do the above, and also create a live server that watches your source files for changes, and auto-builds the website any time a change is made.
+
+To start this live server, use the following `nox` command:
+
+```console
+$ nox -s docs-live
+```
+
+When the build is finished, go to the URL that is displayed. It should show a live preview of your doucmentation.
+
+To stop serving the website, press **`Ctrl`**-`C` in your terminal
+
+### Build the documentation manually
+
+To build the documentation manually, follow these steps:
+
+First, install [the `miniconda` Python distribution](https://conda.io/miniconda.html).
+
+Next, navigate to the `/docs` directory and create a `conda` environment:
 
 ```bash
 conda env create -f environment.yml  
@@ -17,7 +74,7 @@ Activate the environment:
 source activate jupyter_docs  
 ```
 
-Build the docs:
+**Build the docs** using Sphinx with the following commands:
 
 ```bash
 make clean  
@@ -25,6 +82,7 @@ make html
 ```
 
 The docs will be built in `build/html`. They can be viewed by opening `build/html/index.html` or starting an HTTP server and navigating to `0.0.0.0:8000` in your web browser.
+
 ```bash
 python3 -m http.server
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Jupyter metapackage for installation and docs.
 
-## Documentation setup
+## Documentation structure
 
 This documentation uses the [Sphinx](https://sphinx-doc.org) documentation engine.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ extensions = [
     'sphinx_panels'
 ]
 
-panels_add_boostrap_css = False
+panels_add_bootstrap_css = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,7 +4,6 @@
 for the Jupyter ecosystem. It has a collection of resources to navigate the tools
 and communities in this ecosystem, and to help you get started.
 
-
 ## Start Here
 
 ```{list-table}

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,24 @@
+import nox
+
+nox.options.reuse_existing_virtualenvs = True
+
+build_command = ["-b", "html", "docs/source", "docs/build/html"]
+
+@nox.session(python="3.9")
+def docs(session):
+    session.install("-r", "docs/doc-requirements.txt")
+    session.run("sphinx-build", *build_command)
+
+@nox.session(name="docs-live", python="3.9")
+def docs_live(session):
+    session.install("-r", "docs/doc-requirements.txt")
+    session.install("sphinx-autobuild")
+
+    AUTOBUILD_IGNORE = [
+        "docs/build",
+    ]
+    cmd = ["sphinx-autobuild"]
+    for folder in AUTOBUILD_IGNORE:
+        cmd.extend(["--ignore", f"*/{folder}/*"])
+    cmd.extend(build_command)
+    session.run(*cmd)


### PR DESCRIPTION
This adds a `noxfile.py` as well as instructions for how to use `nox` to build the documentation locally. This should make it easier for folks to get up and running, especially if they aren't comfortable with `conda`.