### PR TITLE
Add 2023 community call notes

### DIFF
--- a/docs/source/community/community-call-notes/2023-december.md
+++ b/docs/source/community/community-call-notes/2023-december.md
@@ -1,0 +1,109 @@
+# Jupyter Community Call 12/13
+
+**Date:** December 13, 2023, at 9:00AM PST (your [timezone](https://arewemeetingyet.com/Los%20Angeles/2023-12-13/9:00/Jupyter%20Community%20Call))
+
+[**Discourse**](https://discourse.jupyter.org/t/jupyter-community-calls/668)
+
+[**Youtube**](https://youtu.be/hUU77BfU-Kk)
+
+**Please note:**
+- Community calls are recorded and posted to this [playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
+- These notes will be recorded and posted [here](https://jupyter.readthedocs.io/en/latest/community/community-call-notes/index.html)
+- Everyone present is held to the [Jupyter Code of Conduct](https://jupyter.org/conduct)
+
+## Purpose
+
+Think of it as a monthly, virtual JupyterCon. It’s a place to announce and share fun things happening in the Jupyter community.
+
+For more discussion on the format of these calls, see the thread [here](https://discourse.jupyter.org/t/reviving-the-all-jupyter-team-meetings/423).
+
+## Short reports, celebrations, shout-outs
+
+This is a place to make short announcements (without a need for discussion). 
+
+* **tonyfast** - [dec community call introduction](https://github.com/tonyfast/tonyfast/blob/main/tonyfast/xxiii/2023-12-13-jupyter-community-call.ipynb)
+* **Ana Ruvalcaba** Project Jupyter is now active on Mastodon! Follow us there for the latest Jupyter news and announcements. Please note that @mentions are not monitored. https://hachyderm.io/@ProjectJupyter
+* **Mike Krassowski** JupyterLab 4.1 beta call for testing.
+
+
+## Agenda Items
+
+* **Michael Goerz** [A Python local `.venv` kernel](https://github.com/goerz/python-localvenv-kernel) (5 min)
+* **Eric Gentry** A new in-development [JupyterLab hex editor](https://github.com/ericsnekbytes/hexlab)
+* **Shravan Achar** A "Share" button for Jupyter Notebooks (5 min).
+* **Nick Bollweg** [jupyak](https://github.com/deathbeds/jupyak): a pipeline pushing pulls of projects to pages of pixels for people, across the Jupyter stack
+* **Kyle Kelley** demoing the Deno TypeScript kernel for jupyter.
+  * [Deno Kernel Announce Post](https://blog.jupyter.org/bringing-modern-javascript-to-the-jupyter-notebook-fc998095081e)
+  * [Deno Notebooks](https://github.com/rgbkrk/denotebooks)
+* **Mason Williams** demoing [Pieces for Developers](https://pieces.app) and our [JupyterLab extension](https://docs.pieces.app/extensions-plugins/jupyterlab).
+* **Andrey Velichkevich** A collaborative notebook training/tuning ML models on GPUs (powered by KubeFlow) (5 min).
+    * KubeCon 2024 Talk for the full demo - https://youtu.be/sn2qe225E1o
+    * Be involved into Kubeflow Community - https://www.kubeflow.org/docs/about/community/
+* **Mike Krassowski** Inline completer API and integration with jupyter-ai.
+
+## Notes and Other Links
+
+This is a space to store links shared during community call discussions related to or separate from the agenda items.
+
+### Python local-`.venv` kernel
+
+* Project on Github: https://github.com/goerz/python-localvenv-kernel
+* The FAQ: https://github.com/goerz/python-localvenv-kernel/blob/master/FAQ.md. This includes information on how to make the kernel work for something other than a `.venv` folder. For example (as asked during the call), this might be used to support `.jupyter` populated by https://github.com/jupyterlab/jupyterlab-desktop (TBD)
+* Notes on the type of Makefile used in the demo: https://github.com/goerz/python-localvenv-kernel/wiki/Project-Makefile-using-Pip-Tools
+* "Old" project example with an installable kernel: https://github.com/ARLQCI/2022-04_semiad_paper
+* "New" project is not public yet. When published, links to example repos will be added to the `python-localvenv-kernel` README / Wiki
+
+### Pieces for Developers | AI-Enabled Developer Workflow Assistant
+
+* Install our JupyterLab Extension: [JupyterLab Extension Documenation page](https://docs.pieces.app/extensions-plugins/jupyterlab)
+* Learn more about Pieces: [Pieces Documenation Site](https://docs.pieces.app)
+* Check out our Open Source projects: [Pieces Open Source GitHub Repo](https://github.com/pieces-app/opensource)
+* Join our Discord Server: [Pieces Discord Server](https://discord.gg/getpieces)
+
+### Inline completer
+
+- [Extension point documentation](https://jupyterlab.readthedocs.io/en/latest/extension/extension_points.html#inline-completer)
+- [API documentation for `IInlineCompletionProvider`](https://jupyterlab.readthedocs.io/en/latest/api/interfaces/completer.IInlineCompletionProvider.html)
+- https://github.com/krassowski/jupyterlab-transformers-completer
+- https://github.com/jupyterlab/jupyter-ai/pull/465 (connecting models)
+- https://github.com/jupyterlab/jupyterlab/pull/15160 (frontend)
+
+## Attendees
+
+|   Name   |           Institution     | GitHub Handle                     |
+|----------|---------------------------|-----------------------------------|
+| Shravan Achar | Apple | @shravan-achar
+| Andrey Velichkevich | Apple | @andreyvelich
+| Zach Sailer | Apple | @Zsailer
+| [Michael Goerz](https://michaelgoerz.net) | U.S. Army Research Lab  | [@goerz](https://github.com/goerz/)
+| Philipp Risius | Justus Liebig University Giessen | @philipprisius
+| Nick Bollweg          | Georgia Tech           | @bollwyvl 
+| Kyle Kelley | Noteable | @rgbkrk
+| Amogha Kancharla     | WomeninCloudNative | @amoghak-ds
+| [Mason Williams](https://masnwilliams.com) | [Pieces for Developers](https://pieces.app) | [@mason-at-pieces](https://github.com/mason-at-pieces) / [@masnwilliams](https://github.com/masnwilliams)
+| Mike Krassowski | Quansight | [@krassowski](https://github.com/krassowski) |
+| Eric Gentry | Anaconda | @ericsnekbytes |
+| Sergey Kukhtichev | IBM | @skukhtichev |
+| Ana Ruvalcaba | Project Jupyter | @Ruv7  |
+| Luciano Resende | Apple | @lresende |
+| Andrii Ieroshenko | AWS | @andrii-i |
+| Jason Weill | AWS | @JasonWeill |
+| Jeremy Tuloup | QuantStack | @jtpio |
+| Simon Li | University of Dundee | @manics |
+| Isabela Presedo-Floyd | Quansight Labs | @isabela-pf |
+| Jared Thompson|Comcast| |
+| Nicolas Brichet | QuantStack | @brichet |
+| Rosio Reyes | Anaconda | @RRosio |
+| Frederic Collonval | | @fcollonval |
+| Carlos Brandt | Constructor University | @chbrandt |
+| Rollin Thoams | NERSC | @rcthomas |
+| Gabriel Fouasnon | Quansight Labs | @gabalafou |
+| Jan-Hendrik Müller | University Göttingen | @kolibril13 |
+| Arunav Gupta | AWS | @agupta01 |
+| Ian Dong | Apple | @misterfads |
+| Mehmet Bektas | Netflix | @mbektas |
+| Amola Hinge | Apple | @amolahinge|
+| Wayne Decatur | Upstate Medical University  | @fomightez |
+| Martha Cryan | Mito | @marthacryan |
+| R Ely | Bloomberg | @ohrely |
+| Jialin Zhang| Apple | @jzhang20133 |

--- a/docs/source/community/community-call-notes/2023-february.md
+++ b/docs/source/community/community-call-notes/2023-february.md
@@ -1,3 +1,5 @@
+# Jupyter Community Call 2/28
+
 **Date:** February 28, 2023, at 8am Pacific ([your timezone](https://arewemeetingyet.com/Los%20Angeles/2023-02-28/08:00/Jupyter%20Community%20Call))
 
 [**Discourse:**](https://discourse.jupyter.org/t/jupyter-community-calls/668)

--- a/docs/source/community/community-call-notes/2023-february.md
+++ b/docs/source/community/community-call-notes/2023-february.md
@@ -1,0 +1,101 @@
+**Date:** February 28, 2023, at 8am Pacific ([your timezone](https://arewemeetingyet.com/Los%20Angeles/2023-02-28/08:00/Jupyter%20Community%20Call))
+
+[**Discourse:**](https://discourse.jupyter.org/t/jupyter-community-calls/668)
+[**Youtube**](https://youtu.be/718KFe6MMW4)
+
+**Please note:**
+- Community calls are recorded and posted to this [playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
+- These notes will be recorded and posted [here](https://jupyter.readthedocs.io/en/latest/community/community-call-notes/index.html)
+- Everyone present is held to the [Jupyter Code of Conduct](https://jupyter.org/conduct)
+
+## Purpose
+
+Think of it as a monthly, virtual JupyterCon. It’s a place to announce and share fun things happening in the Jupyter community.
+
+For more discussion on the format of these calls, see the thread [here](https://discourse.jupyter.org/t/reviving-the-all-jupyter-team-meetings/423).
+
+## Short reports, celebrations, shout-outs
+
+This is a place to make short announcements (without a need for discussion). 
+
+* **Isabela** Many thanks to the Security project team for being flexible and helping community call have this time on the calendar!
+    * Security calls are now 1st and 3rd Tuesday of every month
+    * Community call is last Tuesday
+    * No collisions anymore, can move community call to more friendly time! :)
+* **Isabela** Governance update: Software Steering Council is in the process of getting office hours on the calendar and resuming all other duties.
+
+## Agenda Items
+
+* @rowanc1 @agoose77 - `jupyterlab-myst` overview and demo https://github.com/executablebooks/jupyterlab-myst
+    * MyST: Markup language incubated in executable books project, spun out last week
+        * 10% of Python documentation is written MyST and increasing
+    * Moving toward Javascript world => better integration with JupyterLab
+    * See myst-tools.org, new website for the project
+    * MyST: Support for scientific documents and publications, export to various high-quality PDF formats
+        * Also rendered static versions of Jupyter notebooks
+        * What metadata and front-matter needs to be added
+        * How to bring computational thinkin into publishing
+    * JupyterLab MyST extension
+        * Rich metadata as data at the top of document (YAML)
+            * Executing the metadata cells yields a nice top block for a notebook
+            * Nicer than custom HTML, parseable, better to edit and view
+        * Callout blocks:
+            * Bracketed directives like ":::{important}"
+            * Also class information like dropdown
+        * Cross-references
+        * Inline execution in markdown cells
+            * Syntax subject to change
+            * Roles and directives e.g. "{eval}`1+1`"
+            * Embed Jupyter widgets directly in markdown, figures, sparklines
+            * Better weaving of documentation and code
+    * Ongoing nbformat workshop and MyST
+        * Discussing the challenges of developing the extension
+        * In particular, embedding computation in documentation, wasn't originally envisioned
+        * Input types may need to expand
+    * Static publishing, see also https://thebe.readthedocs.io/en/stable/
+        * Write documents with interactivity
+        * Publishing mechanisms
+        * Help promote interactivity and computation experience to the end sharing of documents
+    * Mixing HTML and MyST and accessibility?
+        * Keeping these issues in mind during development
+        * Gets more difficult with widgets
+        * Efforts to use the same technology pieces as Jupyter
+        * => as Jupyter improves things upstream in widgets space it propagates here
+        * Archivability, semantic HTML, paying attention to accessibility scores
+            * https://myst-tools.org/docs/mystjs/accessibility-and-performance
+* Ongoing nbformat workshop discussion @isabela-pf
+    * We don't have a type of Markdown we specify in notebooks
+    * This has created some difficulty during user testing
+    * Would be nice to at least know what kind of Markdown specification we're following
+    * There are web accessibility guidelines, not clear always how they correlate
+    * Greater clarity would help because accommodations get hooked in at the HTML level
+    * At the workshop @rowanc1:
+        * Split into 3 groups
+            * Text-based format in addition to standard format (e.g. jupytext)
+            * Cell types workflow
+            * Markdown formats inside cells
+        * The wild west of notebook, cell metadata, how do people use it?
+            * Noteable example
+                * Front-end interfaces that don't go through Jupyter/JupyterLab
+                * Visualization state stored in cell metadata
+                * Namespaced in noteable
+            * Are there changes in terms of cell metadata being considered PR/discourse wise?
+                * Discourse: ???
+                * Maybe [Jupyter Discourse: Notebook Metadata UX](https://discourse.jupyter.org/t/notebook-metadata-ux/17507_)
+            * Simplest use case (kinda) marking cell metadata for special treatment or processing 
+
+## Other Links Shared
+
+This is a space to store links shared during community call discussions related to or separate from the agenda items.
+
+## Attendees
+
+|   Name   |           Institution     | GitHub Handle                     |
+|----------|---------------------------|-----------------------------------|
+| Rollin   | NERSC                     | @rcthomas                         |
+| Rowan          | Curvenote / ExecutableBooks | @rowanc1 |
+| Gabriela Vives         |QuantStack            |GabrielaVives |
+| Wayne Decatur  | Upstate Medical Univ. | @fomightez |
+| Isabela Presedo-Floyd | Quansight Labs | @isabela-pf |
+
+Plus 1 more.

--- a/docs/source/community/community-call-notes/2023-january.md
+++ b/docs/source/community/community-call-notes/2023-january.md
@@ -1,3 +1,5 @@
+# Jupyter Community Call 1/31
+
 **Date:** January 31, 2023 at 7am Pacific (in your [timezone](https://arewemeetingyet.com/Los%20Angeles/2023-01-31/7:00/Jupyter%20Community%20Call))
 
 [**Discourse**](https://discourse.jupyter.org/t/jupyter-community-calls/668)

--- a/docs/source/community/community-call-notes/2023-january.md
+++ b/docs/source/community/community-call-notes/2023-january.md
@@ -1,0 +1,59 @@
+**Date:** January 31, 2023 at 7am Pacific (in your [timezone](https://arewemeetingyet.com/Los%20Angeles/2023-01-31/7:00/Jupyter%20Community%20Call))
+
+[**Discourse**](https://discourse.jupyter.org/t/jupyter-community-calls/668)
+[**Youtube**](https://youtu.be/LjgctsAIubQ)
+
+**Please note:**
+- Community calls are recorded and posted to this [playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
+- These notes will be recorded and posted [here](https://jupyter.readthedocs.io/en/latest/community/community-call-notes/index.html)
+- Everyone present is held to the [Jupyter Code of Conduct](https://jupyter.org/conduct)
+
+## Purpose
+
+Think of it as a monthly, virtual JupyterCon. It’s a place to announce and share fun things happening in the Jupyter community.
+
+For more discussion on the format of these calls, see the thread [here](https://discourse.jupyter.org/t/reviving-the-all-jupyter-team-meetings/423).
+
+## Short reports, celebrations, shout-outs
+
+This is a place to make short announcements (without a need for discussion). 
+
+* **Isabela** We've officially hit two years of consecutive Jupyter community calls! Thank you all for supporting our community.
+* **Nick** Recent [release of traitlets](https://blog.jupyter.org/announcing-a-new-jupyter-governance-model-and-our-first-executive-council-39b3989dc064) supports tab completion
+* **Gayle** [Blog post](https://blog.jupyter.org/announcing-a-new-jupyter-governance-model-and-our-first-executive-council-39b3989dc064) about Jupyter governance launch
+
+## Agenda Items
+
+Add agenda items here **before** the meeting. We will reorganize the agenda so that it fits in the 60m meeting slot.
+
+* **Stephen Macke**: [IPyflow](https://github.com/ipyflow/ipyflow): a dataflow-aware Python kernel for JupyterLab
+* **Nick Bollweg**: [jyg](https://github.com/deathbeds/jyg): run JupyterLab commands from the CLI... or other browser windows
+* **Gayle**: [Jupytercon](https://www.jupytercon.com/)! How would you promote the event? Reach out at gayle@numfocus.org
+* **Kafonek**: Are any Jupyter-collaborative meetings (Y-py, etc) still going on? Have tried to connect to those communities and had trouble. Also would like to push for pypi to host wasm wheels.
+
+## Other Links Shared
+
+This is a space to store links shared during community call discussions related to or separate from the agenda items.
+
+* [deathbeds/jupyterlab-starters](https://github.com/deathbeds/jupyterlab-starters)
+* [JupyterLab example for adding items to the launcher](https://github.com/jupyterlab/extension-examples/tree/master/launcher) 
+* [jupyter_app_launcher](https://github.com/trungleduc/jupyter_app_launcher)
+* [jupyterlab_commands](https://github.com/timkpaine/jupyterlab_commands)
+* [ipylab](https://github.com/jtpio/ipylab)
+
+## Attendees 
+
+|   Name   |           Institution     | GitHub Handle|
+|----------|---------------------------|--------------|
+| nick bollweg | deathbeds | @bollwyvl  |
+| stephen macke | meta | [@smacke](https://github.com/smacke) |
+| matt kafonek | noteable | [@kafonek](https://github.com/kafonek) |
+| Frederic Collonval | QuantStack | @fcollonval  |
+| Gayle Ollington     | NumFOCUS | @gollington  |
+| Wayne Decatur | Upstate Medical Univ. | @fomightez |
+| Carlos Brandt | Constructor Univ. | @chbrandt |
+| tonyfast | deathbeds | @tonyfast |
+| A. T. Darian | QuantStack  | @afshin |
+| Isabela Presedo-Floyd | Quansight Labs | @isabela-pf |
+
+Plus 3 more

--- a/docs/source/community/community-call-notes/index.rst
+++ b/docs/source/community/community-call-notes/index.rst
@@ -9,6 +9,9 @@ The Jupyter Community Call is an open video call. Think of this as a "monthly, v
 .. toctree::
    :maxdepth: 1
 
+   December 2023 <2023-december.md>
+   February 2023 <2023-february.md>
+   January 2023 <2023-january.md>
    November 2022 <2022-november.md>
    October 2022 <2022-october.md>
    September 2022 <2022-september.md>


### PR DESCRIPTION
This PR adds 2023's Jupyter community call notes to the community docs. Thanks in advance for the review! 🌻 

It includes notes from
- #674 
- #691 
- and December's community call (no related issue)

Please let me know if you have any questions or would like anything changed.
