### PR TITLE
remove jupyter-console dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup_args = dict(
     py_modules          = [],
     install_requires    = [
         'notebook',
-        'jupyter-console',
         'nbconvert',
         'ipykernel',
         'ipywidgets',


### PR DESCRIPTION
IT has not been updated in years, and likely not of much use.