### PR TITLE
Remove deprecated Channel: Gitter

### DIFF
--- a/docs/source/contributing/start-contributing.rst
+++ b/docs/source/contributing/start-contributing.rst
@@ -72,7 +72,6 @@ Jupyter Notebook, JupyterLab, and IPyWidgets use JavaScript and TypeScript.
 * `JupyterLab <https://github.com/jupyterlab/jupyterlab>`__
     * `Notable Issues <https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22>`__
     * `Development Installation <https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`__
-    * `Gitter Channel <https://gitter.im/jupyterlab/jupyterlab>`__
     * `Zulip Channel <https://jupyter.zulipchat.com/#narrow/channel/469762-jupyterlab/topic>`__
     * `Discourse Channel <https://discourse.jupyter.org/c/jupyterlab/17>`__
 * `IPyWidgets <https://github.com/jupyter-widgets/ipywidgets>`__


### PR DESCRIPTION
partially fix for #779 this is partial fix for start-contributing.rst docs by removing Gitter Channel from jupyterlab