### PR TITLE
Mention `Teaching and Learning with Jupyter` book and jupyter4edu

### DIFF
--- a/docs/source/projects/education.rst
+++ b/docs/source/projects/education.rst
@@ -6,6 +6,9 @@ Jupyter Notebooks offer exciting and creative possibilities in education. The
 following subprojects are focused on supporting the use of Jupyter Notebook in
 a variety of educational settings.
 
+`Teaching and Learning with Jupyter <https://jupyter4edu.github.io/jupyter-edu-book/>`__
+is a book about using Jupyter in teaching and learning.
+
 .. glossary::
 
     `nbgrader <https://nbgrader.readthedocs.io/en/stable/>`__
@@ -13,3 +16,5 @@ a variety of educational settings.
         assignments.
         `Documentation <https://nbgrader.readthedocs.io/en/stable/>`__ |
         `Repo <https://github.com/jupyter/nbgrader>`__
+    `jupyter4edu <https://github.com/orgs/jupyter4edu/>`__
+        GitHub organization hosting community resources for Jupyter in education


### PR DESCRIPTION
There is https://github.com/jupyter4edu/jupyter-edu-book and https://github.com/jupyter4edu/ but those are not mentioned any where which might be the reason for little organic interactions over there.

Based on the members of organization and the fact the book workshop for book writing was sponsored by Project Jupyter I guess it is official enough but maybe someone who was involved in the project could confirm if it is fine to feature here (@willingc?)