### PR TITLE
Fix broken link to JupyterHub team meetings

### DIFF
--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -60,7 +60,7 @@ following pages should help you find the information for each.
 
 
 **JupyterHub meetings** happen monthly. For a calendar of future team meetings, see
-`the JupyterHub team compass repository <https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html>`_.
+`the JupyterHub team compass repository <https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings/index.html>`_.
 
 **JupyterLab meetings** happen weekly. For more information about when these meetings happen,
 as well as notes from each meeting, see `the JupyterLab README <https://github.com/jupyterlab/jupyterlab#weekly-dev-meeting>`_.


### PR DESCRIPTION
https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html is now a 404 page; corrects JupyterHub team meetings page link to https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings/index.html .