### PR TITLE
update long_description

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ prune build
 prune dist
 
 include LICENSE
-include README.md
+include *.md

--- a/long_description.md
+++ b/long_description.md
@@ -1,0 +1,27 @@
+# Jupyter metapackage
+
+Find more information on [the Jupyter homepage](https://jupyter.org).
+
+## A default installation of most common Jupyter packages
+
+`pip install jupyter` installs the Jupyter Notebook, JupyterLab, and the IPython Kernel.
+
+This is an empty metapackage for user convenience,
+only expressing dependencies on multiple Jupyter packages.
+`jupyter` should not be used as a dependency for any packages.
+
+For more efficient installation of what you need,
+all Jupyter components installed by `pip install jupyter` can be installed separately.
+For example:
+
+- `notebook` - Jupyter Notebook
+- `jupyterlab` - JupyterLab (added to metapackage v1.1)
+- `ipython` - IPython (terminal)
+- `ipykernel` - IPython Kernel for Jupyter
+- `jupyter-console` - terminal Jupyter client
+- `nbconvert` - convert notebooks between formats
+- `ipywidgets` - interactive widgets package for IPython
+
+No longer included in `pip install jupyter`, but still supported:
+
+- `qtconsole` - Qt Console (removed in metapackage v1.1)

--- a/setup.py
+++ b/setup.py
@@ -7,19 +7,20 @@
 from __future__ import print_function
 
 import os
-import sys
-
-from distutils.core import setup
+from setuptools import setup
 
 pjoin = os.path.join
 here = os.path.abspath(os.path.dirname(__file__))
 
+with open(pjoin(here, "long_description.md")) as f:
+    long_description = f.read()
 
 setup_args = dict(
     name                = 'jupyter',
     version             = '1.1.0',
     description         = "Jupyter metapackage. Install all the Jupyter components in one go.",
-    long_description    = """Install the Jupyter system, including the notebook, qtconsole, and the IPython kernel.""",
+    long_description    = long_description,
+    long_description_content_type = "text/markdown",
     author              = "Jupyter Development Team",
     author_email        = "jupyter@googlegroups.org",
     py_modules          = [],
@@ -31,7 +32,7 @@ setup_args = dict(
         'ipywidgets',
         'jupyterlab',
     ],
-    url                 = "http://jupyter.org",
+    url                 = "https://jupyter.org",
     license             = "BSD",
     classifiers         = [
         'Intended Audience :: Developers',
@@ -47,9 +48,4 @@ setup_args = dict(
     ],
 )
 
-if any(bdist in sys.argv for bdist in ['bdist_wheel', 'bdist_egg']):
-    import setuptools
-
-
-if __name__ == '__main__':
-    setup(**setup_args)
+setup(**setup_args)


### PR DESCRIPTION
mention which packages are installed

After publishing 1.1, I noticed the description on PyPI is out of date. I added a list of packages and explanation of what this metapackage is and a suggestion that it may not be what folks actually want (especially in package dependencies).

I can do 1.1.1 with the fixed metadata.