### PR TITLE
February and March 2022 community call notes

### DIFF
--- a/docs/source/community/community-call-notes/2022-february.md
+++ b/docs/source/community/community-call-notes/2022-february.md
@@ -1,0 +1,72 @@
+# February 22, 2022
+
+**Date:** February 22, 2022, at 8am Pacific (your [timezone](https://arewemeetingyet.com/Los%20Angeles/2022-02-22/8:00/Jupyter%20Community%20Call))
+
+**[Discourse](https://discourse.jupyter.org/t/jupyter-community-calls/668)**
+
+**[YouTube link](https://youtu.be/-_i1JTRnlXc)** 
+
+**Please note:**
+- Community calls are recorded and posted to this [playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
+- These notes will be recorded and posted [here](https://jupyter.readthedocs.io/en/latest/community/community-call-notes/index.html)
+- Everyone present is held to the [Jupyter Code of Conduct](https://jupyter.org/conduct)
+
+## Purpose
+
+Think of it as a monthly, virtual JupyterCon. It’s a place to announce and share fun things happening in the Jupyter community.
+
+For more discussion on the format of these calls, see the thread [here](https://discourse.jupyter.org/t/reviving-the-all-jupyter-team-meetings/423).
+
+## Short reports, celebrations, shout-outs
+
+This is a place to make short announcements (without a need for discussion). 
+
+* **Isabela:** Jupyter accessibility workshops are coming up in March. [Sign up for the March 12 event](https://hopin.com/events/jupyter-accessibility-workshop-intro-to-accesibility-and-inclusive-design-with-eric-bailey). [Sign up for the March 19 event](https://hopin.com/events/jupyter-accessibility-workshop-auditing-in-open-source).
+* **Tony:** We now have Jupyter triage meetings (on Thursdays). Find them on the [community calendar](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings)
+* **Nick:** [`flit 3.7.0`](https://flit.readthedocs.io/en/stable/history.html#version-3-7) released, supports `data_files` for kernelspecs, extensions, etc.
+* **@jasongrout:** We are releasing RC prereleases of ipywidgets 8.0 and 7.7 very soon. Will announce on [Jupyter Discourse](https://discourse.jupyter.org/latest) when it happens.
+
+## Agenda Items
+
+* **Ana Ruvalcaba/Gayle Ollington** Introduction and welcome to Gayle, Community Events Manager for Project Jupyter.
+  * [Jupyter Community Building Committee Charter](https://jupyter.org/governance/communitybuildingcommittee.html)
+  * [December 2021 Jupyter Community Update](https://blog.jupyter.org/jupyter-community-2021-update-84c5cd3c5e75)
+* **Frederic Collonval**: WIP [Jupyter styled components](https://jupyterlab-contrib.github.io/jupyter-ui-toolkit) to speed up your dev.  
+  Come as web components or React components and are ARIA compliant thanks to the underlying [FAST Framework](https://explore.fast.design/).  
+  Related [JEP pre-proposal](https://github.com/jupyter/enhancement-proposals/issues/88)
+     - Question: will these be eventually used for ipywidgets? Answer: There hasn't been a discussion yet, but it is possible to make a new library (like the ones for Vue and Angular)
+* **Jeremy Tuloup, Nicholas Bollweg** [An embeddable REPL powered by JupyterLite](https://jupyterlite.readthedocs.io/en/latest/applications/repl.html), various updates (cache busting, slimer app, Pyodide 0.19)
+* **Tasko Olevski, Andreas Bleuler** [Amalthea](https://github.com/SwissDataScienceCenter/amalthea) - A Kubernetes operator for Jupyter Servers. Short introduction to the project and its goals. [Link to presentation](https://docs.google.com/presentation/d/18DvgOFoJko2bd9Cvmd7sSLsV0jbacNPoUfpHtbapeMY/edit?usp=sharing)
+
+## Other Links Shared
+
+This is a space to store links shared during community call discussions related to or separate from the agenda items.
+
+- Today's date is an anagram! [a 22-02-2022 tweet](https://twitter.com/simongerman600/status/1495870748866621441)
+- [CarpenPi project](https://github.com/CarpenPi)
+- [mamba-org/quetz-frontend repository](https://github.com/mamba-org/quetz-frontend/pull/98)
+- [ipydrawio in JupyterLite](https://ipydrawio--92.org.readthedocs.build/en/92/_static/lab/index.html)
+- [tangle examples notebook in JupyterLite](https://pidgy.readthedocs.io/en/latest/_/retro/notebooks/index.html?path=tangle_examples.ipynb&room=duck-day-wuack)
+- [Renku](https://renkulab.io/)
+
+## Attendees 
+
+|   Name   |           Institution     | GitHub Handle|
+|----------|---------------------------|--------------|
+| Jason Grout | Databricks | @jasongrout
+| Frederic Collonval | QuantStack | @fcollonval |
+| Sarah Gibson | 2i2c | @sgibson91
+| David Brochart | QuantStack | @davidbrochart |
+| Nick Bollweg | Georgia Tech | @bollwyvl @nrbgt |
+|Simon Li 🦆 | University of Dundee| @manics |
+|tonyfast | quansight | @tonyfast |
+|Tasko Olevski| SDSC / ETH Zürich | @olevski |
+| Jeremy Tuloup | QuantStack | @jtpio |
+| Simon Adorf | EPFL | @csadorf |
+| Andreas Bleuler | SDSC / ETH Zürich | @ableuler |
+|Zach Sailer | Apple | @Zsailer |
+|Isabela Presedo-Floyd 🦆 | Quansight Labs | @isabela-pf |
+|Ana Ruvalcaba | California Polytechnic State University | @Ruv7
+|Gayle Ollington | NumFOCUS 
+ 
+Plus 6 more

--- a/docs/source/community/community-call-notes/2022-march.md
+++ b/docs/source/community/community-call-notes/2022-march.md
@@ -1,0 +1,31 @@
+# March 29, 2022
+
+**Date:** March 29, 2022, at 8am Pacific (your [timezone](https://arewemeetingyet.com/Los%20Angeles/2022-03-29/8:00/Jupyter%20Community%20Call))
+
+**[Discourse](https://discourse.jupyter.org/t/jupyter-community-calls/668)**
+
+There is no recording for this call.
+
+**Please note:**
+- Community calls are recorded and posted to this [playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
+- These notes will be recorded and posted [here](https://jupyter.readthedocs.io/en/latest/community/community-call-notes/index.html)
+- Everyone present is held to the [Jupyter Code of Conduct](https://jupyter.org/conduct)
+
+## Purpose
+
+Think of it as a monthly, virtual JupyterCon. It’s a place to announce and share fun things happening in the Jupyter community.
+
+For more discussion on the format of these calls, see the thread [here](https://discourse.jupyter.org/t/reviving-the-all-jupyter-team-meetings/423).
+
+## Short reports, celebrations, shout-outs
+
+This is a place to make short announcements (without a need for discussion). 
+
+* **Zach** [voila-gridstack](https://github.com/voila-dashboards/voila-gridstack) is great and Zach can't wait for a release on PyPI sometime soon!
+    * [viola-dashboards/voila #846 Switch to a lab-based app for the Voila frontend ](https://github.com/voila-dashboards/voila/pull/846)
+
+## Agenda Items
+
+With time changes, this meeting was accidentally double-booked with the Jupyter Secuirty meeting! Since we had an open agenda before the community call, our notes overlap with theirs.
+
+For notes from this call, please refer to the [March 29, 2022 jupyter/security meeting notes!](https://github.com/jupyter/security/tree/main/meetings/2022-03-29.md)

--- a/docs/source/community/community-call-notes/index.rst
+++ b/docs/source/community/community-call-notes/index.rst
@@ -9,6 +9,7 @@ The Jupyter Community Call is an open video call. Think of this as a "monthly, v
 .. toctree::
    :maxdepth: 1
 
+   March 2022 <2022-march.md>
    February 2022 <2022-february.md>
    January 2022 <2022-january.md>
    November 2021 <2021-november.md>

--- a/docs/source/community/community-call-notes/index.rst
+++ b/docs/source/community/community-call-notes/index.rst
@@ -9,6 +9,7 @@ The Jupyter Community Call is an open video call. Think of this as a "monthly, v
 .. toctree::
    :maxdepth: 1
 
+   February 2022 <2022-february.md>
    January 2022 <2022-january.md>
    November 2021 <2021-november.md>
    October 2021 <2021-october.md>


### PR DESCRIPTION
Hello there! It's time for another set of community call notes. This time it's February 2022 with a very full agenda. 

Let me know if there's any mistakes. Thanks in advance for reviewing this PR! 🌻 