### PR TITLE
Update content-contributor.rst - small typo

### DIFF
--- a/docs/source/contributing/content-contributor.rst
+++ b/docs/source/contributing/content-contributor.rst
@@ -73,7 +73,7 @@ Participating in the community
 
 The most important part of Jupyter is its community - this is a large and diverse group of
 people spread across the globe. One of the best ways to contribute to Jupyter is to simply
-be a positive and helpful member of this community. Whether it **participating in online conversations**,
+be a positive and helpful member of this community. Whether it is **participating in online conversations**,
 **offering to help others**, **coming to community meetings**, or **teaching others about Jupyter**,
 there are many ways to improve the Jupyter community. For more information about this, we
 recommend starting with the :ref:`community-guide`.


### PR DESCRIPTION
While reading through the "Contributing" page, I spotted a small typo in the "Participating in the community" section. 

The "is" verb is missing at the beginning of the third sentence of the paragraph after "Whether it":

Whether it participating in online conversations, offering to help others, coming to community meetings, or teaching others about Jupyter, there are many ways to improve the Jupyter community.

The corrected version is the following:

Whether it is participating in online conversations, offering to help others, coming to community meetings, or teaching others about Jupyter, there are many ways to improve the Jupyter community.

I hope that's helpful.
Best