### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -126,3 +126,17 @@ By default, notebook errors will be raised and printed into the terminal. You ca
     jupyter run notebook.ipynb --allow-errors
 
 For more sophisticated execution options, consider the `papermill <https://pypi.org/project/papermill/>`_ library.
+
+Autocomplete
+------------
+
+|fig| `Fig <https://fig.io/>`_ provides IDE-style autocompletions for Jupyter. It works in bash, zsh, and fish.
+
+.. |fig| image:: https://fig.io/badges/Logo.svg
+  :width: 15
+
+To install, run:
+
+.. code:: bash
+
+   brew install fig


### PR DESCRIPTION
[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Jupyter. It looks like this:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/4949076/181367534-4e365991-85d9-4c99-8c9a-0de43b572e09.png">

We think this will help users become more efficient with Jupyter CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!