### PR TITLE
Add/update alt text in documentation

### DIFF
--- a/docs/source/community/community-call-notes/2019-may.md
+++ b/docs/source/community/community-call-notes/2019-may.md
@@ -55,7 +55,7 @@ Add your potential agenda item here **24 hours before** the meeting at the lates
             * 6.0 release of notebook?
             * post jupyterlab 1.0?
 * Qt(5.6)-based PDF output from JupyterLab (0.35) 
-  Quick demo of using QtWebEngine to load a notebook in lab and make a PDF. $_{n+1}$th time's the charm! [![Binder ](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/deathbeds/nbconvert-pdfqt/master?urlpath=lab%2Ftree%2Fnotebooks%2Findex.ipynb) | [issue](https://github.com/jupyter/nbconvert/issues/1031) | [repo](https://github.com/deathbeds/nbconvert-pdfqt) | [name=Nick]
+  Quick demo of using QtWebEngine to load a notebook in lab and make a PDF. $_{n+1}$th time's the charm! [![Launch Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/deathbeds/nbconvert-pdfqt/master?urlpath=lab%2Ftree%2Fnotebooks%2Findex.ipynb) | [issue](https://github.com/jupyter/nbconvert/issues/1031) | [repo](https://github.com/deathbeds/nbconvert-pdfqt) | [name=Nick]
 
 ## Attendees
 

--- a/docs/source/community/community-call-notes/2019-may.md
+++ b/docs/source/community/community-call-notes/2019-may.md
@@ -55,7 +55,7 @@ Add your potential agenda item here **24 hours before** the meeting at the lates
             * 6.0 release of notebook?
             * post jupyterlab 1.0?
 * Qt(5.6)-based PDF output from JupyterLab (0.35) 
-  Quick demo of using QtWebEngine to load a notebook in lab and make a PDF. $_{n+1}$th time's the charm! [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/deathbeds/nbconvert-pdfqt/master?urlpath=lab%2Ftree%2Fnotebooks%2Findex.ipynb) | [issue](https://github.com/jupyter/nbconvert/issues/1031) | [repo](https://github.com/deathbeds/nbconvert-pdfqt) | [name=Nick]
+  Quick demo of using QtWebEngine to load a notebook in lab and make a PDF. $_{n+1}$th time's the charm! [![Binder ](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/deathbeds/nbconvert-pdfqt/master?urlpath=lab%2Ftree%2Fnotebooks%2Findex.ipynb) | [issue](https://github.com/jupyter/nbconvert/issues/1031) | [repo](https://github.com/deathbeds/nbconvert-pdfqt) | [name=Nick]
 
 ## Attendees
 

