### PR TITLE
Replace outdated Gitter links with Zulip

### DIFF
--- a/docs/source/community/content-community.rst
+++ b/docs/source/community/content-community.rst
@@ -84,7 +84,7 @@ relevant information.
 - Blog `<https://blog.jupyter.org/>`_
 - Newsletter `<https://newsletter.jupyter.org/>`_
 - Website `<https://jupyter.org>`_
-- Gitter `<https://gitter.im/jupyter/jupyter>`_
+- Zulip <https://jupyter.zulipchat.com>_
 - Discourse `<https://discourse.jupyter.org/>`_
 - Zulip `<https://jupyter.zulipchat.com>`_
 - Mailing lists (Jupyter, Jupyter in Education) `<https://jupyter.org/community.html>`_

--- a/docs/source/locale/en/LC_MESSAGES/community.po
+++ b/docs/source/locale/en/LC_MESSAGES/community.po
@@ -4963,7 +4963,7 @@ msgstr ""
 # 80103b709d94489da4c958855044ce23
 #: ../../source/community/content-community.rst:89
 #: 4c17016b385c4851843b96ef217158d9
-msgid "Gitter `<https://gitter.im/jupyter/jupyter>`_"
+msgid "Zulip <https://jupyter.zulipchat.com>_"
 msgstr ""
 
 # dd12e64a1c6242688e11b1e72d4b7d17

--- a/docs/source/locale/es/LC_MESSAGES/community.po
+++ b/docs/source/locale/es/LC_MESSAGES/community.po
@@ -398,8 +398,8 @@ msgstr "Sitio Web `<https://jupyter.org>`_"
 
 # 80103b709d94489da4c958855044ce23
 #: ../../source/community/content-community.rst:59
-msgid "Gitter `<https://gitter.im/jupyter/jupyter>`_"
-msgstr "Gitter `<https://gitter.im/jupyter/jupyter>`_"
+msgid "Zulip `<https://jupyter.zulipchat.com>`_"
+msgstr "Zulip `<https://jupyter.zulipchat.com>`_"
 
 # dd12e64a1c6242688e11b1e72d4b7d17
 #: ../../source/community/content-community.rst:60


### PR DESCRIPTION
This PR replaces outdated Gitter links in the community documentation with the current Zulip instance.