### PR TITLE
Update the links to subproject documentation

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -71,7 +71,7 @@ JupyterHub
 ^^^^^^
 * [JupyterHub](http://jupyterhub.readthedocs.io/en/latest)
 * [Configurable HTTP proxy](https://github.com/jupyterhub/configurable-http-proxy)
-* Authenticators: [LDAP](https://github.com/jupyterhub/ldapauthenticator), [OAuth](https://oauthenticator.readthedocs.io/en/latest/), [Native](https://github.com/jupyterhub/nativeauthenticator)
+* Authenticators: [LDAP](https://github.com/jupyterhub/ldapauthenticator), [OAuth](https://oauthenticator.readthedocs.io/en/latest/), [Native](https://native-authenticator.readthedocs.io/en/latest/), [LTI](https://ltiauthenticator.readthedocs.io/en/latest/)
 * Spawners: [sudo](https://github.com/jupyterhub/sudospawner), [Docker](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/), [Kubernetes](https://jupyterhub-kubespawner.readthedocs.io/en/latest/)
 * [Zero to JupyterHub](https://zero-to-jupyterhub.readthedocs.io/en/latest/)
 * [All JupyterHub Projects...](https://github.com/jupyterhub)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -60,16 +60,16 @@ Below is a list of documentation for major parts of the Jupyter ecosystem.
 User Interfaces
 ^^^^^^
 * [JupyterLab](https://github.com/jupyterlab/jupyterlab)
-* [Jupyter Notebook](http://jupyter-notebook.readthedocs.io/en/latest/)
+* [Jupyter Notebook](https://jupyter-notebook.readthedocs.io/en/latest/)
 * [nbclassic](https://github.com/jupyterlab/nbclassic)
-* [Jupyter Console](http://jupyter_console.readthedocs.io/en/latest)
+* [Jupyter Console](https://jupyter_console.readthedocs.io/en/latest)
 * [Qt console](https://qtconsole.readthedocs.io/en/stable)
 * [Voilà](https://voila.readthedocs.io/)
 
 ---
 JupyterHub
 ^^^^^^
-* [JupyterHub](http://jupyterhub.readthedocs.io/en/latest)
+* [JupyterHub](https://jupyterhub.readthedocs.io/en/latest)
 * [Configurable HTTP proxy](https://github.com/jupyterhub/configurable-http-proxy)
 * Authenticators: [LDAP](https://github.com/jupyterhub/ldapauthenticator), [OAuth](https://oauthenticator.readthedocs.io/en/latest/), [Native](https://native-authenticator.readthedocs.io/en/latest/), [LTI](https://ltiauthenticator.readthedocs.io/en/latest/)
 * Spawners: [sudo](https://github.com/jupyterhub/sudospawner), [Docker](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/), [Kubernetes](https://jupyterhub-kubespawner.readthedocs.io/en/latest/)
@@ -79,17 +79,17 @@ JupyterHub
 ---
 Working with Notebooks
 ^^^^^^
-* [nbclient](http://nbclient.readthedocs.io/en/latest) - execution
-* [nbconvert](http://nbconvert.readthedocs.io/en/latest) - conversion
-* [nbformat](http://nbformat.readthedocs.io/en/latest) - formatting
-* [nbviewer](https://github.com/jupyter/nbviewer) - viewing
+* [nbclient](https://nbclient.readthedocs.io/en/latest/) - execution
+* [nbconvert](https://nbconvert.readthedocs.io/en/latest/) - conversion
+* [nbviewer](https://github.com/jupyter/nbviewer/) - viewing
 * [nbdime](https://nbdime.readthedocs.io/) - comparing and merging
-* [nbgrader](http://nbgrader.readthedocs.io/en/latest) - grading
+* [nbgrader](https://nbgrader.readthedocs.io/en/latest/) - grading
+* [nbformat](https://nbformat.readthedocs.io/en/latest/) - programmatic modification, format validation
 
 ---
 Kernels
 ^^^^^^
-* [IPython](https://ipython.readthedocs.io/en/stable)
+* [IPython](https://ipython.readthedocs.io/en/stable/)
 * [IRkernel](https://irkernel.github.io)
 * [IJulia](https://github.com/JuliaLang/IJulia.jl)
 * [Xeus kernels](https://xeus.readthedocs.io/en/latest/)
@@ -98,16 +98,17 @@ Kernels
 ---
 IPython
 ^^^^^^
-* [IPython](http://ipython.readthedocs.io/en/stable)
-* [ipykernel](https://ipython.readthedocs.io/en/stable)
-* [ipyparallel](https://ipyparallel.readthedocs.io/en/latest)
-* [traitlets](http://traitlets.readthedocs.io/en/stable)
+* [IPython](https://ipython.readthedocs.io/en/stable/)
+* [ipykernel](https://ipython.readthedocs.io/en/stable/)
+* [ipyparallel](https://ipyparallel.readthedocs.io/en/latest/)
+* [traitlets](https://traitlets.readthedocs.io/en/stable/)
 
 ---
-Architecture
+Architecture and Specification
 ^^^^^^
-* [jupyter-client](http://jupyter-client.readthedocs.io/en/latest)
-* [jupyter-core](http://jupyter-core.readthedocs.io/en/latest)
+* [nbformat](https://nbformat.readthedocs.io/en/latest/api.html) - Jupyter Notebook Format specification
+* [jupyter-client](https://jupyter-client.readthedocs.io/en/latest/) - Jupyter Messaging Protocol specification
+* [jupyter-core](https://jupyter-core.readthedocs.io/en/latest/)
 * [jupyter-server](https://jupyter-server.readthedocs.io/)
 * [jupyterlab-server](https://jupyterlab-server.readthedocs.io/en/stable/)
 
@@ -187,7 +188,7 @@ reference/content-reference
 [jupyter/help repo](https://github.com/jupyter/help), Start here for help and support questions
 [Jupyter mailing list](https://groups.google.com/forum/#!forum/jupyter), General discussion of Jupyter's use
 [Jupyter in Education group](https://groups.google.com/forum/#!forum/jupyter-education), Discussion of Jupyter's use in education
-[NumFocus](http://www.numfocus.org), "Promotes world-class, innovative, open source scientific software"
+[NumFocus](https://www.numfocus.org), "Promotes world-class, innovative, open source scientific software"
 [Donate to Project Jupyter](https://numfocus.salsalabs.org/donate-to-jupyter/index.html), Please contribute to open science collaboration and sustainability
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -61,7 +61,8 @@ User Interfaces
 ^^^^^^
 * [JupyterLab](https://github.com/jupyterlab/jupyterlab)
 * [Jupyter Notebook](http://jupyter-notebook.readthedocs.io/en/latest/)
-* [Jupyter console](http://jupyter_console.readthedocs.io/en/latest)
+* [nbclassic](https://github.com/jupyterlab/nbclassic)
+* [Jupyter Console](http://jupyter_console.readthedocs.io/en/latest)
 * [Qt console](https://qtconsole.readthedocs.io/en/stable)
 * [Voilà](https://voila.readthedocs.io/)
 
@@ -69,27 +70,23 @@ User Interfaces
 JupyterHub
 ^^^^^^
 * [JupyterHub](http://jupyterhub.readthedocs.io/en/latest)
-* [configurable HTTP proxy](https://github.com/jupyter/configurable-http-proxy)
-* [dockerspawner](https://github.com/jupyter/dockerspawner)
-* [ldapauthenticator](https://github.com/jupyter/ldapauthenticator)
-* [oauthenticator](https://github.com/jupyter/oauthenticator)
-* [sudospawner](https://github.com/jupyter/sudospawner)
+* [configurable HTTP proxy](https://github.com/jupyterhub/configurable-http-proxy)
+* [dockerspawner](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/)
+* [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)
+* [oauthenticator](https://oauthenticator.readthedocs.io/en/latest/)
+* [sudospawner](https://github.com/jupyterhub/sudospawner)
+* [Zero to JupyterHub](https://zero-to-jupyterhub.readthedocs.io/en/latest/)
+* [All JupyterHub Projects...](https://github.com/jupyterhub)
 
 ---
-Education
+Working with Notebooks
 ^^^^^^
-* [nbgrader](http://nbgrader.readthedocs.io/en/latest)
-
----
-Execution
-^^^^^^
-* [nbclient](http://nbclient.readthedocs.io/en/latest)
-
----
-Conversion and Formatting
-^^^^^^
-* [nbconvert](http://nbconvert.readthedocs.io/en/latest)
-* [nbformat](http://nbformat.readthedocs.io/en/latest)
+* [nbclient](http://nbclient.readthedocs.io/en/latest) - execution
+* [nbconvert](http://nbconvert.readthedocs.io/en/latest) - conversion
+* [nbformat](http://nbformat.readthedocs.io/en/latest) - formatting
+* [nbviewer](https://github.com/jupyter/nbviewer) - viewing
+* [nbdime](https://nbdime.readthedocs.io/) - comparing and merging
+* [nbgrader](http://nbgrader.readthedocs.io/en/latest) - grading
 
 ---
 Kernels
@@ -97,7 +94,8 @@ Kernels
 * [IPython](https://ipython.readthedocs.io/en/stable)
 * [IRkernel](https://irkernel.github.io)
 * [IJulia](https://github.com/JuliaLang/IJulia.jl)
-* [Community maintained kernels](https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages)
+* [Xeus kernels](https://xeus.readthedocs.io/en/latest/)
+* [Community maintained kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels)
 
 ---
 IPython
@@ -105,29 +103,29 @@ IPython
 * [IPython](http://ipython.readthedocs.io/en/stable)
 * [ipykernel](https://ipython.readthedocs.io/en/stable)
 * [ipyparallel](https://ipyparallel.readthedocs.io/en/latest)
+* [traitlets](http://traitlets.readthedocs.io/en/stable)
 
 ---
 Architecture
 ^^^^^^
-* [jupyter_client](http://jupyter-client.readthedocs.io/en/latest)
-* [jupyter_core](http://jupyter-core.readthedocs.io/en/latest)
-* [jupyter_server](https://jupyter-server.readthedocs.io/)
+* [jupyter-client](http://jupyter-client.readthedocs.io/en/latest)
+* [jupyter-core](http://jupyter-core.readthedocs.io/en/latest)
+* [jupyter-server](https://jupyter-server.readthedocs.io/)
+* [jupyterlab-server](https://jupyterlab-server.readthedocs.io/en/stable/)
 
 ---
 Deployment
 ^^^^^^
-* [docker-stacks](https://github.com/jupyter/docker-stacks)
-* [jupyter-sphinx-theme](https://github.com/jupyter/jupyter-sphinx-theme)
-* [kernel_gateway](http://jupyter-kernel-gateway.readthedocs.io/en/latest)
-* [nbviewer](https://github.com/jupyter/nbviewer)
-* [tmpnb](https://github.com/jupyter/tmpnb)
-* [traitlets](http://traitlets.readthedocs.io/en/stable)
+* [Docker Stacks](https://jupyter-docker-stacks.readthedocs.io/en/latest/)
+* [Kernel Gateway](https://jupyter-kernel-gateway.readthedocs.io/en/latest/)
+* [Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/)
 
 ---
 Widgets
 ^^^^^^
 * [ipywidgets](https://ipywidgets.readthedocs.io/)
 * [widget-cookiecutter](https://github.com/jupyter-widgets/widget-cookiecutter/)
+* [All Widget Projects...](https://github.com/jupyter-widgets)
 
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -70,11 +70,9 @@ User Interfaces
 JupyterHub
 ^^^^^^
 * [JupyterHub](http://jupyterhub.readthedocs.io/en/latest)
-* [configurable HTTP proxy](https://github.com/jupyterhub/configurable-http-proxy)
-* [dockerspawner](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/)
-* [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)
-* [oauthenticator](https://oauthenticator.readthedocs.io/en/latest/)
-* [sudospawner](https://github.com/jupyterhub/sudospawner)
+* [Configurable HTTP proxy](https://github.com/jupyterhub/configurable-http-proxy)
+* Authenticators: [LDAP](https://github.com/jupyterhub/ldapauthenticator), [OAuth](https://oauthenticator.readthedocs.io/en/latest/), [Native](https://github.com/jupyterhub/nativeauthenticator)
+* Spawners: [sudo](https://github.com/jupyterhub/sudospawner), [Docker](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/), [Kubernetes](https://jupyterhub-kubespawner.readthedocs.io/en/latest/)
 * [Zero to JupyterHub](https://zero-to-jupyterhub.readthedocs.io/en/latest/)
 * [All JupyterHub Projects...](https://github.com/jupyterhub)
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -106,8 +106,8 @@ IPython
 ---
 Architecture and Specification
 ^^^^^^
-* [nbformat](https://nbformat.readthedocs.io/en/latest/api.html) - Jupyter Notebook Format specification
-* [jupyter-client](https://jupyter-client.readthedocs.io/en/latest/) - Jupyter Messaging Protocol specification
+* [nbformat](https://nbformat.readthedocs.io/en/latest/api.html) - Jupyter Notebook Format
+* [jupyter-client](https://jupyter-client.readthedocs.io/en/latest/) - Jupyter Messaging Protocol
 * [jupyter-core](https://jupyter-core.readthedocs.io/en/latest/)
 * [jupyter-server](https://jupyter-server.readthedocs.io/)
 * [jupyterlab-server](https://jupyterlab-server.readthedocs.io/en/stable/)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -84,7 +84,7 @@ Working with Notebooks
 * [nbviewer](https://github.com/jupyter/nbviewer/) - viewing
 * [nbdime](https://nbdime.readthedocs.io/) - comparing and merging
 * [nbgrader](https://nbgrader.readthedocs.io/en/latest/) - grading
-* [nbformat](https://nbformat.readthedocs.io/en/latest/) - programmatic modification, format validation
+* [nbformat](https://nbformat.readthedocs.io/en/latest/) - modification and validation
 
 ---
 Kernels


### PR DESCRIPTION
https://github.com/jupyter/jupyter.github.io/pull/507 will redirect a lot of users to this site and delete /documentation page from jupyter.org. Since the subproject documentation list diverged between two sites, this PR aims to reconciliate changes and add some new subprojects which should have been added to the list some time ago.

Changes:
- merged categories _Education_ (had just nbgrader), _Execution_ (had only nbclient), and _Conversion and Formatting_ into new category _Working with Notebooks_; `jupyter.org` had it all under "Notebook Documents" but this was ambiguous
- updated links to jupyterhub projects to use its new organization name
- changed links pointing to GitHub to point to docs where appropriate
- moved nbviewer and traitlets out of Deployment and placed to more relevant categories as it was on jupyter.org and added Enterprise Gateway as it was on jupyter.org

Added links which were not on jupyter.org:
- `nbdime` since it is in https://github.com/jupyter/nbdime - it will benefit from more spotlight
- `xeus` documentation since it is now an official subproject and there are several xeus-based kernels
- `jupyterlab-server` because most people have no idea it exists and get confused about it configuration options
- `nbclassic` because IMO it is useful for people to know about it

Removed:
- https://github.com/jupyter/jupyter-sphinx-theme because it was not updated in 6 years and was absent on jupyter.org
- https://github.com/jupyter/tmpnb because it is archived and absent on jupyter.org