### PR TITLE
Add Jupyter-wide banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,6 +89,7 @@ html_context = {
 }
 
 html_theme_options = {
+    "announcement": "https://jupyter.org/assets/banner.html",
     "icon_links": [
         {
             "name": "GitHub",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,6 +89,8 @@ html_context = {
 }
 
 html_theme_options = {
+    # This will be empty if banner.html is empty
+    # ref: https://github.com/jupyter/jupyter.github.io#site-wide-announcement-banner
     "announcement": "https://jupyter.org/assets/banner.html",
     "icon_links": [
         {


### PR DESCRIPTION
This pulls in a jupyter-wide banner to automatically update the banner as the banner on jupyter.org updates. See https://github.com/jupyter/jupyter.github.io/issues/868