### PR TITLE
Point donate link to the donate section of jupyter.org/about

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -237,7 +237,7 @@ reference/content-reference
 [Jupyter mailing list](https://groups.google.com/forum/#!forum/jupyter), General discussion of Jupyter's use
 [Jupyter in Education group](https://groups.google.com/forum/#!forum/jupyter-education), Discussion of Jupyter's use in education
 [NumFocus](https://www.numfocus.org), "Promotes world-class, innovative, open source scientific software"
-[Donate to Project Jupyter](https://numfocus.org/donate-to-jupyter), Please contribute to open science collaboration and sustainability
+[Donate to Project Jupyter](https://jupyter.org/about#donate), Please contribute to open science collaboration and sustainability
 ```
 
 


### PR DESCRIPTION
This consolidates the donation link to point to the website, so we have one place to change it.