### PR TITLE
update install link for JupyterHub

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -45,7 +45,7 @@ organizations, and with pluggable authentication and scalability.
 
 * `GitHub Repo <https://github.com/jupyterhub/jupyterhub>`__
 * `Docs <https://jupyterhub.readthedocs.io/en/stable/>`__
-* `Install instructions <https://jupyterhub.readthedocs.io/en/stable/installation-guide.html>`__
+* `Install instructions <https://jupyterhub.readthedocs.io/en/stable/tutorial/quickstart.html>`__
 
 
 Jupyter Console


### PR DESCRIPTION
closes https://github.com/jupyterhub/jupyterhub/issues/4504

not sure why I never opened this PR.