### PR TITLE
remove qtconsole from metapackage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup_args = dict(
     py_modules          = [],
     install_requires    = [
         'notebook',
-        'qtconsole',
         'jupyter-console',
         'nbconvert',
         'ipykernel',


### PR DESCRIPTION
closes #718

support in the polls is overwhelming, and all objections appear to be to stopping support for qtconsole (which we aren't doing), not actually to this removal from the metapackage, which only affects what you get when you `pip install jupyter`. Folks can always `pip install qtconsole` and get it right back.

I can make a 1.1.0 release after this is merged.