### PR TITLE
Fix documentation for default location of jupyter runtime files

### DIFF
--- a/docs/source/use/jupyter-directories.rst
+++ b/docs/source/use/jupyter-directories.rst
@@ -127,10 +127,8 @@ Runtime files
 Things like connection files, which are only useful for the lifetime of a
 particular process, have a runtime directory.
 
-On Linux and other free desktop platforms, these runtime files are stored in
-``$XDG_RUNTIME_DIR/jupyter`` by default. On other platforms, it's a
-``runtime/`` subdirectory of the user's data directory (second row of the
-table above).
+These runtime files are stored in a ``runtime/`` subdirectory of the user's
+data directory (second row of the table above).
 
 An environment variable may also be used to set the runtime directory.
 


### PR DESCRIPTION
Since [jupyter_core PR #143](https://github.com/jupyter/jupyter_core/pull/143), XDG_RUNTIME_DIR is no longer used to set Jupyter runtime dir, and the default on all platforms is `(data_dir)/runtime`.