### PR TITLE
bump ubuntu runner image to 24.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Retirement of previous 20.04 image is coming on April 1, 2025. https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

via [zulip discussion](https://jupyter.zulipchat.com/#narrow/channel/103349-ask-anything/topic/GitHub.20actions.20ubuntu-20.2E04.20runners.20are.20being.20removed)