### PR TITLE
Update link to JupyterHub changelog

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -24,5 +24,5 @@ You can find a changelog at
 JupyterHub
 ==========
 
-You can find a list of changelogs in the JupyterHub community within the
-`JupyterHub team compass documentation <https://github.com/jupyterhub/team-compass#team-information>`_.
+You can find a changelog at
+`the JupyterHub documentation <https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html>`_.


### PR DESCRIPTION
I could not find any reference to release notes in Team Compass documentation, so I think it would be better to directly refer to JupyterHub release notes documentation page.