### PR TITLE
Chore: Typo Fix in multiple files(jupyter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To start this live server, use the following `nox` command:
 $ nox -s docs-live
 ```
 
-When the build is finished, go to the URL that is displayed. It should show a live preview of your doucmentation.
+When the build is finished, go to the URL that is displayed. It should show a live preview of your documentation.
 
 To stop serving the website, press **`Ctrl`**-`C` in your terminal
 

--- a/docs/source/community/community-call-notes/2021-november.md
+++ b/docs/source/community/community-call-notes/2021-november.md
@@ -1,6 +1,6 @@
 # November 30, 2021
 
-**Date:** Novermber 30, 2021, at 8am Pacific (your [timezone](https://arewemeetingyet.com/Los%20Angeles/2021-11-30/8:00/Jupyter%20Community%20Call))
+**Date:** November 30, 2021, at 8am Pacific (your [timezone](https://arewemeetingyet.com/Los%20Angeles/2021-11-30/8:00/Jupyter%20Community%20Call))
 
 **[Discourse](https://discourse.jupyter.org/t/jupyter-community-calls/668)**
 

--- a/docs/source/community/community-call-notes/2022-april.md
+++ b/docs/source/community/community-call-notes/2022-april.md
@@ -25,7 +25,7 @@ This is a place to make short announcements (without a need for discussion).
 
 ## Agenda Items
 
-* **[JupyterLab-LaTeX UX improvements PR](https://github.com/jupyterlab/jupyterlab-latex/pull/192)** Result of 2 semesters of work by [Junior Design Capstone class](https://techstyle.lmc.gatech.edu/cs-tech-comm-junior-design-sequence/) team from Georgia Tech done for client (Axle Informatics/NIH). Project included a user reasearch section which is summarized in PR. New features highlights:
+* **[JupyterLab-LaTeX UX improvements PR](https://github.com/jupyterlab/jupyterlab-latex/pull/192)** Result of 2 semesters of work by [Junior Design Capstone class](https://techstyle.lmc.gatech.edu/cs-tech-comm-junior-design-sequence/) team from Georgia Tech done for client (Axle Informatics/NIH). Project included a user research section which is summarized in PR. New features highlights:
     * Preview button
     * Formatting buttons (bold, italic, underlined, subscript, superscript)
     * Autocomplete for common LaTeX tags (i.e. `\subsection`)

--- a/docs/source/community/community-call-notes/2022-march.md
+++ b/docs/source/community/community-call-notes/2022-march.md
@@ -26,6 +26,6 @@ This is a place to make short announcements (without a need for discussion).
 
 ## Agenda Items
 
-With time changes, this meeting was accidentally double-booked with the Jupyter Secuirty meeting! Since we had an open agenda before the community call, our notes overlap with theirs.
+With time changes, this meeting was accidentally double-booked with the Jupyter Security meeting! Since we had an open agenda before the community call, our notes overlap with theirs.
 
 For notes from this call, please refer to the [March 29, 2022 jupyter/security meeting notes!](https://github.com/jupyter/security/tree/main/meetings/2022-03-29.md)

--- a/docs/source/community/community-call-notes/2022-october.md
+++ b/docs/source/community/community-call-notes/2022-october.md
@@ -35,7 +35,7 @@ For more discussion on the format of these calls, see the thread [here](https://
         * https://github.com/deathbeds/importnb
         * https://github.com/tonyfast/tonyfast
     * "Spooky-ber Note-boo-ks" with [jupyterlab-deck](https://github.com/deathbeds/jupyterlab-deck) and a history of presenting in notebooks and a reporting deck (with Robot Framework).
-* **Debra Chen, Niko Zeng**: Invitation for joint-holding comminity meetup
+* **Debra Chen, Niko Zeng**: Invitation for joint-holding community meetup
 
 ## Other Links Shared
 

--- a/docs/source/locale/en/LC_MESSAGES/community.po
+++ b/docs/source/locale/en/LC_MESSAGES/community.po
@@ -1711,7 +1711,7 @@ msgstr ""
 # 9a919edea46042fda80ad5719ba42c25
 #: ../../source/community/community-call-notes/2019-march.md:83
 #: feb3053e773948d688e91464db171806
-msgid "Don't get limitted to technical discusions !"
+msgid "Don't get limited to technical discusions !"
 msgstr ""
 
 # 6a1d536f3f6c46b2b79fcdecd6491c4c

--- a/docs/source/locale/en/LC_MESSAGES/contributing.po
+++ b/docs/source/locale/en/LC_MESSAGES/contributing.po
@@ -5331,7 +5331,7 @@ msgstr ""
 #: 230612fad0534830bc508b1a034b8694
 msgid ""
 "If session does not already exist, create a new session with given "
-"notebook name and path and given kernel name. Return active sesssion."
+"notebook name and path and given kernel name. Return active session."
 msgstr ""
 
 #: ../../source/contributing/ipython-dev-guide/rest_api.rst:155
@@ -6792,7 +6792,7 @@ msgstr ""
 #: ../../source/contributing/start-contributing.rst:73
 #: 09ab7f21b5844cda8764fd2be5a15953
 msgid ""
-"`Development Instalation "
+"`Development Installation "
 "<https://ipywidgets.readthedocs.io/en/latest/dev_install.html>`__"
 msgstr ""
 

--- a/docs/source/locale/en/LC_MESSAGES/developer-docs.po
+++ b/docs/source/locale/en/LC_MESSAGES/developer-docs.po
@@ -326,7 +326,7 @@ msgstr ""
 #: ../../source/developer-docs/contrib_first_time.rst:73
 #: 335df1b56add43bc87dc22523aa11774
 msgid ""
-"`Development Instalation "
+"`Development Installation "
 "<https://ipywidgets.readthedocs.io/en/latest/dev_install.html>`__"
 msgstr ""
 

--- a/docs/source/locale/en/LC_MESSAGES/development_guide.po
+++ b/docs/source/locale/en/LC_MESSAGES/development_guide.po
@@ -2718,7 +2718,7 @@ msgstr ""
 #: ../../source/development_guide/rest_api.rst:150
 msgid ""
 "If session does not already exist, create a new session with given "
-"notebook name and path and given kernel name. Return active sesssion."
+"notebook name and path and given kernel name. Return active session."
 msgstr ""
 
 # 5a4883c124374c5badd2612c1995b17e

--- a/docs/source/locale/es/LC_MESSAGES/contributor.po
+++ b/docs/source/locale/es/LC_MESSAGES/contributor.po
@@ -260,7 +260,7 @@ msgstr ""
 # cb2170d8f32f40ab8ddb9dfe33eb88ec
 #: ../../source/contributor/contrib_guide_blog.rst:47
 msgid ""
-"Alway check in the metadata fields that a blog post has a title and a "
+"Always check in the metadata fields that a blog post has a title and a "
 "canonical URL. It is possible to put the date in the canonical URL, in "
 "particular for events like jupyter-day, that can occur several times. The"
 " date of the event can differ from the date of the blog post."

--- a/docs/source/locale/es/LC_MESSAGES/developer-docs.po
+++ b/docs/source/locale/es/LC_MESSAGES/developer-docs.po
@@ -284,7 +284,7 @@ msgstr ""
 # b2ed815f0f484e68a121c164065199df
 #: ../../source/developer-docs/contrib_first_time.rst:73
 msgid ""
-"`Development Instalation "
+"`Development Installation "
 "<https://ipywidgets.readthedocs.io/en/latest/dev_install.html>`__"
 msgstr ""
 

--- a/docs/source/locale/es/LC_MESSAGES/development_guide.po
+++ b/docs/source/locale/es/LC_MESSAGES/development_guide.po
@@ -2718,7 +2718,7 @@ msgstr ""
 #: ../../source/development_guide/rest_api.rst:150
 msgid ""
 "If session does not already exist, create a new session with given "
-"notebook name and path and given kernel name. Return active sesssion."
+"notebook name and path and given kernel name. Return active session."
 msgstr ""
 
 # 5a4883c124374c5badd2612c1995b17e

--- a/docs/source/locale/es/LC_MESSAGES/projects.po
+++ b/docs/source/locale/es/LC_MESSAGES/projects.po
@@ -739,7 +739,7 @@ msgstr ""
 # 712a90ba320f4bda9acb4e6df9b85bc2
 #: ../../source/projects/jupyter-directories.rst:40
 msgid ""
-"To list the config directories currrently being used you can run the "
+"To list the config directories currently being used you can run the "
 "below command from the :term:`command line`::"
 msgstr ""
 


### PR DESCRIPTION
This PR fix the typo in multiple files

```pseudo
doucmentation > documentation
Novermber > November
reasearch > research
Secuirty > Security
comminity > community
limitted > limited
sesssion > session
alway > always
Instalation > installation
currrently > currently
```