### PR TITLE
Gitter -> Zulip for JupyterHub

### DIFF
--- a/docs/source/contributing/start-contributing.rst
+++ b/docs/source/contributing/start-contributing.rst
@@ -40,7 +40,7 @@ IPython, nbgrader, JupyterHub, repo2docker, and Binder are major repos written p
 * `JupyterHub <https://github.com/jupyterhub/jupyterhub>`__
     *  `Notable Issues <https://github.com/jupyterhub/jupyterhub/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__
     *  `Development Installation <https://github.com/jupyterhub/jupyterhub#contributing>`__
-    * `Gitter Channel <https://gitter.im/jupyterhub/jupyterhub>`__
+    * `Zulip Channel <https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub>`__
     * `Discourse Channel <https://discourse.jupyter.org/c/notebook/31>`__
 * `repo2docker <https://github.com/jupyter/repo2docker>`__
     *  `Notable Issues <https://github.com/jupyter/repo2docker/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>`__


### PR DESCRIPTION
Other sub-projects probably need Gitter -> Zulip updated too!