### PR TITLE
Adding jupyter notebook startup instructions from pip

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -27,6 +27,15 @@ to run the notebook server. You can start the notebook server from the
 
     jupyter notebook
 
+
+or if you installed jupyter through pip3::
+
+    python3 -m notebook
+
+or if you installed jupyter through legacy pip::
+
+    python -m notebook
+
 This will print some information about the notebook server in your terminal,
 including the URL of the web application
 (by default, ``http://localhost:8888``):

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup_args = dict(
     ],
     url                 = "https://jupyter.org",
     license             = "BSD",
+    python_requires     = '>=3.6',
     classifiers         = [
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
@@ -45,6 +46,10 @@ setup_args = dict(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )
 


### PR DESCRIPTION
Updating jupyter notebook starting instructions to include variants when installed through legacy pip or pip3