### PR TITLE
Remove archived incubator projects

### DIFF
--- a/docs/source/projects/incubator.rst
+++ b/docs/source/projects/incubator.rst
@@ -11,28 +11,9 @@ gives emerging projects a place to evolve.
 Descriptions
 ------------
 
-Interesting projects include:
+There is currently one project in the incubator:
 
-* `content management extensions <https://github.com/jupyter-incubator/contentmanagement>`_ - Jupyter Content Management Extensions
-* `dashboards <https://github.com/jupyter-incubator/dashboards>`_ - Jupyter Dynamic Dashboards from Notebooks
-* `declarative widgets <https://github.com/jupyter-incubator/declarativewidgets>`_ - Jupyter Declarative Widgets Extension
-* `kernel gateway bundlers <https://github.com/jupyter-incubator/kernel_gateway_bundlers>`_ - Converts a notebook to a kernel gateway microservice bundle for download
-* `showcase`_ - A spot to try demos of one or more incubating Jupyter projects in `Binder <http://mybinder.org/>`_
 * `sparkmagic <https://github.com/jupyter-incubator/sparkmagic>`_ - Jupyter magics and kernels for working with remote Spark clusters
-* `traittypes <https://github.com/jupyter-incubator/traittypes>`_ - Traitlets types for NumPy, SciPy and friends
 
 There's also a `repository with proposals <https://github.com/jupyter-incubator/proposals>`_
 of projects wishing to enter the incubator.
-
-Try the Incubator Projects
---------------------------
-
-The `showcase`_ application allows you to try demos of one or more incubating
-Jupyter projects in `Binder <http://mybinder.org/>`_. Just head over to the
-`showcase`_ repo and press the :guilabel:`Launch Binder` button badge to launch
-the online trial. You should see an interactive notebook similar to this one:
-
-.. image:: ../_static/_images/showcase.png
-   :alt: The online trial Jupyter notebook. It begins with a text cell stating that this is a temporary notebook server. It then lists the different incubator projects that are available on the server, with links to demos, documentation and GitHub repo for each.
-
-.. _showcase: https://github.com/jupyter-incubator/showcase


### PR DESCRIPTION
Almost all of the current projects listed in our docs for incubator projects are archived. This came up in the Jupyter Frontends and Accessibility call this week when we were discussing the creation of a credential store for Jupyter.

This PR removes all of the archived projects from the list which leaves only sparkmagic.

Also I removed showcase which was removed from the incubator with the other dashboard projects with the PR here: https://github.com/jupyter/enhancement-proposals/pull/22

One thing that I didn't know how to handle is that the [Jupyter Governance for Subprojects](https://github.com/jupyter/governance/blob/main/newsubprojects.md#incubation-of-subprojects) says that new projects can apply for incubation at https://github.com/jupyter-incubator/proposals, however that project is archived as well. Should I open a governance issue?