### PR TITLE
Build releases with CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,41 @@
+# Build releases and (on tags) publish to PyPI
+name: Release
+
+# always build releases (to make sure wheel-building works)
+# but only publish to PyPI on tags
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+
+      - name: install build package
+        run: |
+          pip install --upgrade pip
+          pip install build
+          pip freeze
+
+      - name: build release
+        run: |
+          python -m build --sdist --wheel .
+          ls -l dist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: jupyter-${{ github.sha }}
+          path: "dist/*"
+          if-no-files-found: error
+
+      - name: publish to pypi
+        uses: pypa/gh-action-pypi-publish@v1.5.1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: install build package
         run: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The easiest way to build the documentation locally is by using the [`nox` comman
 To build and preview the site locally, follow these steps:
 
 1. **Clone this repository**.
-   
+
    ```console
    $ git clone https://github.com/jupyter/jupyter
    $ cd jupyter
@@ -33,7 +33,7 @@ To build and preview the site locally, follow these steps:
    $ pip install nox
    ```
 3. **Run the `docs` command**
-   
+
    ```console
    $ nox -s docs
    ```
@@ -65,19 +65,19 @@ First, install [the `miniconda` Python distribution](https://conda.io/miniconda.
 Next, navigate to the `/docs` directory and create a `conda` environment:
 
 ```bash
-conda env create -f environment.yml  
-```  
+conda env create -f environment.yml
+```
 
 Activate the environment:
 
 ```bash
-source activate jupyter_docs  
+source activate jupyter_docs
 ```
 
 **Build the docs** using Sphinx with the following commands:
 
 ```bash
-make clean  
+make clean
 make html
 ```
 
@@ -86,3 +86,22 @@ The docs will be built in `build/html`. They can be viewed by opening `build/htm
 ```bash
 python3 -m http.server
 ```
+
+## Releasing the jupyter metapackage
+
+Anyone with push access to this repo can make a release
+of the Jupyter metapackage (this happens very rarely).
+We use [tbump][] to publish releases.
+
+tbump updates version numbers and publishes the `git tag` of the version.
+[Our GitHub Actions](https://github.com/jupyter/jupyter/actions)
+then build the releases and publish them to PyPI.
+
+The steps involved:
+
+1. install tbump: `pip install tbump`
+2. tag and publish the release `tbump $NEW_VERSION`.
+
+That's it!
+
+[tbump]: https://github.com/your-tools/tbump

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 setup_args = dict(
     name                = 'jupyter',
-    version             = '1.1.0',
+    version             = '2.0.0.dev',
     description         = "Jupyter metapackage. Install all the Jupyter components in one go.",
     long_description    = """Install the Jupyter system, including the notebook, qtconsole, and the IPython kernel.""",
     author              = "Jupyter Development Team",

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 # github_url = "https://github.com/<user or organization>/<project>/"
 
 [version]
-current = "1.1.0"
+current = "2.0.0.dev"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,41 @@
+# Uncomment this if your project is hosted on GitHub:
+# github_url = "https://github.com/<user or organization>/<project>/"
+
+[version]
+current = "1.1.0"
+
+# Example of a semver regexp.
+# Make sure this matches current_version before
+# using tbump
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (?P<extra>.*)
+  '''
+
+[git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[file]]
+src = "setup.py"
+
+# You can specify a list of commands to
+# run after the files have been patched
+# and before the git commit is made
+
+#  [[before_commit]]
+#  name = "check changelog"
+#  cmd = "grep -q {new_version} Changelog.rst"
+
+# Or run some commands after the git tag and the branch
+# have been pushed:
+#  [[after_push]]
+#  name = "publish"
+#  cmd = "./publish.sh"


### PR DESCRIPTION
adds release-publishing github action (and token in repo secrets) so anyone with write access should be able to publish a release of this package with `tbump $NEXT_VERSION`.