### PR TITLE
custom.css: define CSS color vars for Jupyter

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -14,6 +14,18 @@
     --pst-color-h6: var(--color-dark-grey);
 
     --pst-color-active-navigation: var(--color-dark-orange);
+
+    /* TODO:
+
+    --pst-color-link:
+
+    --pst-color-secondary: 
+    --pst-color-secondary-highlight:
+
+    --pst-color-table-row-zebra-low-bg:
+    --pst-color-table-row-zebra-high-bg:
+    --pst-color-table-row-hover-bg:
+    */
 }
 
 /* -- navbar ------------------------------------------------------------- */


### PR DESCRIPTION
- TODO:
- [ ] specify CSS hex color codes
  - Old pydata theme:
  - New pydata theme: Teal, Purple, and Orange
    - Teal links
    - Purple table row hover background
    - Orange jupyter logo
  - Normative, Accessible, more corporate bland would be easier to use here tbh:
    - Blue, underlined links
    - Muted table row hover background
    - No bright purple "Top" button over the content
      - (I'm low contrast user; I liked the original sphinxdocs colors but they don't invert for dark mode, which is helpful for OLED and necessary for accessibility)
    - match https://jupyter.org/ so that https://docs.jupyter.org/en/latest/ doesn't clash and look jarringly different
    - primary audience:
      - devs that would contribute
      - decision makers looking for broad appeal