--- a/docs/source/community/community-call-notes/2020-december.md
+++ b/docs/source/community/community-call-notes/2020-december.md
@@ -34,7 +34,7 @@ This is a place to make short announcements (without a need for discussion).
 > Add agenda items here **before** the meeting. We will reorganize the agenda so that it fits in the 60m meeting slot.
 
 * **WXYZDVCS** Work-in-progress report on [`wxyz.dvcs`](https://github.com/deathbeds/wxyz), a bridge from Jupyter Widgets to distributed version control - _Nick_
-  * _Hopefully_ released this week 🤞, [![ ][binder]](https://mybinder.org/v2/gh/deathbeds/wxyz/master?urlpath=lab/tree/src/py/wxyz_notebooks/src/wxyz/notebooks/index.ipynb) works though!
+  * _Hopefully_ released this week 🤞, [![Launch Binder]](https://mybinder.org/v2/gh/deathbeds/wxyz/master?urlpath=lab/tree/src/py/wxyz_notebooks/src/wxyz/notebooks/index.ipynb) works though!
 * Pierre's notebooks for teaching Python and data science
 * [JupyterLab Classic](https://github.com/jtpio/jupyterlab-classic) - *Jeremy*
 

--- a/docs/source/community/community-call-notes/2020-december.md
+++ b/docs/source/community/community-call-notes/2020-december.md
@@ -34,7 +34,7 @@ This is a place to make short announcements (without a need for discussion).
 > Add agenda items here **before** the meeting. We will reorganize the agenda so that it fits in the 60m meeting slot.
 
 * **WXYZDVCS** Work-in-progress report on [`wxyz.dvcs`](https://github.com/deathbeds/wxyz), a bridge from Jupyter Widgets to distributed version control - _Nick_
-  * _Hopefully_ released this week 🤞, [![][binder]](https://mybinder.org/v2/gh/deathbeds/wxyz/master?urlpath=lab/tree/src/py/wxyz_notebooks/src/wxyz/notebooks/index.ipynb) works though!
+  * _Hopefully_ released this week 🤞, [![ ][binder]](https://mybinder.org/v2/gh/deathbeds/wxyz/master?urlpath=lab/tree/src/py/wxyz_notebooks/src/wxyz/notebooks/index.ipynb) works though!
 * Pierre's notebooks for teaching Python and data science
 * [JupyterLab Classic](https://github.com/jtpio/jupyterlab-classic) - *Jeremy*
 

--- a/docs/source/community/community-call-notes/2020-november.md
+++ b/docs/source/community/community-call-notes/2020-november.md
@@ -28,7 +28,7 @@ This is a place to make short announcements (without a need for discussion).
 
 Add agenda items here **before** the meeting. We will reorganize the agenda so that it fits in the 60m meeting slot.
 
-* 🦌 [IPyElk 0.2.0](https://github.com/jupyrdf/ipyelk) [![binder-badge](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyrdf/ipyelk/42db3e3?urlpath=lab%2Ftree%2Fexamples%2F_index.ipynb)
+* 🦌 [IPyElk 0.2.0](https://github.com/jupyrdf/ipyelk) [![binder-badge ](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyrdf/ipyelk/42db3e3?urlpath=lab%2Ftree%2Fexamples%2F_index.ipynb)
   * > Jupyter Widgets for interactive graphs _at scale_ powered by the [Eclipse Layout Kernel (ELK)](https://github.com/kieler/elkjs), [sprotty](https://github.com/eclipse/sprotty), [networkx](https://networkx.github.io).
 
 * [dgaf](https://github.com/deathbeds/dgaf) (deathbeds generalized automation framework)

--- a/docs/source/community/community-call-notes/2020-november.md
+++ b/docs/source/community/community-call-notes/2020-november.md
@@ -28,7 +28,7 @@ This is a place to make short announcements (without a need for discussion).
 
 Add agenda items here **before** the meeting. We will reorganize the agenda so that it fits in the 60m meeting slot.
 
-* 🦌 [IPyElk 0.2.0](https://github.com/jupyrdf/ipyelk) [![binder-badge ](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyrdf/ipyelk/42db3e3?urlpath=lab%2Ftree%2Fexamples%2F_index.ipynb)
+* 🦌 [IPyElk 0.2.0](https://github.com/jupyrdf/ipyelk) [![Launch Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyrdf/ipyelk/42db3e3?urlpath=lab%2Ftree%2Fexamples%2F_index.ipynb)
   * > Jupyter Widgets for interactive graphs _at scale_ powered by the [Eclipse Layout Kernel (ELK)](https://github.com/kieler/elkjs), [sprotty](https://github.com/eclipse/sprotty), [networkx](https://networkx.github.io).
 
 * [dgaf](https://github.com/deathbeds/dgaf) (deathbeds generalized automation framework)

--- a/docs/source/community/community-call-notes/2021-april.md
+++ b/docs/source/community/community-call-notes/2021-april.md
@@ -33,11 +33,11 @@ For more discussion on the format of these calls, see the thread [here](https://
 - **Gonzalo** Internationalization workflow for extension developers
 
     - Some feedback... :man-facepalming: 
-        - ![A comment from a community members on internationalization: As I see, there is a delay with the creation and publishing of language packs. We use Jupyter Lab as a base for one of our products and we are interested in using language lacks in it (especially Chinese and Japanese. What is the reason for the delay and is it possible to help the project somehow? We are interested in contributing to the Jupyter Lab project in many domains, for example, sofrware development, testing and translation.](https://i.imgur.com/mho6Ka9.png)
+        - "As I see, there is a delay with the creation and publishing of language packs. We use Jupyter Lab as a base for one of our products and we are interested in using language lacks in it (especially Chinese and Japanese. What is the reason for the delay and is it possible to help the project somehow? We are interested in contributing to the Jupyter Lab project in many domains, for example, sofrware development, testing and translation."
 
     - Releasing language packages :world_map::card_file_box: 
         - [Current packages and state](https://crowdin.com/project/jupyterlab)  (showing first 10)
-          ![The top 10 translations by percent completed are Spanish at 100%, Chinese Simplified at 100%, Hebrew at 88%, Turkish at 86%, Brazilian Portuguese at 83%, Ukrainian at 83%, Japanese at 83% French at 83%, Russian at 74%, and Polish at 60% ](https://i.imgur.com/vNeRe8s.png)
+          ![The top 10 translations by percent completed are Spanish at 100%, Chinese Simplified at 100%, Hebrew at 88%, Turkish at 86%, Brazilian Portuguese at 83%, Ukrainian at 83%, Japanese at 83% French at 83%, Russian at 74%, and Polish at 60%](https://i.imgur.com/vNeRe8s.png)
         - Releasing Spanish and Chinese simplified today evening. :eyes:
         - Please attend the JLab dev meeting for more information on the internal process for managing the translations and language packs.
 
@@ -52,7 +52,7 @@ For more discussion on the format of these calls, see the thread [here](https://
     - **Nbterm**
         - [Blog: Jupyter Notebooks in the terminal](https://blog.jupyter.org/nbterm-jupyter-notebooks-in-the-terminal-6a2b55d08b70)
         - [Github Repository](https://github.com/davidbrochart/nbterm)
-          ![Notebook cell input and outputs represented in the terminal. The terminal has a black background and syntax coloring. Line numbers appear to the left of each line as "In 1", "In 2" etc. Inputs appear as text within a grey bounding box. Each input line's output appears as grey text below the box. ](https://i.imgur.com/kzNyCno.png)
+          ![Notebook cell input and outputs represented in the terminal. The terminal has a black background and syntax coloring. Line numbers appear to the left of each line as "In 1", "In 2" etc. Inputs appear as text within a grey bounding box. Each input line's output appears as grey text below the box.](https://i.imgur.com/kzNyCno.png)
 
 ## Other Links Shared
 

--- a/docs/source/community/community-call-notes/2021-april.md
+++ b/docs/source/community/community-call-notes/2021-april.md
@@ -33,7 +33,7 @@ For more discussion on the format of these calls, see the thread [here](https://
 - **Gonzalo** Internationalization workflow for extension developers
 
     - Some feedback... :man-facepalming: 
-        - ![Text asking why there is a delay for publishing the language packs needed for internationalization ](https://i.imgur.com/mho6Ka9.png)
+        - ![A comment from a community members on internationalization: As I see, there is a delay with the creation and publishing of language packs. We use Jupyter Lab as a base for one of our products and we are interested in using language lacks in it (especially Chinese and Japanese. What is the reason for the delay and is it possible to help the project somehow? We are interested in contributing to the Jupyter Lab project in many domains, for example, sofrware development, testing and translation.](https://i.imgur.com/mho6Ka9.png)
 
     - Releasing language packages :world_map::card_file_box: 
         - [Current packages and state](https://crowdin.com/project/jupyterlab)  (showing first 10)
@@ -52,7 +52,7 @@ For more discussion on the format of these calls, see the thread [here](https://
     - **Nbterm**
         - [Blog: Jupyter Notebooks in the terminal](https://blog.jupyter.org/nbterm-jupyter-notebooks-in-the-terminal-6a2b55d08b70)
         - [Github Repository](https://github.com/davidbrochart/nbterm)
-          ![Notebook cell input and outputs represented in the terminal ](https://i.imgur.com/kzNyCno.png)
+          ![Notebook cell input and outputs represented in the terminal. The terminal has a black background and syntax coloring. Line numbers appear to the left of each line as "In 1", "In 2" etc. Inputs appear as text within a grey bounding box. Each input line's output appears as grey text below the box. ](https://i.imgur.com/kzNyCno.png)
 
 ## Other Links Shared
 

--- a/docs/source/community/community-call-notes/2021-april.md
+++ b/docs/source/community/community-call-notes/2021-april.md
@@ -33,11 +33,11 @@ For more discussion on the format of these calls, see the thread [here](https://
 - **Gonzalo** Internationalization workflow for extension developers
 
     - Some feedback... :man-facepalming: 
-        - ![Text asking why there is a delay for publishing the language packs needed for internationalization](https://i.imgur.com/mho6Ka9.png)
+        - ![Text asking why there is a delay for publishing the language packs needed for internationalization ](https://i.imgur.com/mho6Ka9.png)
 
     - Releasing language packages :world_map::card_file_box: 
         - [Current packages and state](https://crowdin.com/project/jupyterlab)  (showing first 10)
-          ![The top 10 translations by percent completed are Spanish at 100%, Chinese Simplified at 100%, Hebrew at 88%, Turkish at 86%, Brazilian Portuguese at 83%, Ukrainian at 83%, Japanese at 83% French at 83%, Russian at 74%, and Polish at 60%](https://i.imgur.com/vNeRe8s.png)
+          ![The top 10 translations by percent completed are Spanish at 100%, Chinese Simplified at 100%, Hebrew at 88%, Turkish at 86%, Brazilian Portuguese at 83%, Ukrainian at 83%, Japanese at 83% French at 83%, Russian at 74%, and Polish at 60% ](https://i.imgur.com/vNeRe8s.png)
         - Releasing Spanish and Chinese simplified today evening. :eyes:
         - Please attend the JLab dev meeting for more information on the internal process for managing the translations and language packs.
 
@@ -52,7 +52,7 @@ For more discussion on the format of these calls, see the thread [here](https://
     - **Nbterm**
         - [Blog: Jupyter Notebooks in the terminal](https://blog.jupyter.org/nbterm-jupyter-notebooks-in-the-terminal-6a2b55d08b70)
         - [Github Repository](https://github.com/davidbrochart/nbterm)
-          ![Notebook cell input and outputs represented in the terminal](https://i.imgur.com/kzNyCno.png)
+          ![Notebook cell input and outputs represented in the terminal ](https://i.imgur.com/kzNyCno.png)
 
 ## Other Links Shared
 

--- a/docs/source/contributing/dev-contributions/contrib_guide.md
+++ b/docs/source/contributing/dev-contributions/contrib_guide.md
@@ -1,9 +1,8 @@
-===============
-How can I help?
-===============
+# How can I help?
 
-.. contents:: Contents
-   :local:
+```{contents} Contents
+:local:
+```
 
 Contributing to open source can be a nerve-wrecking process, but don't worry
 everyone on the Jupyter team is dedicated to making sure that your open source
@@ -20,8 +19,7 @@ a small amount of the code necessary to fix the issue you are tackling. Any and
 all help is welcome and any and all people are encouraged to contribute.
 
 
-Submitting Pull Requests
-========================
+## Submitting Pull Requests
 
 Individuals are welcome, and encouraged, to submit pull requests and contribute
 to the Jupyter source. If you are a first-time contributor looking to get
@@ -31,8 +29,9 @@ is particularly useful because the Jupyter codebase is scattered across several
 repositories within the jupyter organization, as opposed to a single
 repository. You can click the link below to find sprint-friendly issues.
 
-`is:issue is:open is:sprint-friendly user:jupyter
-<https://github.com/search?q=is%3Aissue+is%3Aopen+is%3Asprint-friendly+user%3Ajupyter&type=Issues&ref=searchresults>`_
+```{link-button} https://github.com/search?q=is%3Aissue+is%3Aopen+is%3Asprint-friendly+user%3Ajupyter&type=Issues&ref=searchresults
+:text: is:issue is:open is:sprint-friendly user:jupyter
+```
 
 Once you've found an issue that you are eager to solve, you can use the guide
 below to get started. If you experience any problems while working on the
@@ -46,9 +45,9 @@ including partial or in-progress work, is appreciated.
 
 1. Fork the repository associated with the issue you are addressing and clone
    it to a local directory on your machine.
+2. `cd` into the directory and create a new branch using `git checkout -b insert-branch-name-here`.
 
-2. ``cd`` into the directory and create a new branch using ``git checkout -b
-   insert-branch-name-here``. Pick a branch name that gives some insight into
+   Pick a branch name that gives some insight into
    what the issue you are fixing is. For example, if you are updating the text
    that is logged out by the program when a certain error happens you might
    name your branch `update-error-text`.
@@ -60,7 +59,7 @@ including partial or in-progress work, is appreciated.
    reside and leave a comment in the file describing what issue you are trying
    to address.
 
-5. Open a pull request to the repository with ``[WIP]`` appended to the front
+5. Open a pull request to the repository with `[WIP]` appended to the front
    so that the core team is aware that you are actively pursuing the issue.
    When creating a pull request, make sure that the title clearly and concisely
    described what your code does. For example, we might use the title "Updated
@@ -76,7 +75,7 @@ including partial or in-progress work, is appreciated.
 6. Run the test suite locally in order to ensure that everything is properly
    configured on your system. Refer to the repository's README for information
    on how to run the test suite. This will typically require that you run the
-   ``nosetests`` command on the commandline. Alternatively, you may submit a
+   `nosetests` command on the commandline. Alternatively, you may submit a
    pull request. Our Continuous Integration system will test your code and
    report test results.
 
@@ -101,7 +100,7 @@ including partial or in-progress work, is appreciated.
 8. Go back to the file that you are updating and begin adding the code for your
    pull request.
 
-9. Run the test suite again to see if your changes have caused any of the test
+9.  Run the test suite again to see if your changes have caused any of the test
    cases to pass. If any of the test cases have failed, go back to your code
    and make the updates necessary to have them pass.
 
@@ -118,52 +117,47 @@ including partial or in-progress work, is appreciated.
 12. Once your PR is ready to become a part of the code base, it will be merged
     by a member of the core team.
 
-Contribution Workflow
----------------------
+## Contribution Workflow
 
-.. image:: ../../_static/_images/contribution_workflow.png
-   :alt: A flow chart listing the steps of contributing code to Jupyter with 14 labeled boxes linked by arrows. The chart is uni-directional. At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Refer to the link below the image for full text.
+```{image} ../../_static/_images/contribution_workflow.png
+:alt: A flow chart listing the steps of contributing code to Jupyter with 14 labeled boxes linked by arrows. The chart is uni-directional. At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Refer to the link below the image for full text.
+```
 
-Full Contribution Workflow description.[#f1]_
+Full Contribution Workflow description.[^f1]
 
-
-Core Developer Workflow
------------------------
+## Core Developer Workflow
 
 To help you understand our review process by core developers after you submit a
 pull request, here's a guide that outlines the general process (specifics may
 vary a bit across our repositories). Here is an example for Jupyter notebook
-4.x:
+`4.x`:
 
-
-
-In general, Pull Requests are against ``master`` unless they only affect a
+In general, Pull Requests are against `master` unless they only affect a
 backport branch. If a PR affects master and should be backported, the general
 flow is:
 
-  0. mark the PR with milestone for the next backport release (4.3)
-  1. merge into master
-  2. backport to 4.x
-  3. push updated 4.x branch
+1. mark the PR with milestone for the next backport release (4.3)
+2. merge into master
+3. backport to 4.x
+4. push updated 4.x branch
 
-Backports can be done in a variety of ways, but we have `a script
-<https://github.com/ipython/ipython/blob/master/tools/backport_pr.py>`_ for
+Backports can be done in a variety of ways, but we have [a script](https://github.com/ipython/ipython/blob/master/tools/backport_pr.py) for
 automating the common process to:
 
-  1. download the patch ` e.g. <https://patch-diff.githubusercontent.com/raw/jupyter/notebook/pull/1645.patch>`
-  2. checkout the 4.x branch
-  3. apply the patch
-  4. make a commit
+1. download the patch ` e.g. <https://patch-diff.githubusercontent.com/raw/jupyter/notebook/pull/1645.patch>`
+2. checkout the 4.x branch
+3. apply the patch
+4. make a commit
 
 which works for simple cases, at least.
 
 In this case, it would be:
 
-    python /path/to/ipython-repo/tools/backport_pr.py jupyter/notebook 4.x 1645
+```
+python /path/to/ipython-repo/tools/backport_pr.py jupyter/notebook 4.x 1645
+```
 
-
-Submitting a Bug
-=================
+## Submitting a Bug
 
 While using the Notebook, you might experience a bug that manifests itself in 
 unexpected behavior.  If so, we encourage you  to open issues on GitHub. To 
@@ -181,7 +175,7 @@ you take the following steps before submitting an issue.
    in, in order to aid in the debugging of the issue. You will need to provide
    information about the Python version, Jupyter version, operating system,
    and browser that you are using when submitting bugs. You can also use
-   ``pip list`` or  ``conda list`` and ``grep`` in order to identify the
+   `pip list` or  `conda list` and `grep` in order to identify the
    versions of the libraries that are relevant to the issue that you are
    submitting.
 
@@ -191,43 +185,42 @@ you take the following steps before submitting an issue.
 5. Prepare an explanation of why the current behavior is not desired and 
    what it should be.
 
-Reporting a Vulnerability
-=========================
+## Reporting a Vulnerability
 
 If you believe you've found a security vulnerability in a Jupyter project,
-please report it to `security@ipython.org <mailto:security@ipython.org>`_. If you
-prefer to encrypt your security reports, you can use `this PGP public
-key <https://jupyter-notebook.readthedocs.io/en/stable/_downloads/1d303a645f2505a8fd283826fafc9908/ipython_security.asc>`_.
+please report it to [`security@ipython.org`](mailto:security@ipython.org).
+If you prefer to encrypt your security reports, you can use [this PGP public  key](https://jupyter-notebook.readthedocs.io/en/stable/_downloads/1d303a645f2505a8fd283826fafc9908/ipython_security.asc).
 
-.. rubric:: Footnotes
+[^f1]:  A flow chart with 14 labeled boxes linked by arrows.
 
-.. [#f1] A flow chart with 14 labeled boxes linked by arrows. The chart is uni-directional.  At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Here the flow chart is described as lists in which the possible next steps are listed beneath each box label.
-   1. Start
-      1a. forward to 'Find an issue to address'
-   2. Find an issue to address
-      2a. forward to 'Identify the relevant section of the codebase'
-   3. Identify the relevant section of the codebase
-      3a. forward to 'Write simple test cases to verify that your fix or enhancement works.'
-   4. Write simple test cases to verify that your fix or enhancement works.
-      4a. forward to 'Implement the bug fix or enhancement in the appropriate location'
-   5. Implement the bug fix or enhancement in the appropriate location.
-       5a. Forward to 'Run the test suite and verify that the updated code works appropriately.'
-   6. Run the test suite and verify that the updated code works appropriately.
-      6a. forward to 'Test suit passes!'
-      6b. forward to 'Test suit fails!'
-   7. Test suit fails
-      7a. forward to 'Identify and fix any issues in the new code that might be causing errors. Refer to the mailing list or Gitter channel for help.'
-   8. Identify and fix any issues in the new code that might be causing errors. Refer to the mailing list or Gitter channel for help.
-      8a. back to 'Run the test suite and verify that the updated code works appropriately'
-   9. Test suit passes!
-      9a. forward to 'Submit a pull request to the appropriate repository with your awesome code!'
-   10. Submit a pull request to the appropriate repository with your awesome code!
-      10a. forward to 'Reviewer approves and merges the PR'
-      10b. forward to 'Reviewer responds with changes you should make to the PR'
-   11. Reviewer responds with changes you should make to the PR
-      11a. forward to 'Apply the necessary fixes or updates to the pull request'
-   12. Apply the necessary fixes or updates to the pull request'
-      12a. back to 'Submit a pull request to the appropriate repository with your awesome code!'
-   13. Reviewer approves and merges the PR'
-      13a. forward to 'Rejoice and repeat!'
-   14. 'Rejoice and repeat!'
+    The chart is uni-directional. At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Here the flow chart is described as lists in which the possible next steps are listed beneath each box label.
+
+    1. Start
+       1a. forward to 'Find an issue to address'
+    2. Find an issue to address
+       2a. forward to 'Identify the relevant section of the codebase'
+    3. Identify the relevant section of the codebase
+       3a. forward to 'Write simple test cases to verify that your fix or enhancement works.'
+    4. Write simple test cases to verify that your fix or enhancement works.
+       4a. forward to 'Implement the bug fix or enhancement in the appropriate location'
+    5. Implement the bug fix or enhancement in the appropriate location.
+        5a. Forward to 'Run the test suite and verify that the updated code works appropriately.'
+    6. Run the test suite and verify that the updated code works appropriately.
+       6a. forward to 'Test suit passes!'
+       6b. forward to 'Test suit fails!'
+    7. Test suit fails
+       7a. forward to 'Identify and fix any issues in the new code that might be causing errors. Refer to the mailing list or Gitter channel for help.'
+    8. Identify and fix any issues in the new code that might be causing errors. Refer to the mailing list or Gitter channel for help.
+       8a. back to 'Run the test suite and verify that the updated code works appropriately'
+    9. Test suit passes!
+       9a. forward to 'Submit a pull request to the appropriate repository with your awesome code!'
+    10. Submit a pull request to the appropriate repository with your awesome code!
+       10a. forward to 'Reviewer approves and merges the PR'
+       10b. forward to 'Reviewer responds with changes you should make to the PR'
+    11. Reviewer responds with changes you should make to the PR
+       11a. forward to 'Apply the necessary fixes or updates to the pull request'
+    12. Apply the necessary fixes or updates to the pull request'
+       12a. back to 'Submit a pull request to the appropriate repository with your awesome code!'
+    13. Reviewer approves and merges the PR'
+       13a. forward to 'Rejoice and repeat!'
+    14. 'Rejoice and repeat!'

--- a/docs/source/contributing/dev-contributions/contrib_guide.rst
+++ b/docs/source/contributing/dev-contributions/contrib_guide.rst
@@ -120,9 +120,9 @@ including partial or in-progress work, is appreciated.
 
 Contribution Workflow
 ---------------------
-[Link to full alt-text of Contribution Workflow flowchart.](https://gist.githubusercontent.com/MarsBarLee/2dc5e9c83adf0555d08277b2262302e5/raw/be6a0c46f58d7135a75df7747698cef676b9cdc0/Jupyter%2520Documentation:%2520Contribution%2520Workflow%2520Alt-Text)
+[Link to full alt-text of Contribution Workflow flow chart.](https://gist.githubusercontent.com/MarsBarLee/2dc5e9c83adf0555d08277b2262302e5/raw/be6a0c46f58d7135a75df7747698cef676b9cdc0/Jupyter%2520Documentation:%2520Contribution%2520Workflow%2520Alt-Text)
 .. image:: ../../_static/_images/contribution_workflow.png
-   :alt: A flow chart with 14 labeled boxes linked by arrows. The chart is uni-directional.  At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Refer to the link above the image for full, long alt-text.
+   :alt: A flow chart listing the steps of contributing code to Jupyter with 14 labeled boxes linked by arrows. The chart is uni-directional. At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Refer to the link above the image for full text.
 
 
 

--- a/docs/source/contributing/dev-contributions/contrib_guide.rst
+++ b/docs/source/contributing/dev-contributions/contrib_guide.rst
@@ -120,10 +120,11 @@ including partial or in-progress work, is appreciated.
 
 Contribution Workflow
 ---------------------
-[Link to full alt-text of Contribution Workflow flow chart.](https://gist.githubusercontent.com/MarsBarLee/2dc5e9c83adf0555d08277b2262302e5/raw/be6a0c46f58d7135a75df7747698cef676b9cdc0/Jupyter%2520Documentation:%2520Contribution%2520Workflow%2520Alt-Text)
-.. image:: ../../_static/_images/contribution_workflow.png
-   :alt: A flow chart listing the steps of contributing code to Jupyter with 14 labeled boxes linked by arrows. The chart is uni-directional. At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Refer to the link above the image for full text.
 
+.. image:: ../../_static/_images/contribution_workflow.png
+   :alt: A flow chart listing the steps of contributing code to Jupyter with 14 labeled boxes linked by arrows. The chart is uni-directional. At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Refer to the link below the image for full text.
+
+Full Contribution Workflow description.[#f1]_
 
 
 Core Developer Workflow
@@ -197,3 +198,36 @@ If you believe you've found a security vulnerability in a Jupyter project,
 please report it to `security@ipython.org <mailto:security@ipython.org>`_. If you
 prefer to encrypt your security reports, you can use `this PGP public
 key <https://jupyter-notebook.readthedocs.io/en/stable/_downloads/1d303a645f2505a8fd283826fafc9908/ipython_security.asc>`_.
+
+.. rubric:: Footnotes
+
+.. [#f1] A flow chart with 14 labeled boxes linked by arrows. The chart is uni-directional.  At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Here the flow chart is described as lists in which the possible next steps are listed beneath each box label.
+   1. Start
+      1a. forward to 'Find an issue to address'
+   2. Find an issue to address
+      2a. forward to 'Identify the relevant section of the codebase'
+   3. Identify the relevant section of the codebase
+      3a. forward to 'Write simple test cases to verify that your fix or enhancement works.'
+   4. Write simple test cases to verify that your fix or enhancement works.
+      4a. forward to 'Implement the bug fix or enhancement in the appropriate location'
+   5. Implement the bug fix or enhancement in the appropriate location.
+       5a. Forward to 'Run the test suite and verify that the updated code works appropriately.'
+   6. Run the test suite and verify that the updated code works appropriately.
+      6a. forward to 'Test suit passes!'
+      6b. forward to 'Test suit fails!'
+   7. Test suit fails
+      7a. forward to 'Identify and fix any issues in the new code that might be causing errors. Refer to the mailing list or Gitter channel for help.'
+   8. Identify and fix any issues in the new code that might be causing errors. Refer to the mailing list or Gitter channel for help.
+      8a. back to 'Run the test suite and verify that the updated code works appropriately'
+   9. Test suit passes!
+      9a. forward to 'Submit a pull request to the appropriate repository with your awesome code!'
+   10. Submit a pull request to the appropriate repository with your awesome code!
+      10a. forward to 'Reviewer approves and merges the PR'
+      10b. forward to 'Reviewer responds with changes you should make to the PR'
+   11. Reviewer responds with changes you should make to the PR
+      11a. forward to 'Apply the necessary fixes or updates to the pull request'
+   12. Apply the necessary fixes or updates to the pull request'
+      12a. back to 'Submit a pull request to the appropriate repository with your awesome code!'
+   13. Reviewer approves and merges the PR'
+      13a. forward to 'Rejoice and repeat!'
+   14. 'Rejoice and repeat!'

--- a/docs/source/contributing/dev-contributions/contrib_guide.rst
+++ b/docs/source/contributing/dev-contributions/contrib_guide.rst
@@ -121,6 +121,7 @@ including partial or in-progress work, is appreciated.
 Contribution Workflow
 ---------------------
 .. image:: ../../_static/_images/contribution_workflow.png
+   :alt: 
 
 
 

--- a/docs/source/contributing/dev-contributions/contrib_guide.rst
+++ b/docs/source/contributing/dev-contributions/contrib_guide.rst
@@ -120,8 +120,9 @@ including partial or in-progress work, is appreciated.
 
 Contribution Workflow
 ---------------------
+[Link to full alt-text of Contribution Workflow flowchart.](https://gist.githubusercontent.com/MarsBarLee/2dc5e9c83adf0555d08277b2262302e5/raw/be6a0c46f58d7135a75df7747698cef676b9cdc0/Jupyter%2520Documentation:%2520Contribution%2520Workflow%2520Alt-Text)
 .. image:: ../../_static/_images/contribution_workflow.png
-   :alt: 
+   :alt: A flow chart with 14 labeled boxes linked by arrows. The chart is uni-directional.  At each step, arrows point forward to one or more boxes and back to the previous box or boxes. Refer to the link above the image for full, long alt-text.
 
 
 

--- a/docs/source/contributing/docs-contributions/doc-new-build.md
+++ b/docs/source/contributing/docs-contributions/doc-new-build.md
@@ -27,7 +27,7 @@ The Services/Add ReadTheDocs window will open. Press the green **Add service** b
 
 The ReadTheDocs service is added successfully. The service will take effect on the next merged pull request to the project repo.
 
-![In GitHub, the ipywidgets repository page is open. A banner notification at the top of the page is displayed, reading "Okay, that hook was successfully created."](static/gh-rtd-hook-success.png "Screenshot of service successfully added")
+![In GitHub, the ipywidgets repository page is open. A banner notification at the top of the page is displayed, reading "Okay, that hook was successfully created."](static/gh-rtd-hook-success.png)
 
 
 *Created: 01-07-2016*

--- a/docs/source/contributing/docs-contributions/doc-new-build.md
+++ b/docs/source/contributing/docs-contributions/doc-new-build.md
@@ -13,7 +13,7 @@ project documentation whenever a pull request is merged into the GitHub repo.
 
 Each GitHub repo has a Settings tab at the far right of the repo menubar. Navigate to Settings and then the **Webhooks & services** submenu tab.
 
-![Settings and Webhooks & services submenu](static/gh-webhooks-services.png "Screenshot of GitHub repo settings")
+![Settings and Webhooks & services submenu ](static/gh-webhooks-services.png "Screenshot of GitHub repo settings")
 
 ### Add the ReadTheDocs service
 
@@ -21,13 +21,13 @@ Select **Add service** and enter *ReadTheDocs* in the **Available Services** inp
 
 The Services/Add ReadTheDocs window will open. Press the green **Add service** button to activate the ReadTheDocs service.
 
-![Add ReadTheDocs service](static/gh-add-rtd.png "Screenshot of adding ReadTheDocs service")
+![Add ReadTheDocs service ](static/gh-add-rtd.png "Screenshot of adding ReadTheDocs service")
 
 ### Success
 
 The ReadTheDocs service is added successfully. The service will take effect on the next merged pull request to the project repo.
 
-![Service successfully added](static/gh-rtd-hook-success.png "Screenshot of service successfully added")
+![Service successfully added ](static/gh-rtd-hook-success.png "Screenshot of service successfully added")
 
 
 *Created: 01-07-2016*

--- a/docs/source/contributing/docs-contributions/doc-new-build.md
+++ b/docs/source/contributing/docs-contributions/doc-new-build.md
@@ -13,7 +13,7 @@ project documentation whenever a pull request is merged into the GitHub repo.
 
 Each GitHub repo has a Settings tab at the far right of the repo menubar. Navigate to Settings and then the **Webhooks & services** submenu tab.
 
-![Settings and Webhooks & services submenu ](static/gh-webhooks-services.png "Screenshot of GitHub repo settings")
+![The ipywidgets GitHub repository's "Settings" tab has been opened, with the "Add service" submenu expanded. The "ReadTheDocs" menu item is highlighted to indicate where on the page this setting can be found.](static/gh-webhooks-services.png)
 
 ### Add the ReadTheDocs service
 
@@ -21,13 +21,13 @@ Select **Add service** and enter *ReadTheDocs* in the **Available Services** inp
 
 The Services/Add ReadTheDocs window will open. Press the green **Add service** button to activate the ReadTheDocs service.
 
-![Add ReadTheDocs service ](static/gh-add-rtd.png "Screenshot of adding ReadTheDocs service")
+![In GitHub, the "Settings" tab of the ipywidgets repository shows that the "ReadTheDocs" service was successfully added to the project. A checkbox with the label "Active" indicates that the service is currently running.](static/gh-add-rtd.png)
 
 ### Success
 
 The ReadTheDocs service is added successfully. The service will take effect on the next merged pull request to the project repo.
 
-![Service successfully added ](static/gh-rtd-hook-success.png "Screenshot of service successfully added")
+![In GitHub, the ipywidgets repository page is open. A banner notification at the top of the page is displayed, reading "Okay, that hook was successfully created."](static/gh-rtd-hook-success.png "Screenshot of service successfully added")
 
 
 *Created: 01-07-2016*

--- a/docs/source/contributing/docs-contributions/doc-new-repos.md
+++ b/docs/source/contributing/docs-contributions/doc-new-repos.md
@@ -11,14 +11,14 @@ On a larger scope, having the Jupyter name appear prominently in a repo's
 ### Link in repo description
 Please include a link to the documentation in the repo's description.
 
-![Repo description and documentation link](static/repo-description.png "Screenshot of documentation link in GitHub repo description")
+![Repo description and documentation link ](static/repo-description.png "Screenshot of documentation link in GitHub repo description")
 
 ### Badges in README
 One common way that individuals find documentation is to look for and click
 on the doc badge that commonly is found right after the title. Another
 benefit is an easy visual indication if the docs are not rendering properly.
 
-![Badges in README.md](static/repo-badges.png "Screenshot of badges displayed under the repo title in the README file")
+![Badges in README.md ](static/repo-badges.png "Screenshot of badges displayed under the repo title in the README file")
 
 ### Resources section in README
 
@@ -29,7 +29,7 @@ demo notebooks, if available.
 
 The *Resources* section includes:
 
-![Resources section in `README.md`](static/repo-resources.png "Screenshot of resource list at end of README file")
+![Resources section in `README.md` ](static/repo-resources.png "Screenshot of resource list at end of README file")
 
 
 ## Checklist adding docs to a new or existing GitHub Repo

--- a/docs/source/contributing/docs-contributions/doc-new-repos.md
+++ b/docs/source/contributing/docs-contributions/doc-new-repos.md
@@ -11,14 +11,14 @@ On a larger scope, having the Jupyter name appear prominently in a repo's
 ### Link in repo description
 Please include a link to the documentation in the repo's description.
 
-![Repo description and documentation link ](static/repo-description.png "Screenshot of documentation link in GitHub repo description")
+![Screenshot of documentation link in GitHub repo description](static/repo-description.png "Screenshot of documentation link in GitHub repo description")
 
 ### Badges in README
 One common way that individuals find documentation is to look for and click
 on the doc badge that commonly is found right after the title. Another
 benefit is an easy visual indication if the docs are not rendering properly.
 
-![Badges in README.md ](static/repo-badges.png "Screenshot of badges displayed under the repo title in the README file")
+![The GitHub-rendered view of the README.md file for the Jupyter Notebook project is annotated with a red speech bubble reading "Add badge for Docs" to indicate the location of the documentation badge on the page.](static/repo-badges.png)
 
 ### Resources section in README
 
@@ -27,9 +27,8 @@ information to users about the individual project and the larger Project
 Jupyter organization. Make sure to include any links to the individual project's
 demo notebooks, if available.
 
-The *Resources* section includes:
+For example, here is the [Resources section from jupyter/notebook]:(https://github.com/jupyter/notebook/blob/master/README.md#resources)
 
-![Resources section in `README.md` ](static/repo-resources.png "Screenshot of resource list at end of README file")
 
 
 ## Checklist adding docs to a new or existing GitHub Repo

--- a/docs/source/contributing/docs-contributions/doc-new-repos.md
+++ b/docs/source/contributing/docs-contributions/doc-new-repos.md
@@ -18,7 +18,7 @@ One common way that individuals find documentation is to look for and click
 on the doc badge that commonly is found right after the title. Another
 benefit is an easy visual indication if the docs are not rendering properly.
 
-![The GitHub-rendered view of the README.md file for the Jupyter Notebook project is annotated with a red speech bubble reading "Add badge for Docs" to indicate the location of the documentation badge on the page.](static/repo-badges.png)
+![The GitHub-rendered view of the README.md file for the Jupyter Notebook project is annotated with a red speech bubble reading "Add badge for Docs."](static/repo-badges.png)
 
 ### Resources section in README
 

--- a/docs/source/contributing/docs-contributions/doc-new-repos.md
+++ b/docs/source/contributing/docs-contributions/doc-new-repos.md
@@ -11,7 +11,7 @@ On a larger scope, having the Jupyter name appear prominently in a repo's
 ### Link in repo description
 Please include a link to the documentation in the repo's description.
 
-![Screenshot of documentation link in GitHub repo description](static/repo-description.png "Screenshot of documentation link in GitHub repo description")
+![Documentation link in GitHub jupyter/notebook repo description annotated with a red speech bubble reading "Add link to documentation (usually a link to Read the Docs.)")](static/repo-description.png)
 
 ### Badges in README
 One common way that individuals find documentation is to look for and click

--- a/docs/source/contributing/docs-contributions/doc-new-translation.md
+++ b/docs/source/contributing/docs-contributions/doc-new-translation.md
@@ -32,7 +32,7 @@ in the workflow described below. This workflow has a handful of actors and compo
 
 ### The translation process
 
-![Translation CI/CD ](static/translation-ci-cd.png "Diagram of the translation continuous integration
+![Diagram of Translation CI and CD. Different steps are represented by humans, files and websites icons connected by arrows](static/translation-ci-cd.png "Diagram of the translation continuous integration 
 and deployment flow")
 
 1. A user creates or edits reStructuredText (`.rst`) or Markdown (`.md`) documents written in U.S.
@@ -372,8 +372,7 @@ ReadTheDocs will build both the source documentation site as well as sites for a
 languages. ReadTheDocs will associate the sites with one another and make them accessible via
 language links in a popup.
 
-![ReadTheDocs popup ](static/translation-rtd-popup.png "Screenshot of the ReadTheDocs popup that
-allows a user to view documentation in a different language")
+![Screenshot of the Jupyter Project Documenation site with the ReadTheDocs popup open, showing links to the documentation in other languages.](static/translation-rtd-popup.png)
 
 ## Reference
 

--- a/docs/source/contributing/docs-contributions/doc-new-translation.md
+++ b/docs/source/contributing/docs-contributions/doc-new-translation.md
@@ -34,6 +34,8 @@ in the workflow described below. This workflow has a handful of actors and compo
 
 ![](static/translation-ci-cd.png)
 
+<!---Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.--->
+
 1. A user creates or edits reStructuredText (`.rst`) or Markdown (`.md`) documents written in U.S.
    English.
 2. The user submits a pull request on GitHub.

--- a/docs/source/contributing/docs-contributions/doc-new-translation.md
+++ b/docs/source/contributing/docs-contributions/doc-new-translation.md
@@ -32,7 +32,7 @@ in the workflow described below. This workflow has a handful of actors and compo
 
 ### The translation process
 
-![Translation CI/CD](static/translation-ci-cd.png "Diagram of the translation continuous integration
+![Translation CI/CD ](static/translation-ci-cd.png "Diagram of the translation continuous integration
 and deployment flow")
 
 1. A user creates or edits reStructuredText (`.rst`) or Markdown (`.md`) documents written in U.S.
@@ -372,7 +372,7 @@ ReadTheDocs will build both the source documentation site as well as sites for a
 languages. ReadTheDocs will associate the sites with one another and make them accessible via
 language links in a popup.
 
-![ReadTheDocs popup](static/translation-rtd-popup.png "Screenshot of the ReadTheDocs popup that
+![ReadTheDocs popup ](static/translation-rtd-popup.png "Screenshot of the ReadTheDocs popup that
 allows a user to view documentation in a different language")
 
 ## Reference

--- a/docs/source/contributing/docs-contributions/doc-new-translation.md
+++ b/docs/source/contributing/docs-contributions/doc-new-translation.md
@@ -373,7 +373,7 @@ ReadTheDocs will build both the source documentation site as well as sites for a
 languages. ReadTheDocs will associate the sites with one another and make them accessible via
 language links in a popup.
 
-![Project Jupyter documenation site with the ReadTheDocs popup open on the right, showing links to the documentation in other languages.](static/translation-rtd-popup.png)
+![Project Jupyter documentation site with the ReadTheDocs popup open on the right, showing links to the documentation in other languages.](static/translation-rtd-popup.png)
 
 ## Reference
 

--- a/docs/source/contributing/docs-contributions/doc-new-translation.md
+++ b/docs/source/contributing/docs-contributions/doc-new-translation.md
@@ -32,7 +32,7 @@ in the workflow described below. This workflow has a handful of actors and compo
 
 ### The translation process
 
-![Diagram of translation CI and CD. Different steps are represented by humans, files and websites icons connected by arrows.](static/translation-ci-cd.png )
+![Diagram of translation CI and CD. Different steps are represented by humans, files and websites icons connected by arrows.](static/translation-ci-cd.png)
 
 1. A user creates or edits reStructuredText (`.rst`) or Markdown (`.md`) documents written in U.S.
    English.

--- a/docs/source/contributing/docs-contributions/doc-new-translation.md
+++ b/docs/source/contributing/docs-contributions/doc-new-translation.md
@@ -32,7 +32,7 @@ in the workflow described below. This workflow has a handful of actors and compo
 
 ### The translation process
 
-![Diagram of translation CI and CD. Different steps are represented by humans, files and websites icons connected by arrows.](static/translation-ci-cd.png)
+![](static/translation-ci-cd.png)
 
 1. A user creates or edits reStructuredText (`.rst`) or Markdown (`.md`) documents written in U.S.
    English.
@@ -371,7 +371,7 @@ ReadTheDocs will build both the source documentation site as well as sites for a
 languages. ReadTheDocs will associate the sites with one another and make them accessible via
 language links in a popup.
 
-![Project Jupyter documenation site with the ReadTheDocs popup open, showing links to the documentation in other languages.](static/translation-rtd-popup.png)
+![Project Jupyter documenation site with the ReadTheDocs popup open on the right, showing links to the documentation in other languages.](static/translation-rtd-popup.png)
 
 ## Reference
 

--- a/docs/source/contributing/docs-contributions/doc-new-translation.md
+++ b/docs/source/contributing/docs-contributions/doc-new-translation.md
@@ -32,8 +32,7 @@ in the workflow described below. This workflow has a handful of actors and compo
 
 ### The translation process
 
-![Diagram of Translation CI and CD. Different steps are represented by humans, files and websites icons connected by arrows](static/translation-ci-cd.png "Diagram of the translation continuous integration 
-and deployment flow")
+![Diagram of translation CI and CD. Different steps are represented by humans, files and websites icons connected by arrows.](static/translation-ci-cd.png )
 
 1. A user creates or edits reStructuredText (`.rst`) or Markdown (`.md`) documents written in U.S.
    English.
@@ -372,7 +371,7 @@ ReadTheDocs will build both the source documentation site as well as sites for a
 languages. ReadTheDocs will associate the sites with one another and make them accessible via
 language links in a popup.
 
-![Screenshot of the Jupyter Project Documenation site with the ReadTheDocs popup open, showing links to the documentation in other languages.](static/translation-rtd-popup.png)
+![Project Jupyter documenation site with the ReadTheDocs popup open, showing links to the documentation in other languages.](static/translation-rtd-popup.png)
 
 ## Reference
 

--- a/docs/source/contributing/docs-contributions/repo-structure.md
+++ b/docs/source/contributing/docs-contributions/repo-structure.md
@@ -16,7 +16,7 @@
 - ``makefile`` : used by Sphinx to build the docs
 - ``environment.yml`` : conda build instructions
 
-![The docs directory in the jupyter kernel_gateway repo ( path: jupyter/kernel_gateway/docs). The first two elements in the directory are folders that have blue boxes surrounding them: `_static` and `source`.  The third and forth elements in the directory are files with orange boxes surrounding them: `Makefile` and `environment.yml`. There are two more files in the directory, which have no visual emphasis.](static/docs-directory.png)
+![The docs directory in the jupyter kernel_gateway repo (path: jupyter/kernel_gateway/docs). The first two elements in the directory are folders that have blue boxes surrounding them: `_static` and `source`.  The third and forth elements in the directory are files with orange boxes surrounding them: `Makefile` and `environment.yml`. There are two more files in the directory, which have no visual emphasis.](static/docs-directory.png)
 
 
 ## Sphinx

--- a/docs/source/contributing/docs-contributions/repo-structure.md
+++ b/docs/source/contributing/docs-contributions/repo-structure.md
@@ -7,7 +7,7 @@
 - ``readthedocs.yml`` : configuration file for readthedocs to build using
   conda
 
-![The root level of the jupyter kernel_gateway repo. There are orange boxes surrounding two elements in the directory structure: the docs folder and the readthedocs.yml file. The docs folder is the first element in the directory. The readthedocs.yml file is the 12th item in the directory.](static/repo-root.png "Screenshot of GitHub repo root")
+![The root level of the jupyter kernel_gateway repo. There are orange boxes surrounding two elements in the directory structure: the docs folder and the readthedocs.yml file. The docs folder is the first element in the directory. The readthedocs.yml file is the 12th item in the directory.](static/repo-root.png)
 
 ## Inside the docs directory
 
@@ -16,7 +16,7 @@
 - ``makefile`` : used by Sphinx to build the docs
 - ``environment.yml`` : conda build instructions
 
-![the docs directory in the jupyter kernel_gateway repo ( path: jupyter/kernel_gateway/docs). The first two elements in the directory are folders that have blue boxes surrounding them: `_static` and `source`.  The third and forth elements in the directory are files with orange boxes surrounding them: `Makefile` and `environment.yml`. There are two more files in the directory, which have no visual emphasis.](static/docs-directory.png "Screenshot of docs directory")
+![the docs directory in the jupyter kernel_gateway repo ( path: jupyter/kernel_gateway/docs). The first two elements in the directory are folders that have blue boxes surrounding them: `_static` and `source`.  The third and forth elements in the directory are files with orange boxes surrounding them: `Makefile` and `environment.yml`. There are two more files in the directory, which have no visual emphasis.](static/docs-directory.png)
 
 
 ## Sphinx

--- a/docs/source/contributing/docs-contributions/repo-structure.md
+++ b/docs/source/contributing/docs-contributions/repo-structure.md
@@ -16,7 +16,7 @@
 - ``makefile`` : used by Sphinx to build the docs
 - ``environment.yml`` : conda build instructions
 
-![the docs directory in the jupyter kernel_gateway repo ( path: jupyter/kernel_gateway/docs). The first two elements in the directory are folders that have blue boxes surrounding them: `_static` and `source`.  The third and forth elements in the directory are files with orange boxes surrounding them: `Makefile` and `environment.yml`. There are two more files in the directory, which have no visual emphasis.](static/docs-directory.png)
+![The docs directory in the jupyter kernel_gateway repo ( path: jupyter/kernel_gateway/docs). The first two elements in the directory are folders that have blue boxes surrounding them: `_static` and `source`.  The third and forth elements in the directory are files with orange boxes surrounding them: `Makefile` and `environment.yml`. There are two more files in the directory, which have no visual emphasis.](static/docs-directory.png)
 
 
 ## Sphinx

--- a/docs/source/contributing/docs-contributions/repo-structure.md
+++ b/docs/source/contributing/docs-contributions/repo-structure.md
@@ -7,7 +7,7 @@
 - ``readthedocs.yml`` : configuration file for readthedocs to build using
   conda
 
-![Repo root directory](static/repo-root.png "Screenshot of GitHub repo root")
+![Repo root directory ](static/repo-root.png "Screenshot of GitHub repo root")
 
 ## Inside the docs directory
 
@@ -16,7 +16,7 @@
 - ``makefile`` : used by Sphinx to build the docs
 - ``environment.yml`` : conda build instructions
 
-![``docs`` directory](static/docs-directory.png "Screenshot of docs directory")
+![``docs`` directory ](static/docs-directory.png "Screenshot of docs directory")
 
 
 ## Sphinx

--- a/docs/source/contributing/docs-contributions/repo-structure.md
+++ b/docs/source/contributing/docs-contributions/repo-structure.md
@@ -7,7 +7,7 @@
 - ``readthedocs.yml`` : configuration file for readthedocs to build using
   conda
 
-![Repo root directory ](static/repo-root.png "Screenshot of GitHub repo root")
+![The root level of the jupyter kernel_gateway repo. There are orange boxes surrounding two elements in the directory structure: the docs folder and the readthedocs.yml file. The docs folder is the first element in the directory. The readthedocs.yml file is the 12th item in the directory.](static/repo-root.png "Screenshot of GitHub repo root")
 
 ## Inside the docs directory
 
@@ -16,7 +16,7 @@
 - ``makefile`` : used by Sphinx to build the docs
 - ``environment.yml`` : conda build instructions
 
-![``docs`` directory ](static/docs-directory.png "Screenshot of docs directory")
+![the docs directory in the jupyter kernel_gateway repo ( path: jupyter/kernel_gateway/docs). The first two elements in the directory are folders that have blue boxes surrounding them: `_static` and `source`.  The third and forth elements in the directory are files with orange boxes surrounding them: `Makefile` and `environment.yml`. There are two more files in the directory, which have no visual emphasis.](static/docs-directory.png "Screenshot of docs directory")
 
 
 ## Sphinx

--- a/docs/source/projects/architecture/content-architecture.rst
+++ b/docs/source/projects/architecture/content-architecture.rst
@@ -51,6 +51,9 @@ The core execution machinery for the kernel is shared with terminal IPython:
 .. image:: figs/ipy_kernel_and_terminal.png
    :alt: 
 
+.. 
+   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
+
 A kernel process can be connected to more than one frontend simultaneously. In
 this case, the different frontends will have access to the same variables.
 
@@ -68,6 +71,9 @@ in the target language:
 
 .. image:: figs/other_kernels.png
    :alt: 
+
+.. 
+   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
 
 Wrapper kernels are easier to write quickly for languages that have good
 Python wrappers, like `octave_kernel <https://pypi.python.org/pypi/octave_kernel>`_,
@@ -122,6 +128,9 @@ steps:
 
 .. image:: figs/nbconvert.png
    :alt: 
+
+.. 
+   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
 
 1. Preprocessors modify the notebook in memory. E.g. ExecutePreprocessor runs
    the code in the notebook and updates the output.

--- a/docs/source/projects/architecture/content-architecture.rst
+++ b/docs/source/projects/architecture/content-architecture.rst
@@ -49,6 +49,7 @@ between the frontends and the IPython Kernel is described in
 The core execution machinery for the kernel is shared with terminal IPython:
 
 .. image:: figs/ipy_kernel_and_terminal.png
+   :alt: 
 
 A kernel process can be connected to more than one frontend simultaneously. In
 this case, the different frontends will have access to the same variables.
@@ -66,6 +67,7 @@ the core execution part. Native kernels implement execution and communications
 in the target language:
 
 .. image:: figs/other_kernels.png
+   :alt: 
 
 Wrapper kernels are easier to write quickly for languages that have good
 Python wrappers, like `octave_kernel <https://pypi.python.org/pypi/octave_kernel>`_,
@@ -102,6 +104,7 @@ to the notebook server, which saves it on disk as a JSON file with a
 ``.ipynb`` extension.
 
 .. image:: figs/notebook_components.png
+   :alt: 
 
 The notebook server, not the kernel, is responsible for saving and loading
 notebooks, so you can edit notebooks even if you don't have the kernel for
@@ -118,6 +121,7 @@ as HTML, LaTeX, or reStructuredText. This conversion goes through a series of
 steps:
 
 .. image:: figs/nbconvert.png
+   :alt: 
 
 1. Preprocessors modify the notebook in memory. E.g. ExecutePreprocessor runs
    the code in the notebook and updates the output.
@@ -175,4 +179,4 @@ Below is a high level visual overview of project relationships. It is current as
 
 .. image:: /_static/_images/repos_map.png
    :width: 75%
-   :alt: Architecture diagram of project relationships
+   :alt: Architecture diagram of project relationships 

--- a/docs/source/projects/architecture/content-architecture.rst
+++ b/docs/source/projects/architecture/content-architecture.rst
@@ -49,7 +49,7 @@ between the frontends and the IPython Kernel is described in
 The core execution machinery for the kernel is shared with terminal IPython:
 
 .. image:: figs/ipy_kernel_and_terminal.png
-   :alt: Venn diagram showing that Terminal IPython and the IPython Kernel both share the same Python executable. Terminal IPython communicates with the Python executable using stdin and stdout, whereas the Python Kernel uses JSON messages sent over ZeroMQ. 
+   :alt: 
 
 A kernel process can be connected to more than one frontend simultaneously. In
 this case, the different frontends will have access to the same variables.
@@ -67,7 +67,7 @@ the core execution part. Native kernels implement execution and communications
 in the target language:
 
 .. image:: figs/other_kernels.png
-   :alt: Diagram showing how a wrapper kernel differs from a native kernel. Wrapper reuses IPython's message-passing code; native does not.
+   :alt: 
 
 Wrapper kernels are easier to write quickly for languages that have good
 Python wrappers, like `octave_kernel <https://pypi.python.org/pypi/octave_kernel>`_,
@@ -121,7 +121,7 @@ as HTML, LaTeX, or reStructuredText. This conversion goes through a series of
 steps:
 
 .. image:: figs/nbconvert.png
-   :alt: Flow chart demonstrating the steps in the conversion process of the nbconvert tool. The notebook is passed to preprocessors, which then go to the exporter. The exporter creates the exported file, which is then passed to postprocessors in the final step. 
+   :alt: 
 
 1. Preprocessors modify the notebook in memory. E.g. ExecutePreprocessor runs
    the code in the notebook and updates the output.

--- a/docs/source/projects/architecture/content-architecture.rst
+++ b/docs/source/projects/architecture/content-architecture.rst
@@ -49,7 +49,7 @@ between the frontends and the IPython Kernel is described in
 The core execution machinery for the kernel is shared with terminal IPython:
 
 .. image:: figs/ipy_kernel_and_terminal.png
-   :alt: 
+   :alt: Venn diagram showing that Terminal IPython and the IPython Kernel both share the same Python executable. Terminal IPython communicates with the Python executable using stdin and stdout, whereas the Python Kernel uses JSON messages sent over ZeroMQ. 
 
 A kernel process can be connected to more than one frontend simultaneously. In
 this case, the different frontends will have access to the same variables.
@@ -67,7 +67,7 @@ the core execution part. Native kernels implement execution and communications
 in the target language:
 
 .. image:: figs/other_kernels.png
-   :alt: 
+   :alt: Diagram showing how a wrapper kernel differs from a native kernel. Wrapper reuses IPython's message-passing code; native does not.
 
 Wrapper kernels are easier to write quickly for languages that have good
 Python wrappers, like `octave_kernel <https://pypi.python.org/pypi/octave_kernel>`_,
@@ -104,7 +104,7 @@ to the notebook server, which saves it on disk as a JSON file with a
 ``.ipynb`` extension.
 
 .. image:: figs/notebook_components.png
-   :alt: 
+   :alt: Communication diagram showing five nodes labeled user, browser, notebook server, notebook file, and kernel. The notebook server is a communication hub. The browser, notebook file and kernel cannot talk to each other directly. They communicate indirectly through the notebook server. The user can only talk to the browser. The notebook server and kernel are colored green whereas the browser is colored purple to draw a distinction between the Jupyter front end versus back end.
 
 The notebook server, not the kernel, is responsible for saving and loading
 notebooks, so you can edit notebooks even if you don't have the kernel for
@@ -121,7 +121,7 @@ as HTML, LaTeX, or reStructuredText. This conversion goes through a series of
 steps:
 
 .. image:: figs/nbconvert.png
-   :alt: 
+   :alt: Flowchart demonstrating the steps in the conversion process of the Nbconvert tool. The notebook is passed to preprocessors, which then go to the exporter. The exporter creates the exported file, which is then passed to postprocessors in the final step. 
 
 1. Preprocessors modify the notebook in memory. E.g. ExecutePreprocessor runs
    the code in the notebook and updates the output.

--- a/docs/source/projects/architecture/content-architecture.rst
+++ b/docs/source/projects/architecture/content-architecture.rst
@@ -121,7 +121,7 @@ as HTML, LaTeX, or reStructuredText. This conversion goes through a series of
 steps:
 
 .. image:: figs/nbconvert.png
-   :alt: Flowchart demonstrating the steps in the conversion process of the Nbconvert tool. The notebook is passed to preprocessors, which then go to the exporter. The exporter creates the exported file, which is then passed to postprocessors in the final step. 
+   :alt: Flow chart demonstrating the steps in the conversion process of the nbconvert tool. The notebook is passed to preprocessors, which then go to the exporter. The exporter creates the exported file, which is then passed to postprocessors in the final step. 
 
 1. Preprocessors modify the notebook in memory. E.g. ExecutePreprocessor runs
    the code in the notebook and updates the output.
@@ -179,4 +179,4 @@ Below is a high level visual overview of project relationships. It is current as
 
 .. image:: /_static/_images/repos_map.png
    :width: 75%
-   :alt: Architecture diagram of project relationships 
+   :alt: Architecture diagram of Jupyter project relationships from servers, applications, API, and kernels.

--- a/docs/source/projects/architecture/content-architecture.rst
+++ b/docs/source/projects/architecture/content-architecture.rst
@@ -48,11 +48,11 @@ between the frontends and the IPython Kernel is described in
 
 The core execution machinery for the kernel is shared with terminal IPython.
 
+.. Alt text here and below is intentionally blank
+.. this is because the image content is described thoroughly in the surrounding text.
+
 .. image:: figs/ipy_kernel_and_terminal.png
    :alt: 
-
-.. 
-   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
 
 A kernel process can be connected to more than one frontend simultaneously. In
 this case, the different frontends will have access to the same variables.
@@ -71,9 +71,6 @@ in the target language.
 
 .. image:: figs/other_kernels.png
    :alt: 
-
-.. 
-   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
 
 Wrapper kernels are easier to write quickly for languages that have good
 Python wrappers, like `octave_kernel <https://pypi.python.org/pypi/octave_kernel>`_,
@@ -111,9 +108,6 @@ to the notebook server, which saves it on disk as a JSON file with a
 
 .. image:: figs/notebook_components.png
    :alt:
-   
-.. 
-   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
 
 The notebook server is a communication hub. The browser, notebook file on disk, and
 kernel cannot talk to each other directly. They communicate through the notebook server. 
@@ -133,9 +127,6 @@ steps:
 
 .. image:: figs/nbconvert.png
    :alt: 
-
-.. 
-   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
 
 1. Preprocessors modify the notebook in memory. E.g. ExecutePreprocessor runs
    the code in the notebook and updates the output.

--- a/docs/source/projects/architecture/content-architecture.rst
+++ b/docs/source/projects/architecture/content-architecture.rst
@@ -46,7 +46,7 @@ messages sent over `ZeroMQ <http://zeromq.org/>`_ sockets; the protocol used
 between the frontends and the IPython Kernel is described in
 :ref:`jupyterclient:messaging`.
 
-The core execution machinery for the kernel is shared with terminal IPython:
+The core execution machinery for the kernel is shared with terminal IPython.
 
 .. image:: figs/ipy_kernel_and_terminal.png
    :alt: 
@@ -67,7 +67,7 @@ we are refining IPython to make that more practical.
 Today, there are two ways to develop a kernel for another language. Wrapper
 kernels reuse the communications machinery from IPython, and implement only
 the core execution part. Native kernels implement execution and communications
-in the target language:
+in the target language.
 
 .. image:: figs/other_kernels.png
    :alt: 
@@ -110,8 +110,13 @@ to the notebook server, which saves it on disk as a JSON file with a
 ``.ipynb`` extension.
 
 .. image:: figs/notebook_components.png
-   :alt: Communication diagram showing five nodes labeled user, browser, notebook server, notebook file, and kernel. The notebook server is a communication hub. The browser, notebook file and kernel cannot talk to each other directly. They communicate indirectly through the notebook server. The user can only talk to the browser. The notebook server and kernel are colored green whereas the browser is colored purple to draw a distinction between the Jupyter front end versus back end.
+   :alt:
+   
+.. 
+   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
 
+The notebook server is a communication hub. The browser, notebook file on disk, and
+kernel cannot talk to each other directly. They communicate through the notebook server. 
 The notebook server, not the kernel, is responsible for saving and loading
 notebooks, so you can edit notebooks even if you don't have the kernel for
 that language—you just won't be able to run code. The kernel doesn't know

--- a/docs/source/projects/education.rst
+++ b/docs/source/projects/education.rst
@@ -16,5 +16,6 @@ is a book about using Jupyter in teaching and learning.
         assignments.
         `Documentation <https://nbgrader.readthedocs.io/en/stable/>`__ |
         `Repo <https://github.com/jupyter/nbgrader>`__
+
     `jupyter4edu <https://github.com/orgs/jupyter4edu/>`__
         GitHub organization hosting community resources for Jupyter in education

--- a/docs/source/projects/incubator.rst
+++ b/docs/source/projects/incubator.rst
@@ -33,5 +33,6 @@ Jupyter projects in `Binder <http://mybinder.org/>`_. Just head over to the
 the online trial. You should see an interactive notebook similar to this one:
 
 .. image:: ../_static/_images/showcase.png
+   :alt: 
 
 .. _showcase: https://github.com/jupyter-incubator/showcase

--- a/docs/source/projects/incubator.rst
+++ b/docs/source/projects/incubator.rst
@@ -33,6 +33,6 @@ Jupyter projects in `Binder <http://mybinder.org/>`_. Just head over to the
 the online trial. You should see an interactive notebook similar to this one:
 
 .. image:: ../_static/_images/showcase.png
-   :alt: 
+   :alt: Screenshot of the online trial Jupyter notebook. It begins with a text cell stating that this is a temporary notebook server that acts as a sandbox. It then lists the different incubator projects that are available on the server, with links to demos, documentation and GitHub repo for each.
 
 .. _showcase: https://github.com/jupyter-incubator/showcase

--- a/docs/source/projects/incubator.rst
+++ b/docs/source/projects/incubator.rst
@@ -33,6 +33,6 @@ Jupyter projects in `Binder <http://mybinder.org/>`_. Just head over to the
 the online trial. You should see an interactive notebook similar to this one:
 
 .. image:: ../_static/_images/showcase.png
-   :alt: Screenshot of the online trial Jupyter notebook. It begins with a text cell stating that this is a temporary notebook server that acts as a sandbox. It then lists the different incubator projects that are available on the server, with links to demos, documentation and GitHub repo for each.
+   :alt: The online trial Jupyter notebook. It begins with a text cell stating that this is a temporary notebook server. It then lists the different incubator projects that are available on the server, with links to demos, documentation and GitHub repo for each.
 
 .. _showcase: https://github.com/jupyter-incubator/showcase

--- a/docs/source/reference/ipython.rst
+++ b/docs/source/reference/ipython.rst
@@ -4,6 +4,7 @@ IPython
 .. image:: ../_static/_images/ipy_logo.png
       :width: 50%
       :target: https://ipython.org
+      :alt: 
 
 
 Description

--- a/docs/source/reference/ipython.rst
+++ b/docs/source/reference/ipython.rst
@@ -4,7 +4,7 @@ IPython
 .. image:: ../_static/_images/ipy_logo.png
       :width: 50%
       :target: https://ipython.org
-      :alt: 
+      :alt: IPython Interactive Computing - Home
 
 
 Description

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -50,7 +50,7 @@ notebooks. Often this will be your home directory.
 **Notebook Dashboard**
 
 .. image:: _static/_images/tryjupyter_file.png
-    :alt: 
+    :alt: Screenshot of try.jupyter.org with the "Files" tab of the Jupyter dashboard open. There is a list of files, Jupyter notebooks, and subdirectories relative to the root directory where the server was started and a text reading "Select items to perform actions on them".
 
 Introducing the Notebook Server's Command Line Options
 ------------------------------------------------------

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -50,6 +50,7 @@ notebooks. Often this will be your home directory.
 **Notebook Dashboard**
 
 .. image:: _static/_images/tryjupyter_file.png
+    :alt: 
 
 Introducing the Notebook Server's Command Line Options
 ------------------------------------------------------

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -50,7 +50,7 @@ notebooks. Often this will be your home directory.
 **Notebook Dashboard**
 
 .. image:: _static/_images/tryjupyter_file.png
-    :alt: Screenshot of try.jupyter.org with the "Files" tab of the Jupyter dashboard open. There is a list of files, Jupyter notebooks, and subdirectories relative to the root directory where the server was started and a text reading "Select items to perform actions on them".
+    :alt: try.jupyter.org with the "Files" tab of the Notebook Dashboard open. There is a list of files, Jupyter notebooks, and subdirectories relative to the root directory where the server was started and a text reading "Select items to perform actions on them".
 
 Introducing the Notebook Server's Command Line Options
 ------------------------------------------------------

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -52,6 +52,9 @@ notebooks. Often this will be your home directory.
 .. image:: _static/_images/tryjupyter_file.png
     :alt: 
 
+ .. 
+   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
+
 Introducing the Notebook Server's Command Line Options
 ------------------------------------------------------
 

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -50,7 +50,7 @@ notebooks. Often this will be your home directory.
 **Notebook Dashboard**
 
 .. image:: _static/_images/tryjupyter_file.png
-    :alt: try.jupyter.org with the "Files" tab of the Notebook Dashboard open. There is a list of files, Jupyter notebooks, and subdirectories relative to the root directory where the server was started and a text reading "Select items to perform actions on them".
+    :alt: 
 
 Introducing the Notebook Server's Command Line Options
 ------------------------------------------------------

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -49,11 +49,10 @@ notebooks. Often this will be your home directory.
 
 **Notebook Dashboard**
 
+ .. Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
+
 .. image:: _static/_images/tryjupyter_file.png
     :alt: 
-
- .. 
-   Alt text is intentionally left blank because the image content is described thoroughly in the surrounding text.
 
 Introducing the Notebook Server's Command Line Options
 ------------------------------------------------------


### PR DESCRIPTION
This PR adds or updates existing [alt text](https://moz.com/learn/seo/alt-text) to Project Jupyter documentation. It includes alt text for
- all images on the main documentation
- all images used in community call notes

If there are images in this repo you think were missed, I'd love to know so we can address them in the future.

If you have any questions about reviewing alt text, let me know and I'd be happy to tell you what I look for.

Thanks in advance for reviewing this PR! 🌻 

---

This alt text was contributed by wonderful volunteers at one of the [Jupyter accessibility workshops](https://blog.jupyter.org/join-us-for-the-jupyter-accessibility-workshops-part-1-133e0e522d1b)! They teamed up to make progress on so many images. 

If you are curious how we have a commit authored by ten people (wow! 🎉), feel free to check out our [working PR](https://github.com/isabela-pf/jupyter/pull/1) or the [How to Participate section of the event agenda](https://github.com/Quansight-Labs/jupyter-accessibility-workshops/blob/main/events/2022-january-22/mentored_sprint_agenda.md#how-to-participate-in-writing-alt-text).



