### PR TITLE
Add `jupyterlab` to meta package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup_args = dict(
         'nbconvert',
         'ipykernel',
         'ipywidgets',
+        'jupyterlab',
     ],
     url                 = "http://jupyter.org",
     license             = "BSD",


### PR DESCRIPTION
This is something we discussed at the Notebook Weekly call today.

The last version of the `jupyter` metapackage was released in 2015 and does not include `jupyterlab`.

![image](https://user-images.githubusercontent.com/591645/173870347-b0e888dc-786f-44dd-8264-56f8804c8535.png)

This PR proposes adding `jupyterlab` to this metapackage by default. This metapackage is still installed a lot by end users, so it would be great if they could get the new Jupyter UI by default:

![image](https://user-images.githubusercontent.com/591645/173870915-12bc293c-a6c0-4bbc-a739-f2d858d43c00.png)


cc @afshin @Zsailer @echarles @rrosio