### PR TITLE
docs/narrative-notebook.rst: add 'reproduce someone else's results'

### DIFF
--- a/docs/source/use/use-cases/narrative-notebook.rst
+++ b/docs/source/use/use-cases/narrative-notebook.rst
@@ -13,6 +13,7 @@ applications.
 Narrative examples
 ------------------
 
+- Reproducing someone else's results by following their Notebook
 - Using the Notebook for data exploration
 - Using extensions and widgets
 - Using nbconvert for code execution and workflow simplification


### PR DESCRIPTION
First day user here, I installed jupyter in order to follow along with the notebook linked at https://github.com/dscripka/openWakeWord#training-new-models to make my own wake word.

I saw that these docs are in progress, and that my usecase isn't mentioned in any of the narrative pages.