### PR TITLE
docs: align macOS default data directory

### DIFF
--- a/docs/source/use/jupyter-directories.rst
+++ b/docs/source/use/jupyter-directories.rst
@@ -86,21 +86,21 @@ search path. For example, kernel specs are in ``kernels`` subdirectories.
    Directories given in :envvar:`JUPYTER_PATH` are searched before other
    locations. This is used in addition to other entries, rather than replacing any.
 
-+-------------------------------+----------------------------+----------------------------+
-| Linux (& other free desktops) | Mac                        | Windows                    |
-+===============================+============================+============================+
-| :envvar:`JUPYTER_PATH`                                                                  |
-+-------------------------------+----------------------------+----------------------------+
-| :envvar:`JUPYTER_DATA_DIR`    | :envvar:`JUPYTER_DATA_DIR` | :envvar:`JUPYTER_DATA_DIR` |
-| or (if not set)               | or (if not set)            | or (if not set)            |
-| ``~/.local/share/jupyter/``   | ``~/Library/Jupyter``      | ``%APPDATA%\jupyter``      |
-| (respects ``$XDG_DATA_HOME``) |                            |                            |
-+-------------------------------+----------------------------+----------------------------+
-| ``{sys.prefix}/share/jupyter/``                                                         |
-+-------------------------------+----------------------------+----------------------------+
-| ``/usr/local/share/jupyter``                               | ``%PROGRAMDATA\jupyter``   |
-| ``/usr/share/jupyter``                                     |                            |
-+-------------------------------+----------------------------+----------------------------+
++-------------------------------+-------------------------------------------+----------------------------+
+| Linux (& other free desktops) | Mac                                       | Windows                    |
++===============================+===========================================+============================+
+| :envvar:`JUPYTER_PATH`                                                                                 |
++-------------------------------+-------------------------------------------+----------------------------+
+| :envvar:`JUPYTER_DATA_DIR`    | :envvar:`JUPYTER_DATA_DIR`                | :envvar:`JUPYTER_DATA_DIR` |
+| or (if not set)               | or (if not set)                           | or (if not set)            |
+| ``~/.local/share/jupyter/``   | ``~/Library/Application Support/Jupyter`` | ``%APPDATA%\jupyter``      |
+| (respects ``$XDG_DATA_HOME``) |                                           |                            |
++-------------------------------+-------------------------------------------+----------------------------+
+| ``{sys.prefix}/share/jupyter/``                                                                        |
++-------------------------------+-------------------------------------------+----------------------------+
+| ``/usr/local/share/jupyter``                                              | ``%PROGRAMDATA\jupyter``   |
+| ``/usr/share/jupyter``                                                    |                            |
++-------------------------------+-------------------------------------------+----------------------------+
 
 .. _jupyter_data_dir:
 


### PR DESCRIPTION
## Overview
This PR updates the documentation regarding the default Jupyter data directory for macOS. The current documentation incorrectly lists `~/Library/Jupyter`, while the actual implementation (since the adoption of `platformdirs`) and the test suite use `~/Library/Application Support/Jupyter`.

## Motivation
This discrepancy is causing real-world issues for downstream package maintainers. Specifically, in the **IJulia.jl** project, this outdated documentation led to a bug where kernelspecs were installed in the legacy directory, making them invisible to modern Jupyter installations.

This was a point of confusion and discussion in [IJulia.jl PR #1238](https://github.com/JuliaLang/IJulia.jl/pull/1238), where the mismatch between the implementation and the documentation was identified as the root cause.

By aligning the documentation with the current Apple Human Interface Guidelines and the actual `platformdirs` implementation, we can prevent similar confusion for other language kernel developers and tool authors.

## Evidence
In `test/test_paths.py`, the expected path is explicitly asserted:

```python
@macos
@use_platformdirs
def test_data_dir_darwin():
    data = jupyter_data_dir()
    assert data == realpath("~/Library/Application Support/Jupyter")
    
    
Although this is a very minor documentation change, I would appreciate it if you could accept it for the sake of technical accuracy and to prevent further confusion in the ecosystem.