### PR TITLE
Update kernels documentation: add xeus, jupyter-client, ipykernel

### DIFF
--- a/docs/source/projects/kernels.rst
+++ b/docs/source/projects/kernels.rst
@@ -49,16 +49,6 @@ implementation of kernels for Jupyter and provides a number of kernels such as
         `Documentation <https://xeus.readthedocs.io/en/latest/>`__ |
         `Repo <https://github.com/jupyter-xeus/xeus>`__
 
-    `ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`__
-        interactive widgets for Python in the Jupyter Notebook.
-        `Documentation <https://ipywidgets.readthedocs.io/en/latest/>`__ |
-        `Repo <https://github.com/ipython/ipywidgets>`__
-
-    `ipyparallel <https://ipyparallel.readthedocs.io/en/latest/>`__
-        lightweight parallel computing in Python offering seamless notebook integration.
-        `Documentation <https://ipyparallel.readthedocs.io/en/latest/>`__ |
-        `Repo <https://github.com/ipython/ipyparallel>`__
-
 .. seealso::
 
       `Jupyter kernels <list of available kernels_>`_

--- a/docs/source/projects/kernels.rst
+++ b/docs/source/projects/kernels.rst
@@ -34,7 +34,7 @@ implementation of kernels for Jupyter and provides a number of kernels such as
 .. glossary::
 
     `IPython <https://ipython.org>`__
-        interactive computing in Python - 
+        interactive computing in Python.
         `Documentation <https://ipython.readthedocs.io/en/stable/>`__ |
         `Repo <https://github.com/ipython/ipykernel>`__
 

--- a/docs/source/projects/kernels.rst
+++ b/docs/source/projects/kernels.rst
@@ -36,11 +36,11 @@ implementation of kernels for Jupyter and provides a number of kernels such as
     `IPython <https://ipython.org>`__
         interactive computing in Python.
         `Documentation <https://ipython.readthedocs.io/en/stable/>`__ |
-        `Repo <https://github.com/ipython/ipykernel>`__
+        `Repo <https://github.com/ipython/ipython>`__
 
     `ipykernel <ipykernel>`__
         the wrapper around IPython which enables using IPython as a kernel
-        `Repo <https://github.com/ipython/ipython>`__
+        `Repo <https://github.com/ipython/ipykernel>`__
 
     `Xeus <https://ipyparallel.readthedocs.io/en/latest/>`__
         library facilitating the implementation of kernels for Jupyter.

--- a/docs/source/projects/kernels.rst
+++ b/docs/source/projects/kernels.rst
@@ -4,10 +4,9 @@
 Kernels (Programming Languages)
 ===============================
 
-The Jupyter team maintains the `IPython kernel <https://github.com/ipython/ipython>`_
-since the Jupyter notebook server depends on the IPython :term:`kernel`
-functionality. Many other languages, in addition to Python, may be used in
-the notebook.
+The Jupyter team maintains the `IPython <https://github.com/ipython/ipython>`_
+project which is shipped as a default kernel (as :term:`ipykernel`) in a number of Jupyter clients.
+Many other languages, in addition to Python, may be used in the notebook.
 
 The community maintains many other language kernels, and new kernels become
 available often. Please see the `list of available kernels`_ for additional
@@ -19,15 +18,36 @@ Kernels
 
 Kernels are `programming language specific` processes that run independently
 and interact with the Jupyter Applications and their user interfaces.
-`IPython <https://ipython.org>`__ is the reference Jupyter kernel, providing a
-powerful environment for interactive computing in Python.
+`ipykernel <https://github.com/ipython/ipykernel>`__ is the reference Jupyter kernel
+is the reference Jupyter kernel built on top of `IPython <https://ipython.org>`__,
+providing a powerful environment for interactive computing in Python.
+
+`jupyter-client <https://jupyter-client.readthedocs.io/en/stable/>`__ contains
+the authoritative description of the Jupyter messaging protocol which is used
+by clients to communicate with the kernels.
+
+`Xeus <https://ipyparallel.readthedocs.io/en/latest/>`__ subproject facilitates
+implementation of kernels for Jupyter and provides a number of kernels such as
+`xeus-cling <https://github.com/jupyter-xeus/xeus-cling>`__ (C++),
+`xeus-sql <https://github.com/jupyter-xeus/xeus-sql>`__ (SQL) and many more.
 
 .. glossary::
 
     `IPython <https://ipython.org>`__
-        interactive computing in Python.
+        interactive computing in Python - 
         `Documentation <https://ipython.readthedocs.io/en/stable/>`__ |
+        `Repo <https://github.com/ipython/ipykernel>`__
+
+    `ipykernel <ipykernel>`__
+        the wrapper around IPython which enables using IPython as a kernel
         `Repo <https://github.com/ipython/ipython>`__
+
+    `Xeus <https://ipyparallel.readthedocs.io/en/latest/>`__
+        library facilitating the implementation of kernels for Jupyter
+        It implements the Jupyter Kernel protocol so developers
+        can focus on implementing the interpreter part of the kernel.
+        `Documentation <https://xeus.readthedocs.io/en/latest/>`__ |
+        `Repo <https://github.com/jupyter-xeus/xeus>`__
 
     `ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`__
         interactive widgets for Python in the Jupyter Notebook.
@@ -41,7 +61,7 @@ powerful environment for interactive computing in Python.
 
 .. seealso::
 
-      `Jupyter kernels <https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages>`_
+      `Jupyter kernels <list of available kernels_>`_
 
       A full list of kernels available for other languages. Many of
       these kernels are developed by third parties and may or may not be stable.

--- a/docs/source/projects/kernels.rst
+++ b/docs/source/projects/kernels.rst
@@ -19,14 +19,14 @@ Kernels
 Kernels are `programming language specific` processes that run independently
 and interact with the Jupyter Applications and their user interfaces.
 `ipykernel <https://github.com/ipython/ipykernel>`__ is the reference Jupyter kernel
-is the reference Jupyter kernel built on top of `IPython <https://ipython.org>`__,
+built on top of `IPython <https://ipython.org>`__,
 providing a powerful environment for interactive computing in Python.
 
 `jupyter-client <https://jupyter-client.readthedocs.io/en/stable/>`__ contains
 the authoritative description of the Jupyter messaging protocol which is used
 by clients to communicate with the kernels.
 
-`Xeus <https://ipyparallel.readthedocs.io/en/latest/>`__ subproject facilitates
+`Xeus <https://xeus.readthedocs.io/en/latest/>`__ facilitates the
 implementation of kernels for Jupyter and provides a number of kernels such as
 `xeus-cling <https://github.com/jupyter-xeus/xeus-cling>`__ (C++),
 `xeus-sql <https://github.com/jupyter-xeus/xeus-sql>`__ (SQL) and many more.
@@ -43,7 +43,7 @@ implementation of kernels for Jupyter and provides a number of kernels such as
         `Repo <https://github.com/ipython/ipython>`__
 
     `Xeus <https://ipyparallel.readthedocs.io/en/latest/>`__
-        library facilitating the implementation of kernels for Jupyter
+        library facilitating the implementation of kernels for Jupyter.
         It implements the Jupyter Kernel protocol so developers
         can focus on implementing the interpreter part of the kernel.
         `Documentation <https://xeus.readthedocs.io/en/latest/>`__ |


### PR DESCRIPTION
Update kernels documentation: add xeus, jupyter-client, ipykernel and remove outdated info (like IPython is no longer a kernel, ipykernel is). 

I removed mention of ipyparallel and ipywidgets as those are not kernels; they are mentioned on https://docs.jupyter.org/en/latest/projects/ipython_projects.html so it should be fine.