### PR TITLE
Fix documentation site display and a few warnings

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -4,4 +4,4 @@ myst_parser
 nbsphinx
 pydata-sphinx-theme
 sphinxext-rediraffe
-sphinx-panels
+sphinx-design

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,5 +1,5 @@
 name: jupyter_docs
 dependencies:
-  - python=3.10
+  - python=3.11
   - pip:
       - -r doc-requirements.txt

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -65,7 +65,11 @@ p.first.admonition-title {
     padding-bottom: .3em;
 }
 
-div.card ul.simple {
+div.sd-card ul.simple {
     list-style: none;
     padding-left: 1em;
+}
+
+.bd-content .sd-card .sd-card-header {
+    background-color: var(--pst-color-surface);
 }

--- a/docs/source/community/community-call-notes/2023-february.md
+++ b/docs/source/community/community-call-notes/2023-february.md
@@ -47,7 +47,10 @@ This is a place to make short announcements (without a need for discussion).
         * Cross-references
         * Inline execution in markdown cells
             * Syntax subject to change
-            * Roles and directives e.g. "{eval}`1+1`"
+            * Roles and directives e.g.
+            ```
+              {eval}`1+1`
+            ```
             * Embed Jupyter widgets directly in markdown, figures, sparklines
             * Better weaving of documentation and code
     * Ongoing nbformat workshop and MyST

--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -10,6 +10,13 @@ provide information about the Jupyter community such as background, events,
 and communication channels. As our community is highly dynamic, information
 may change, and we will do our best to keep it up to date.
 
+.. toctree::
+   :hidden:
+
+   community-call-notes/index
+   host-guide
+
+
 Jupyter Community Meetings
 ==========================
 

--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -10,14 +10,6 @@ provide information about the Jupyter community such as background, events,
 and communication channels. As our community is highly dynamic, information
 may change, and we will do our best to keep it up to date.
 
-.. TODO: remove this hidden toctree when left sidebar TOCs work in pydata sphinx theme
-
-.. toctree::
-   :hidden:
-
-   community-call-notes/index
-   host-guide
-
 Jupyter Community Meetings
 ==========================
 

--- a/docs/source/community/host-guide.md
+++ b/docs/source/community/host-guide.md
@@ -56,6 +56,7 @@ Partner with another contributor (a meeting facilitator) to do the following:
   - If they get no response from the account, the host should assume
     it's recording, and remove it from the meeting.
 
+(meeting-script-and-checklist)=
 ## &#x270f; Suggested Meeting Script and Checklist 
 
 ### &#x23F3; Prior to meeting start

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ extensions = [
     'sphinx.ext.graphviz', # Add the graphviz extension
     'sphinxext.rediraffe',
     'myst_parser',
-    'sphinx_panels'
+    'sphinx_design',
 ]
 
 panels_add_bootstrap_css = False

--- a/docs/source/contributing/dev-contributions/contrib_guide.md
+++ b/docs/source/contributing/dev-contributions/contrib_guide.md
@@ -29,8 +29,8 @@ is particularly useful because the Jupyter codebase is scattered across several
 repositories within the jupyter organization, as opposed to a single
 repository. You can click the link below to find sprint-friendly issues.
 
-```{link-button} https://github.com/search?q=is%3Aissue+is%3Aopen+is%3Asprint-friendly+user%3Ajupyter&type=Issues&ref=searchresults
-:text: is:issue is:open is:sprint-friendly user:jupyter
+```{button-link} https://github.com/search?q=is%3Aissue+is%3Aopen+is%3Asprint-friendly+user%3Ajupyter&type=Issues&ref=searchresults
+is:issue is:open is:sprint-friendly user:jupyter
 ```
 
 Once you've found an issue that you are eager to solve, you can use the guide

--- a/docs/source/contributing/docs-contributions/doc-new-translation.md
+++ b/docs/source/contributing/docs-contributions/doc-new-translation.md
@@ -87,6 +87,7 @@ Note: We recognize this flow assumes documentation starts life written in U.S. E
 look into removing this assumption in the future if it becomes a significant barrier to new
 contributions.
 
+(translator-workflows)=
 ## Community translator workflows
 
 We are delighted when members of the Jupyter community want to help translate documentation. We use
@@ -288,7 +289,7 @@ filters:
 10. Click _Resources_ in the left sidebar.
 11. Click one of the `.po` files to see translation progress by language.
 12. Click one of the languages to see details about translation progress, translate text, and review
-    translations. See the [Translator workflows](#translator-workflows) section above for details.
+    translations. See the [Community translator workflows](#translator-workflows) section above for details.
 
 After confirming the initial English `.po` files have reached Transifex, set up continuous
 integration to ensure source strings are kept up-to-date in Transifex whenever the English

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -93,7 +93,10 @@ Individual sub-projects are typically organized around a key feature of the
 Jupyter ecosystem, and have their own community, documentation and governance.
 Below is a list of documentation for major parts of the Jupyter ecosystem.
 
-```{panels}
+````{grid} 1 1 2 2
+:gutter: 3
+
+```{grid-item-card}
 User Interfaces
 ^^^^^^
 * [JupyterLab](https://github.com/jupyterlab/jupyterlab)
@@ -102,8 +105,9 @@ User Interfaces
 * [Jupyter Console](https://jupyter-console.readthedocs.io/en/latest)
 * [Qt console](https://qtconsole.readthedocs.io/en/stable)
 * [Voilà](https://voila.readthedocs.io/)
+```
 
----
+```{grid-item-card}
 JupyterHub
 ^^^^^^
 * [JupyterHub](https://jupyterhub.readthedocs.io/en/latest)
@@ -112,8 +116,9 @@ JupyterHub
 * Spawners: [sudo](https://github.com/jupyterhub/sudospawner), [Docker](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/), [Kubernetes](https://jupyterhub-kubespawner.readthedocs.io/en/latest/)
 * [Zero to JupyterHub](https://zero-to-jupyterhub.readthedocs.io/en/latest/)
 * [All JupyterHub Projects...](https://github.com/jupyterhub)
+```
 
----
+```{grid-item-card}
 Working with Notebooks
 ^^^^^^
 * [nbclient](https://nbclient.readthedocs.io/en/latest/) - execution
@@ -122,8 +127,9 @@ Working with Notebooks
 * [nbdime](https://nbdime.readthedocs.io/) - comparing and merging
 * [nbgrader](https://nbgrader.readthedocs.io/en/latest/) - grading
 * [nbformat](https://nbformat.readthedocs.io/en/latest/) - modification and validation
+```
 
----
+```{grid-item-card}
 Kernels
 ^^^^^^
 * [IPython](https://ipython.readthedocs.io/en/stable/)
@@ -131,16 +137,18 @@ Kernels
 * [IJulia](https://github.com/JuliaLang/IJulia.jl)
 * [Xeus kernels](https://xeus.readthedocs.io/en/latest/)
 * [Community maintained kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels)
+```
 
----
+```{grid-item-card}
 IPython
 ^^^^^^
 * [IPython](https://ipython.readthedocs.io/en/stable/)
 * [ipykernel](https://ipython.readthedocs.io/en/stable/)
 * [ipyparallel](https://ipyparallel.readthedocs.io/en/latest/)
 * [traitlets](https://traitlets.readthedocs.io/en/stable/)
+```
 
----
+```{grid-item-card}
 Architecture and Specification
 ^^^^^^
 * [nbformat](https://nbformat.readthedocs.io/en/latest/api.html) - Jupyter Notebook Format
@@ -148,22 +156,24 @@ Architecture and Specification
 * [jupyter-core](https://jupyter-core.readthedocs.io/en/latest/)
 * [jupyter-server](https://jupyter-server.readthedocs.io/)
 * [jupyterlab-server](https://jupyterlab-server.readthedocs.io/en/stable/)
+```
 
----
+```{grid-item-card}
 Deployment
 ^^^^^^
 * [Docker Stacks](https://jupyter-docker-stacks.readthedocs.io/en/latest/)
 * [Kernel Gateway](https://jupyter-kernel-gateway.readthedocs.io/en/latest/)
 * [Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/)
+```
 
----
+```{grid-item-card}
 Widgets
 ^^^^^^
 * [ipywidgets](https://ipywidgets.readthedocs.io/)
 * [widget-cookiecutter](https://github.com/jupyter-widgets/widget-cookiecutter/)
 * [All Widget Projects...](https://github.com/jupyter-widgets)
-
 ```
+````
 
 ## Table of Contents
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,6 +8,7 @@ notebook authoring and editing applications. The Jupyter project and its
 subprojects all center around providing tools (and [standards](https://docs.jupyter.org/en/latest/#sub-project-documentation))
 for interactive computing with [computational notebooks](#what-is-a-notebook).
 
+(what-is-a-notebook)=
 ## What is a Notebook?
 
 ![jupyterlab.png](_static/_images/jupyterlab.png)

--- a/docs/source/start/index.md
+++ b/docs/source/start/index.md
@@ -14,10 +14,9 @@ These sections describe a few ways to get started with some of the most-commonly
 **Try Jupyter** (https://try.jupyter.org) is a site for trying out the Jupyter Notebook, equipped with kernels for several different languages (Julia, R, C++, Scheme, Ruby) without installing anything.
 Click the link below to go to the page.
 
-```{link-button} https://try.jupyter.org
-:type: url
-:text: Click to Try Jupyter
-:classes: btn-primary
+```{button-link} https://try.jupyter.org
+:color: secondary
+Click to Try Jupyter
 ```
 
 When running the examples on the `Try Jupyter` site, you will get a temporary Jupyter

--- a/docs/source/what_is_jupyter.md
+++ b/docs/source/what_is_jupyter.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 # What is Jupyter?
 
 ![The JupyterLab notebook editor, with an open notebook showing an interactive view of the insulin receptor](_static/_images/notebook_insulin_lab_small.png)
@@ -22,7 +25,7 @@ The term "Jupyter" is often used as a shorthand to refer to one of those
 products or ideas (which might cause confusion). Let's take a look at each piece,
 and provide some clarity, below.
 
-# What is a "Computational Notebook" anyway?
+## What is a "Computational Notebook" anyway?
 
 A famous computer programmer ([Donald Knuth](https://en.wikipedia.org/wiki/Donald_Knuth))
 popularized the idea to combine explanatory plain english text with computer
@@ -46,7 +49,7 @@ can do inside of a notebook. For example, a notebook file might be used to:
   from the James Webb Space Telescope (JWST)
 - Generate an [image of a black hole](https://numfocus.org/case-studies/first-photograph-black-hole)
   by processing telescope data
-- Calculate the presence of [gravitational waves]((https://blog.jupyter.org/congratulations-to-the-ligo-and-virgo-collaborations-from-project-jupyter-5923247be019))
+- Calculate the presence of [gravitational waves](https://blog.jupyter.org/congratulations-to-the-ligo-and-virgo-collaborations-from-project-jupyter-5923247be019)
   from observatory data
 
 Those last three are real world examples that demonstrate the scientific
@@ -80,7 +83,7 @@ And the term "Jupyter" might refer to:
 The name Jupyter comes from the three programming languages the project
 originally supported: Julia (ju), Python (pyt) and R (r).
 
-# How do the Jupyter notebook-editor programs work?
+## How do the Jupyter notebook-editor programs work?
 
 It is common for notebook-editor programs like JupyterLab, or Jupyter
 Notebook, to share some features and workflows, because they are influenced
@@ -89,7 +92,7 @@ and how best to work with them effectively.
 
 Let's take a look at some of those ideas.
 
-## Interactive programming (the REPL)
+### Interactive programming (the REPL)
 
 In the past, writing programs, running them, and seeing results was commonly
 a slower and more deliberative process than it is today.
@@ -122,7 +125,7 @@ New snippets of code can refer to variables defined in previous Eval steps,
 because the REPL keeps objects that were created (by previous runs of the
 loop) in-memory, until the user closes their REPL.
 
-## Kernels
+### Kernels
 
 Notebook editor programs like JupyterLab create a REPL (read more about those
 above) for each of your open notebook files, in a language of your choice. In
@@ -142,7 +145,7 @@ The kernels that run in the background for each of your notebooks are what
 power the fast, exploratory programming workflows that Jupyter notebook
 editor programs excel at.
 
-## Multiple programs, one experience (client-server architecture)
+### Multiple programs, one experience (client-server architecture)
 
 Most Notebook editor programs in Project Jupyter, like JupyterLab, may seem like
 a single experience, but when you run JupyterLab on your laptop, there are
@@ -185,7 +188,7 @@ kernels in virtually any way you can imagine. You can invent new editing
 and viewing experiences for your data this way, using the interactive
 computing capabilities provided by the kernels.
 
-## Benefits of a many-piece design
+### Benefits of a many-piece design
 
 By breaking up a program like JupyterLab into multiple component pieces, you
 can customize the software to meet your needs. If one piece is missing something,
@@ -224,7 +227,7 @@ Because Project Jupyter is free and open, it encourages anyone to explore
 new ways of working with their notebooks and kernels, and likes to offer
 compatibility and interoperation with other software.
 
-# What else should I know about Project Jupyter?
+## What else should I know about Project Jupyter?
 
 Jupyter software is free and open-source, developed by a global community
 of volunteers and contributors, available for the benefit of all.
@@ -252,7 +255,7 @@ subprojects handle the actual development of the various software components.
 Some subprojects take care of broader topics, such as the [Accessibility](https://jupyter-accessibility.readthedocs.io/en/latest/),
 [Security](https://jupyter.org/security), [Community](https://docs.jupyter.org/en/latest/community/content-community.html), and [Documentation](https://github.com/jupyter/docs-team-compass) projects.
 
-# A (Partial) Tour of the Jupyter Universe
+## A (Partial) Tour of the Jupyter Universe
 
 In the following sections, we are going to look at some popular components of
 the Jupyter ecosystem. This is *not* a comprehensive reference of every aspect

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,12 +4,12 @@ nox.options.reuse_existing_virtualenvs = True
 
 build_command = ["-b", "html", "docs/source", "docs/build/html"]
 
-@nox.session(python="3.9")
+@nox.session(python="3.11")
 def docs(session):
     session.install("-r", "docs/doc-requirements.txt")
     session.run("sphinx-build", *build_command)
 
-@nox.session(name="docs-live", python="3.9")
+@nox.session(name="docs-live", python="3.11")
 def docs_live(session):
     session.install("-r", "docs/doc-requirements.txt")
     session.install("sphinx-autobuild")


### PR DESCRIPTION
Closes https://github.com/jupyter/jupyter/issues/709

While visting this page I noticed a couple of issues with display (mainly the search button). However, when building locally to fix this issue I found a couple of others.

This PR does the following:
- Moves the docs build process to python 3.11
- Removes an extra toctree in the community page
- Moves the docs from sphinx-panels to sphinx-design, as the former is now deprecated. This changes the display of buttons and grids/cards a bit (but I tried to keep it close to the original)
- Fixes a few build warnings from sphinx.

This solves issue #709 and also fixes some unflagged issues with dark mode display (such as the landing page cards which were displaying with a white background in dark mode).

If this is not useful or if you prefer me to break these into several different PRs, let me know. Any feedback is appreciated as this is my first PR to jupyter 😄 

Cheers!