### PR TITLE
Added docs-issues-hub page for coordinating docs work.

### DIFF
--- a/docs/source/contributing/docs-contributions/doc-issues-hub.md
+++ b/docs/source/contributing/docs-contributions/doc-issues-hub.md
@@ -1,0 +1,13 @@
+# Documentation Issue Hub
+
+Each subproject has its own documentation. This page provides quick links
+to documentation issues for Jupyter subprojects.
+
+## Docs Issues Per-Subproject
+
+- [Jupyter.org (meta-project) issues](https://github.com/jupyter/jupyter/labels/documentation) (`documentation` label)
+- [Jupyter Notebook issues](https://github.com/jupyter/notebook/labels/documentation) (`documentation` label)
+- [JupyterLab issues](https://github.com/jupyterlab/jupyterlab/labels/documentation) (`documentation` label)
+- [Jupyter Server issues](https://github.com/jupyter-server/jupyter_server/labels/documentation) (`documentation` label)
+- [JupyterHub issues](https://github.com/jupyterhub/jupyterhub/labels/documentation) (`documentation` label)
+- [ipywidgets issues](https://github.com/jupyter-widgets/ipywidgets/labels/documentation) (`documentation` label)

--- a/docs/source/contributing/docs-contributions/index.rst
+++ b/docs/source/contributing/docs-contributions/index.rst
@@ -13,6 +13,7 @@ Documentation Guide
    doc-workflow.rst
    doc-tools.rst
    doc-future-index.rst
+   doc-issues-hub.md
 
 Documentation helps guide new users, fosters communication between developers,
 and shares tips and best practices with other community members. That's why


### PR DESCRIPTION
This page should help coordinate docs work across subprojects, as mentioned here:

- https://github.com/jupyter/docs-team-compass/issues/31